### PR TITLE
bug: Process Normalization doesn't need a check for length of inputs

### DIFF
--- a/src/pyhs3/analyses.py
+++ b/src/pyhs3/analyses.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class Analysis(BaseModel):
@@ -30,12 +30,14 @@ class Analysis(BaseModel):
         prior: Optional name of prior distribution from distributions component
     """
 
-    name: str
-    likelihood: str
-    parameters_of_interest: list[str] | None = Field(default=None)
-    domains: list[str]
-    init: str | None = Field(default=None)
-    prior: str | None = Field(default=None)
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    likelihood: str = Field(..., repr=False)
+    parameters_of_interest: list[str] | None = Field(default=None, repr=False)
+    domains: list[str] = Field(..., repr=False)
+    init: str | None = Field(default=None, repr=False)
+    prior: str | None = Field(default=None, repr=False)
 
 
 class Analyses(RootModel[list[Analysis]]):

--- a/src/pyhs3/base.py
+++ b/src/pyhs3/base.py
@@ -124,8 +124,8 @@ class Evaluable(BaseModel):
 
     model_config = ConfigDict(serialize_by_alias=True)
 
-    name: str = Field(..., json_schema_extra={"preprocess": False})
-    type: str = Field(..., json_schema_extra={"preprocess": False})
+    name: str = Field(..., json_schema_extra={"preprocess": False}, repr=True)
+    type: str = Field(..., json_schema_extra={"preprocess": False}, repr=False)
     _parameters: dict[str, str] = PrivateAttr(default_factory=dict)
     _constants_values: dict[str, float | int] = PrivateAttr(default_factory=dict)
 

--- a/src/pyhs3/core.py
+++ b/src/pyhs3/core.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
+from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal, TypeAlias, TypeVar, cast
@@ -10,7 +12,7 @@ from typing import Any, Literal, TypeAlias, TypeVar, cast
 import numpy as np
 import numpy.typing as npt
 import pytensor.tensor as pt
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pytensor.compile.function import function
 from pytensor.graph.basic import applys_between, graph_inputs
 from rich.progress import (
@@ -28,6 +30,7 @@ from pyhs3.context import Context
 from pyhs3.data import Data
 from pyhs3.distributions import Distributions
 from pyhs3.domains import Domain, Domains, ProductDomain
+from pyhs3.exceptions import WorkspaceValidationError
 from pyhs3.functions import Functions
 from pyhs3.likelihoods import Likelihoods
 from pyhs3.metadata import Metadata
@@ -86,12 +89,20 @@ class Workspace(BaseModel):
     misc: dict[str, Any] | None = Field(default_factory=dict)
 
     @classmethod
-    def load(cls, path: str | os.PathLike[str]) -> Workspace:
+    def load(
+        cls,
+        path: str | os.PathLike[str],
+        *,
+        verbose: bool = False,
+        suppress_traceback: bool = True,
+    ) -> Workspace:
         """
         Load workspace from a JSON file.
 
         Args:
             path: Path to the JSON file containing the HS3 specification
+            verbose: If True, show all errors. If False, show first 20 and summarize rest.
+            suppress_traceback: If True, suppress traceback on validation errors (default True).
 
         Returns:
             Workspace: The loaded workspace instance
@@ -99,7 +110,74 @@ class Workspace(BaseModel):
         path_obj = Path(path)
         with path_obj.open("r", encoding="utf-8") as f:
             spec_dict = json.load(f)
-        return cls(**spec_dict)
+
+        try:
+            return cls(**spec_dict)
+        except ValidationError as e:
+            # Create a concise error summary instead of the massive full error
+            error_count = len(e.errors())
+            error_types: Counter[str] = Counter()
+            loc_errors: Counter[tuple[str, ...]] = Counter()
+
+            for error in e.errors():
+                error_types[error["type"]] += 1
+                loc_errors[
+                    tuple("#" if isinstance(key, int) else key for key in error["loc"])
+                ] += 1
+
+            # Create a concise error message
+            error_summary = (
+                f"Workspace validation failed with {error_count} errors from {path}\n"
+            )
+            error_summary += "\nError breakdown by type:\n"
+            for error_type, count in error_types.most_common():
+                error_summary += f"  {error_type}: {count}\n"
+
+            error_summary += "\nError breakdown by component:\n"
+            for loc, count in loc_errors.most_common():
+                loc_str = ".".join(loc)
+                error_summary += f"  {loc_str}: {count}\n"
+
+            # Show detailed errors with improved formatting
+            errors_to_show = e.errors() if verbose else e.errors()[:20]
+            error_summary += (
+                f"\nErrors for debugging ({'all' if verbose else 'first 20'}):\n"
+            )
+            for i, error in enumerate(errors_to_show):
+                # Format location more readably
+                loc_parts = []
+                for part in error.get("loc", []):
+                    if isinstance(part, int):
+                        loc_parts.append(f"[{part}]")
+                    else:
+                        loc_parts.append(str(part))
+
+                # Build readable location string
+                readable_loc = ""
+                for j, part in enumerate(loc_parts):
+                    if j == 0:
+                        readable_loc = part
+                    elif part.startswith("["):
+                        readable_loc += part  # Index directly follows
+                    else:
+                        readable_loc += f" -> {part}"
+
+                # Add name from input if available
+                input_data = error.get("input", {})
+                if isinstance(input_data, dict) and "name" in input_data:
+                    name = input_data["name"]
+                    if readable_loc and not readable_loc.endswith("]"):
+                        readable_loc += f"('{name}')"
+
+                msg = error.get("msg", "Unknown error")
+                error_summary += f"  {i + 1}. {readable_loc}: {msg}\n"
+
+            if not verbose and error_count > 20:
+                error_summary += f"  ... and {error_count - 20} more errors (use verbose=True to see all)\n"
+
+            if suppress_traceback:
+                sys.tracebacklimit = 0
+            raise WorkspaceValidationError(error_summary) from None
 
     def model(
         self,

--- a/src/pyhs3/data.py
+++ b/src/pyhs3/data.py
@@ -96,7 +96,9 @@ class GaussianUncertainty(BaseModel):
 
     model_config = ConfigDict()
 
-    type: Literal["gaussian_uncertainty"] = Field(..., repr=False)
+    type: Literal["gaussian_uncertainty"] = Field(
+        default="gaussian_uncertainty", repr=False
+    )
     sigma: list[float] = Field(..., repr=False)
     correlation: list[list[float]] | Literal[0] = Field(default=0, repr=False)
 
@@ -146,9 +148,9 @@ class PointData(Datum):
         uncertainty: Optional uncertainty/error
     """
 
-    type: Literal["point"]
-    value: float
-    uncertainty: float | None = Field(default=None)
+    type: Literal["point"] = Field(default="point", repr=False)
+    value: float = Field(..., repr=False)
+    uncertainty: float | None = Field(default=None, repr=False)
 
 
 class UnbinnedData(Datum):
@@ -167,11 +169,11 @@ class UnbinnedData(Datum):
         entries_uncertainties: Optional uncertainties for each coordinate
     """
 
-    type: Literal["unbinned"]
-    entries: list[list[float]]
-    axes: list[Axis]
-    weights: list[float] | None = Field(default=None)
-    entries_uncertainties: list[list[float]] | None = Field(default=None)
+    type: Literal["unbinned"] = Field(default="unbinned", repr=False)
+    entries: list[list[float]] = Field(..., repr=False)
+    axes: list[Axis] = Field(..., repr=False)
+    weights: list[float] | None = Field(default=None, repr=False)
+    entries_uncertainties: list[list[float]] | None = Field(default=None, repr=False)
 
     @model_validator(mode="after")
     def validate_unbinned_data(self) -> UnbinnedData:
@@ -230,10 +232,10 @@ class BinnedData(Datum):
         uncertainty: Optional uncertainty specification
     """
 
-    type: Literal["binned"]
-    contents: list[float]
-    axes: list[Axis]
-    uncertainty: GaussianUncertainty | None = Field(default=None)
+    type: Literal["binned"] = Field(default="binned", repr=False)
+    contents: list[float] = Field(..., repr=False)
+    axes: list[Axis] = Field(..., repr=False)
+    uncertainty: GaussianUncertainty | None = Field(default=None, repr=False)
 
     @model_validator(mode="after")
     def validate_binned_data(self) -> BinnedData:

--- a/src/pyhs3/data.py
+++ b/src/pyhs3/data.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 from typing import Annotated, Literal
 
 import numpy as np
-from pydantic import BaseModel, Field, RootModel, model_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
 
 from pyhs3.exceptions import custom_error_msg
 
@@ -32,11 +32,13 @@ class Axis(BaseModel):
         edges: Bin edges array (for irregular binning, length n+1)
     """
 
-    name: str
-    min: float | None = Field(default=None)
-    max: float | None = Field(default=None)
-    nbins: int | None = Field(default=None)
-    edges: list[float] | None = Field(default=None)
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    min: float | None = Field(default=None, repr=False)
+    max: float | None = Field(default=None, repr=False)
+    nbins: int | None = Field(default=None, repr=False)
+    edges: list[float] | None = Field(default=None, repr=False)
 
     @model_validator(mode="after")
     def validate_binning(self) -> Axis:
@@ -92,9 +94,11 @@ class GaussianUncertainty(BaseModel):
         correlation: Correlation matrix or 0 for no correlation
     """
 
-    type: Literal["gaussian_uncertainty"]
-    sigma: list[float]
-    correlation: list[list[float]] | Literal[0] = Field(default=0)
+    model_config = ConfigDict()
+
+    type: Literal["gaussian_uncertainty"] = Field(..., repr=False)
+    sigma: list[float] = Field(..., repr=False)
+    correlation: list[list[float]] | Literal[0] = Field(default=0, repr=False)
 
     @model_validator(mode="after")
     def validate_correlation(self) -> GaussianUncertainty:
@@ -123,8 +127,10 @@ class Datum(BaseModel):
         type: Type identifier for the data format
     """
 
-    name: str
-    type: str
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    type: str = Field(..., repr=False)
 
 
 class PointData(Datum):

--- a/src/pyhs3/distributions/histogram.py
+++ b/src/pyhs3/distributions/histogram.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from pyhs3.data import Axis
 from pyhs3.distributions.core import Distribution
@@ -25,8 +25,10 @@ class HistogramData(BaseModel):
         contents: list of bin content parameter values
     """
 
-    axes: list[Axis]
-    contents: list[float]
+    model_config = ConfigDict()
+
+    axes: list[Axis] = Field(..., repr=False)
+    contents: list[float] = Field(..., repr=False)
 
 
 class HistogramDist(Distribution):

--- a/src/pyhs3/distributions/mathematical.py
+++ b/src/pyhs3/distributions/mathematical.py
@@ -61,8 +61,8 @@ class GenericDist(Distribution):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, serialize_by_alias=True)
 
-    type: Literal["generic_dist"] = "generic_dist"
-    expression_str: str = Field(alias="expression")
+    type: Literal["generic_dist"] = Field(default="generic_dist", repr=False)
+    expression_str: str = Field(alias="expression", repr=False)
     _sympy_expr: sp.Expr = PrivateAttr(default=None)
     _dependent_vars: list[str] = PrivateAttr(default_factory=list)
 

--- a/src/pyhs3/domains.py
+++ b/src/pyhs3/domains.py
@@ -114,8 +114,8 @@ class ProductDomain(Domain):
         axes: List of Axis specifications defining each dimension
     """
 
-    type: Literal["product_domain"] = "product_domain"
-    axes: list[Axis] = Field(default_factory=list)
+    type: Literal["product_domain"] = Field(default="product_domain", repr=False)
+    axes: list[Axis] = Field(default_factory=list, repr=False)
     _axes_map: dict[str, Axis] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")

--- a/src/pyhs3/domains.py
+++ b/src/pyhs3/domains.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, PrivateAttr, RootModel, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    RootModel,
+    model_validator,
+)
 
 from pyhs3.exceptions import custom_error_msg
 
@@ -29,9 +36,11 @@ class Axis(BaseModel):
         max: Maximum value for the axis range (optional)
     """
 
-    name: str
-    min: float | None = None
-    max: float | None = None
+    model_config = ConfigDict()
+
+    name: str = Field(repr=True)
+    min: float | None = Field(default=None, repr=False)
+    max: float | None = Field(default=None, repr=False)
 
     @model_validator(mode="after")
     def check_min_le_max(self) -> Axis:
@@ -56,8 +65,10 @@ class Domain(BaseModel):
         type: Domain type identifier
     """
 
-    name: str
-    type: str
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    type: str = Field(..., repr=False)
 
     @property
     def dimension(self) -> int:

--- a/src/pyhs3/exceptions.py
+++ b/src/pyhs3/exceptions.py
@@ -79,7 +79,9 @@ def custom_error_msg(custom_messages: dict[str, str]) -> Any:
         except ValidationError as exc:
             new_errors: list[InitErrorDetails | ErrorDetails] = []
             for error in exc.errors():
+                error["loc"] = error["loc"][1:]  # to skip current location
                 custom_message = custom_messages.get(error["type"])
+
                 if custom_message:
                     err_ctx = error.get("ctx", {}).copy()
 

--- a/src/pyhs3/exceptions.py
+++ b/src/pyhs3/exceptions.py
@@ -47,6 +47,12 @@ class ExpressionEvaluationError(HS3Exception):
     """
 
 
+class WorkspaceValidationError(HS3Exception):
+    """
+    Raised when a workspace fails to validate.
+    """
+
+
 def custom_error_msg(custom_messages: dict[str, str]) -> Any:
     r"""
     Customize an error message for pydantic validation errors.
@@ -97,6 +103,7 @@ def custom_error_msg(custom_messages: dict[str, str]) -> Any:
                         loc=error["loc"],
                         input=error["input"],
                     )
+
                     new_errors.append(new_error)
                 else:
                     new_errors.append(error)

--- a/src/pyhs3/functions/standard.py
+++ b/src/pyhs3/functions/standard.py
@@ -72,8 +72,8 @@ def _asym_interpolation(
 class SumFunction(Function):
     """Sum function that adds summands together."""
 
-    type: Literal["sum"] = "sum"
-    summands: list[str]
+    type: Literal["sum"] = Field(default="sum", repr=False)
+    summands: list[str] = Field(..., repr=False)
 
     def expression(self, context: Context) -> TensorVar:
         """
@@ -98,8 +98,8 @@ class SumFunction(Function):
 class ProductFunction(Function):
     """Product function that multiplies factors together."""
 
-    type: Literal["product"] = "product"
-    factors: list[int | float | str]
+    type: Literal["product"] = Field(default="product", repr=False)
+    factors: list[int | float | str] = Field(..., repr=False)
 
     def expression(self, context: Context) -> TensorVar:
         """
@@ -145,8 +145,8 @@ class GenericFunction(Function):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, serialize_by_alias=True)
 
-    type: Literal["generic_function"] = "generic_function"
-    expression_str: str = Field(alias="expression")
+    type: Literal["generic_function"] = Field(default="generic_function", repr=False)
+    expression_str: str = Field(alias="expression", repr=False)
     _sympy_expr: sp.Expr = PrivateAttr(default=None)
     _dependent_vars: list[str] = PrivateAttr(default_factory=list)
 
@@ -233,10 +233,10 @@ class InterpolationFunction(Function):
 
     model_config = ConfigDict(use_enum_values=True)
 
-    type: Literal["interpolation"] = "interpolation"
-    high: list[str]
-    low: list[str]
-    nom: str
+    type: Literal["interpolation"] = Field(default="interpolation", repr=False)
+    high: list[str] = Field(..., repr=False)
+    low: list[str] = Field(..., repr=False)
+    nom: str = Field(..., repr=False)
     interpolationCodes: Annotated[
         list[InterpolationCode],
         custom_error_msg(
@@ -244,9 +244,9 @@ class InterpolationFunction(Function):
                 "enum": "Unknown interpolation code {input} in function '{name}'. Valid codes are {expected}."
             }
         ),
-    ]
-    positiveDefinite: bool
-    vars: list[str]
+    ] = Field(..., repr=False)
+    positiveDefinite: bool = Field(..., repr=False)
+    vars: list[str] = Field(..., repr=False)
 
     def _flexible_interp_single(
         self,
@@ -551,17 +551,21 @@ class ProcessNormalizationFunction(Function):
         otherFactorList: Names of additional multiplicative factors
     """
 
-    type: Literal["CMS::process_normalization"] = "CMS::process_normalization"
-    nominalValue: float = Field(default=1.0, json_schema_extra={"preprocess": False})
-    thetaList: list[str] = Field(default_factory=list)
+    type: Literal["CMS::process_normalization"] = Field(
+        default="CMS::process_normalization", repr=False
+    )
+    nominalValue: float = Field(
+        default=1.0, json_schema_extra={"preprocess": False}, repr=False
+    )
+    thetaList: list[str] = Field(default_factory=list, repr=False)
     logKappa: list[float] = Field(
-        default_factory=list, json_schema_extra={"preprocess": False}
+        default_factory=list, json_schema_extra={"preprocess": False}, repr=False
     )
-    asymmThetaList: list[str] = Field(default_factory=list)
+    asymmThetaList: list[str] = Field(default_factory=list, repr=False)
     logAsymmKappa: list[list[float]] = Field(
-        default_factory=list, json_schema_extra={"preprocess": False}
+        default_factory=list, json_schema_extra={"preprocess": False}, repr=False
     )
-    otherFactorList: list[str] = Field(default_factory=list)
+    otherFactorList: list[str] = Field(default_factory=list, repr=False)
 
     @model_validator(mode="after")
     def validate_list_lengths(self) -> ProcessNormalizationFunction:
@@ -644,10 +648,10 @@ class CMSAsymPowFunction(Function):
         theta: Parameter name for the nuisance parameter
     """
 
-    type: Literal["CMS::asympow"] = "CMS::asympow"
-    kappaLow: str | float | int
-    kappaHigh: str | float | int
-    theta: str
+    type: Literal["CMS::asympow"] = Field(default="CMS::asympow", repr=False)
+    kappaLow: str | float | int = Field(..., repr=False)
+    kappaHigh: str | float | int = Field(..., repr=False)
+    theta: str = Field(..., repr=False)
 
     def expression(self, context: Context) -> TensorVar:
         """
@@ -706,8 +710,10 @@ class HistogramFunction(Function):
         data: histogram data with binning and contents
     """
 
-    type: Literal["histogram"] = "histogram"
-    data: HistogramData = Field(..., json_schema_extra={"preprocess": False})
+    type: Literal["histogram"] = Field(default="histogram", repr=False)
+    data: HistogramData = Field(
+        ..., json_schema_extra={"preprocess": False}, repr=False
+    )
 
 
 class RooRecursiveFractionFunction(Function):
@@ -729,9 +735,11 @@ class RooRecursiveFractionFunction(Function):
         recursive: Whether to use recursive fraction calculation
     """
 
-    type: Literal["roorecursivefraction_dist"] = "roorecursivefraction_dist"
-    coefficients: list[int | float | str] = Field(alias="list")
-    recursive: bool = True
+    type: Literal["roorecursivefraction_dist"] = Field(
+        default="roorecursivefraction_dist", repr=False
+    )
+    coefficients: list[int | float | str] = Field(alias="list", repr=False)
+    recursive: bool = Field(default=True, repr=False)
 
     def expression(self, context: Context) -> TensorVar:
         """

--- a/src/pyhs3/functions/standard.py
+++ b/src/pyhs3/functions/standard.py
@@ -683,8 +683,10 @@ class HistogramData(BaseModel):
         contents: list of bin content parameter values
     """
 
-    axes: list[Axis]
-    contents: list[float]
+    model_config = ConfigDict()
+
+    axes: list[Axis] = Field(..., repr=False)
+    contents: list[float] = Field(..., repr=False)
 
 
 class HistogramFunction(Function):

--- a/src/pyhs3/functions/standard.py
+++ b/src/pyhs3/functions/standard.py
@@ -567,21 +567,6 @@ class ProcessNormalizationFunction(Function):
     )
     otherFactorList: list[str] = Field(default_factory=list, repr=False)
 
-    @model_validator(mode="after")
-    def validate_list_lengths(self) -> ProcessNormalizationFunction:
-        """Validate that parameter lists have consistent lengths."""
-        # Check symmetric variations
-        assert len(self.logKappa) == len(self.thetaList), (
-            f"logKappa length ({len(self.logKappa)}) must match thetaList length ({len(self.thetaList)})"
-        )
-
-        # Check asymmetric variations
-        assert len(self.logAsymmKappa) == len(self.asymmThetaList), (
-            f"logAsymmKappa length ({len(self.logAsymmKappa)}) must match asymmThetaList length ({len(self.asymmThetaList)})"
-        )
-
-        return self
-
     def expression(self, context: Context) -> TensorVar:
         """
         Evaluate the process normalization function.

--- a/src/pyhs3/likelihoods.py
+++ b/src/pyhs3/likelihoods.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 class Likelihood(BaseModel):
@@ -27,10 +27,12 @@ class Likelihood(BaseModel):
         aux_distributions: Optional array of auxiliary distributions for regularization
     """
 
-    name: str
-    distributions: list[str]
-    data: list[str | int | float | int]
-    aux_distributions: list[str] | None = Field(default=None)
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    distributions: list[str] = Field(..., repr=False)
+    data: list[str | int | float | int] = Field(..., repr=False)
+    aux_distributions: list[str] | None = Field(default=None, repr=False)
 
 
 class Likelihoods(RootModel[list[Likelihood]]):

--- a/src/pyhs3/metadata.py
+++ b/src/pyhs3/metadata.py
@@ -7,7 +7,7 @@ package information, authorship, and publication details following the HS3 speci
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PackageInfo(BaseModel):
@@ -22,8 +22,10 @@ class PackageInfo(BaseModel):
         version: Version string of the package
     """
 
-    name: str
-    version: str
+    model_config = ConfigDict()
+
+    name: str = Field(repr=True)
+    version: str = Field(repr=False)
 
 
 class Metadata(BaseModel):
@@ -42,8 +44,10 @@ class Metadata(BaseModel):
         description: Short description or abstract (optional)
     """
 
-    hs3_version: str
-    packages: list[PackageInfo] | None = None
-    authors: list[str] | None = None
-    publications: list[str] | None = None
-    description: str | None = None
+    model_config = ConfigDict()
+
+    hs3_version: str = Field(..., repr=False)
+    packages: list[PackageInfo] | None = Field(default=None, repr=False)
+    authors: list[str] | None = Field(default=None, repr=False)
+    publications: list[str] | None = Field(default=None, repr=False)
+    description: str | None = Field(default=None, repr=False)

--- a/src/pyhs3/parameter_points.py
+++ b/src/pyhs3/parameter_points.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterator
 from typing import Any
 
 import pytensor.tensor as pt
-from pydantic import BaseModel, Field, PrivateAttr, RootModel
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, RootModel
 
 from pyhs3.typing.aliases import TensorVar
 
@@ -32,11 +32,13 @@ class ParameterPoint(BaseModel):
         kind: Type of tensor to create (optional, defaults to pt.scalar)
     """
 
-    name: str
-    value: float
-    const: bool = False
-    nbins: int | None = None
-    kind: Callable[..., TensorVar] = Field(default=pt.scalar, exclude=True)
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    value: float = Field(..., repr=False)
+    const: bool = Field(default=False, repr=False)
+    nbins: int | None = Field(default=None, repr=False)
+    kind: Callable[..., TensorVar] = Field(default=pt.scalar, exclude=True, repr=False)
 
 
 class ParameterSet(BaseModel):
@@ -52,8 +54,10 @@ class ParameterSet(BaseModel):
         parameters: List of ParameterPoint specifications
     """
 
-    name: str
-    parameters: list[ParameterPoint] = Field(default_factory=list)
+    model_config = ConfigDict()
+
+    name: str = Field(..., repr=True)
+    parameters: list[ParameterPoint] = Field(default_factory=list, repr=False)
 
     @property
     def points(self) -> dict[str, ParameterPoint]:

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -5,10 +5,12 @@ import math
 
 import numpy as np
 import pytensor.tensor as pt
+import pytest
 from pytensor import function
 
 from pyhs3 import Workspace
 from pyhs3.core import create_bounded_tensor
+from pyhs3.exceptions import WorkspaceValidationError
 
 
 def test_workspace_load_from_file(datadir):
@@ -235,3 +237,40 @@ def test_combine_long_exercise_logpdf_evaluation(datadir):
     # Since observed = 10 and all expected values > 10, smaller r values should give higher logPDF
     assert logpdf_val_r05 > default_logpdf_val  # r=0.5 closer to optimum than r=1.0
     assert default_logpdf_val > logpdf_val_r20  # r=1.0 closer to optimum than r=2.0
+
+
+def test_workspace_validation_error(tmp_path):
+    """Test that WorkspaceValidationError is raised for invalid workspace JSON."""
+    # Create an invalid workspace JSON that will trigger validation errors
+    invalid_workspace = {
+        # Missing required 'metadata' field
+        "distributions": [
+            {
+                "name": "gauss",
+                "type": "invalid_distribution_type",  # Invalid type
+                "x": "x",
+                "mean": "mu",
+                # Missing required 'sigma' field for gaussian_dist
+            }
+        ],
+        "parameter_points": [
+            {
+                "name": "test_params",
+                "parameters": [
+                    {
+                        # Missing required 'name' field
+                        "value": 1.0
+                    }
+                ],
+            }
+        ],
+    }
+
+    # Write invalid JSON to temp file
+    invalid_json_path = tmp_path / "invalid_workspace.json"
+    with invalid_json_path.open("w") as f:
+        json.dump(invalid_workspace, f)
+
+    # Verify that loading the invalid workspace raises WorkspaceValidationError
+    with pytest.raises(WorkspaceValidationError, match="Workspace validation failed"):
+        Workspace.load(invalid_json_path)


### PR DESCRIPTION
There are defaults set if the lengths are empty...

- **change the repr=False for most things**
- **add repr=False for cleaner represntations**
- **skip current location for custom error messages**
- **readable error messages, suppress traceback**
- **no need for length checking**
