### PR TITLE
chore: Fix minor duplication from refactoring

### DIFF
--- a/src/pyhs3/functions/__init__.py
+++ b/src/pyhs3/functions/__init__.py
@@ -33,27 +33,9 @@ HistogramFunction = standard.HistogramFunction
 RooRecursiveFractionFunction = standard.RooRecursiveFractionFunction
 
 
-# Define the union type for all function configurations
-FunctionConfig = (
-    SumFunction
-    | ProductFunction
-    | GenericFunction
-    | InterpolationFunction
-    | ProcessNormalizationFunction
-    | CMSAsymPowFunction
-    | HistogramFunction
-    | RooRecursiveFractionFunction
-)
-
+# Combine all function registries
 registered_functions: dict[str, type[Function]] = {
-    "sum": SumFunction,
-    "product": ProductFunction,
-    "generic_function": GenericFunction,
-    "interpolation": InterpolationFunction,
-    "CMS::process_normalization": ProcessNormalizationFunction,
-    "CMS::asympow": CMSAsymPowFunction,
-    "histogram": HistogramFunction,
-    "roorecursivefraction_dist": RooRecursiveFractionFunction,
+    **standard.functions,
 }
 
 # Type alias for all function types using discriminated union

--- a/src/pyhs3/functions/standard.py
+++ b/src/pyhs3/functions/standard.py
@@ -8,9 +8,8 @@ generic functions with mathematical expressions, and interpolation functions.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
 from enum import IntEnum
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Literal, cast
 
 import pytensor.tensor as pt
 import sympy as sp
@@ -19,7 +18,6 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
-    RootModel,
     model_validator,
 )
 
@@ -767,19 +765,8 @@ class RooRecursiveFractionFunction(Function):
         return cast(TensorVar, first_fraction)
 
 
-# Define the union type for all function configurations
-FunctionConfig = (
-    SumFunction
-    | ProductFunction
-    | GenericFunction
-    | InterpolationFunction
-    | ProcessNormalizationFunction
-    | CMSAsymPowFunction
-    | HistogramFunction
-    | RooRecursiveFractionFunction
-)
-
-registered_functions: dict[str, type[Function]] = {
+# Registry for functions defined in this module
+functions: dict[str, type[Function]] = {
     "sum": SumFunction,
     "product": ProductFunction,
     "generic_function": GenericFunction,
@@ -789,58 +776,3 @@ registered_functions: dict[str, type[Function]] = {
     "histogram": HistogramFunction,
     "roorecursivefraction_dist": RooRecursiveFractionFunction,
 }
-
-# Type alias for all function types using discriminated union
-FunctionType = Annotated[
-    SumFunction
-    | ProductFunction
-    | GenericFunction
-    | InterpolationFunction
-    | ProcessNormalizationFunction
-    | CMSAsymPowFunction
-    | HistogramFunction
-    | RooRecursiveFractionFunction,
-    Field(discriminator="type"),
-]
-
-
-class Functions(RootModel[list[FunctionType]]):
-    """
-    Collection of HS3 functions for parameter computation.
-
-    Manages a set of function instances that compute parameter values
-    based on other parameters. Functions can be products, generic
-    mathematical expressions, or interpolation functions.
-
-    Provides dict-like access to functions by name and handles
-    function creation from configuration dictionaries.
-
-    Attributes:
-        funcs: Mapping from function names to Function instances.
-    """
-
-    root: Annotated[
-        list[FunctionType],
-        custom_error_msg(
-            {
-                "union_tag_invalid": "Unknown function type '{tag}' does not match any of the expected functions: {expected_tags}"
-            }
-        ),
-    ] = Field(default_factory=list)
-    _map: dict[str, Function] = PrivateAttr(default_factory=dict)
-
-    def model_post_init(self, __context: Any, /) -> None:
-        """Initialize computed collections after Pydantic validation."""
-        self._map = {func.name: func for func in self.root}
-
-    def __getitem__(self, item: str) -> Function:
-        return self._map[item]
-
-    def __contains__(self, item: str) -> bool:
-        return item in self._map
-
-    def __iter__(self) -> Iterator[Function]:  # type: ignore[override]  # https://github.com/pydantic/pydantic/issues/8872
-        return iter(self.root)
-
-    def __len__(self) -> int:
-        return len(self.root)


### PR DESCRIPTION
There was a duplication of `Functions`, `FunctionsType`, and `registered_functions` when refactoring the code in #84.
