### PR TITLE
feat: Replace rootref with sphinxcontrib-doxylink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/_generated/
+docs/ROOT.tag
 
 # PyBuilder
 .pybuilder/

--- a/docs/_scripts/fetch_root_tag.py
+++ b/docs/_scripts/fetch_root_tag.py
@@ -28,6 +28,11 @@ def main():
         print(f"✓ {TAG_FILE} already exists, skipping download")
         return 0
 
+    # Validate URL uses HTTPS for security
+    if not TAG_URL.startswith("https://"):
+        print(f"✗ URL must start with 'https://': {TAG_URL}", file=sys.stderr)
+        return 1
+
     print(f"Downloading {TAG_URL}...")
     try:
         with urlopen(TAG_URL) as response:

--- a/docs/_scripts/fetch_root_tag.py
+++ b/docs/_scripts/fetch_root_tag.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Download and extract ROOT Doxygen tag file."""
+
+# ruff: noqa: T201
+
+from __future__ import annotations
+
+import gzip
+import os
+import shutil
+import sys
+from pathlib import Path
+from urllib.request import urlopen
+
+# Get ROOT version from environment variable or use default
+ROOT_VERSION = os.environ.get("ROOT_DOXYGEN_VERSION", "v636")
+
+# Paths
+DOCS_DIR = Path(__file__).parent.parent
+TAG_FILE = DOCS_DIR / "ROOT.tag"
+TAG_URL = f"https://root.cern/doc/{ROOT_VERSION}/ROOT.tag.gz"
+
+
+def main():
+    """Download and extract ROOT.tag if it doesn't exist."""
+    # Skip if already exists (idempotent)
+    if TAG_FILE.exists():
+        print(f"✓ {TAG_FILE} already exists, skipping download")
+        return 0
+
+    print(f"Downloading {TAG_URL}...")
+    try:
+        with urlopen(TAG_URL) as response:
+            if response.status != 200:
+                print(f"✗ Failed to download: HTTP {response.status}", file=sys.stderr)
+                return 1
+
+            # Decompress gzip directly to file
+            with (
+                gzip.open(response, "rb") as gz_file,
+                TAG_FILE.open("wb") as out_file,
+            ):
+                shutil.copyfileobj(gz_file, out_file)
+
+        print(f"✓ Downloaded and extracted to {TAG_FILE}")
+        return 0
+
+    except Exception as e:
+        print(f"✗ Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,4 +137,34 @@ html_css_files = [
 ]
 
 # https://github.com/sphinx-contrib/doxylink/issues/72
-suppress_warnings = ["sphinxcontrib.doxylink"]
+doxylink_parse_error_ignore_regexes = [
+    "^Skipping define RLogger.hxx::",
+    "^Skipping function TClingCallFunc.cxx::",
+    "^Skipping function TDavixFile.cxx::",
+    "^Skipping function TProof.h::",
+    "^Skipping function TProofLite.h::",
+    "^Skipping function TStringLong.h::",
+    "^Skipping function civetweb.c::",
+    "^Skipping function entrylistblock_figure1.C::",
+    "^Skipping function legend1.C::",
+    "^Skipping function legend2.C::",
+    "^Skipping function legend3.C::",
+    "^Skipping function polyline.C::",
+    "^Skipping function rootcling_impl.cxx::",
+    "^Skipping function textalign.C::",
+    "^Skipping function textangle.C::",
+    "^Skipping function PassiveKeyGrab::",
+    "^Skipping function QuartzImage::",
+    "^Skipping function QuartzPixmap::",
+    "^Skipping function QuartzView::",
+    "^Skipping function QuartzWindow::",
+    "^Skipping function ROOT::",
+    "^Skipping function cout_redirect::",
+    "^Skipping function CPyCppyy::",
+    "^Skipping function ROOTOpenGLView::",
+    "^Skipping function RooStats::",
+    "^Skipping function THnBase::",
+    "^Skipping function THnSparse::",
+    "^Skipping function THnSparseT::",
+    "^Skipping function TThreadTimer::",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.metadata
+import pathlib
 from typing import Any
 
 from intersphinx_registry import get_intersphinx_mapping
@@ -27,6 +28,7 @@ extensions = [
     "sphinx_issues",
     "sphinxcontrib.mermaid",
     "sphinxcontrib.bibtex",
+    "sphinxcontrib.doxylink",
     "matplotlib.sphinxext.plot_directive",
 ]
 
@@ -101,7 +103,18 @@ always_document_param_types = True
 # Napoleon configuration for custom sections
 napoleon_custom_sections = [
     ("HS3 Reference", "references_style"),
+    ("ROOT Reference", "references_style"),
 ]
+
+# ROOT Doxygen cross-references
+_root_doxygen_version = "v636"
+
+doxylink = {
+    "root": (
+        str(pathlib.Path(__file__).parent / "ROOT.tag"),
+        f"https://root.cern/doc/{_root_doxygen_version}/",
+    ),
+}
 
 # sphinx-copybutton configuration
 copybutton_prompt_text = r">>> |\.\.\. |\$ "
@@ -122,3 +135,6 @@ html_static_path = ["_static"]
 html_css_files = [
     "css/custom.css",
 ]
+
+# https://github.com/sphinx-contrib/doxylink/issues/72
+suppress_warnings = ["sphinxcontrib.doxylink"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -2074,6 +2074,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-doxylink-1.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-1.2.3-pyhd8ed1ab_0.conda
@@ -2280,6 +2281,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-doxylink-1.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-1.2.3-pyhd8ed1ab_0.conda
@@ -2496,6 +2498,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-doxylink-1.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-1.2.3-pyhd8ed1ab_0.conda
@@ -2708,6 +2711,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-doxylink-1.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-1.2.3-pyhd8ed1ab_0.conda
@@ -2912,6 +2916,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-bibtex-2.6.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-doxylink-1.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-1.2.3-pyhd8ed1ab_0.conda
@@ -26934,6 +26939,18 @@ packages:
   - pkg:pypi/sphinxcontrib-devhelp?source=hash-mapping
   size: 24536
   timestamp: 1733754232002
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-doxylink-1.13.0-pyhd8ed1ab_0.conda
+  sha256: 995f6afcef385b30d1e8c60375071084c86ad58870b21adb74f929d0a9ea32f6
+  md5: 160afe542aeb7f3324dc041af9729850
+  depends:
+  - pyparsing >=3.0.8,<4.0.0
+  - python >=3.9,<4.0
+  - python-dateutil >=2.8.2,<3.0.0
+  - sphinx >=1.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 17798
+  timestamp: 1740762092393
 - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
   sha256: c1492c0262ccf16694bdcd3bb62aa4627878ea8782d5cd3876614ffeb62b3996
   md5: e9fb3fe8a5b758b4aff187d434f94f03

--- a/pixi.toml
+++ b/pixi.toml
@@ -96,15 +96,17 @@ intersphinx-registry = ">=0.2411.17"
 sphinx-issues = "*"
 sphinxcontrib-mermaid = "*"
 sphinxcontrib-bibtex = "*"
+sphinxcontrib-doxylink = "*"
 sphinx-autobuild = "*"
 pydocstyle = "*"
 lychee = ">=0.22.0,<0.23"
 
 [feature.docs.tasks]
-docs-build = { cmd = "sphinx-build -n -T -b html docs docs/_build/html", description = "Build documentation (static)", inputs = ["docs/"], outputs = ["docs/_build/html"] }
+docs-fetch-root-tag = { cmd = "python docs/_scripts/fetch_root_tag.py", description = "Download ROOT Doxygen tag file" }
+docs-build = { cmd = "sphinx-build -n -T -b html docs docs/_build/html", depends-on = ["docs-fetch-root-tag"], description = "Build documentation (static)", inputs = ["docs/"], outputs = ["docs/_build/html"] }
 docs-linkcheck = { cmd = "lychee docs/", description = "Check documentation for broken links" }
 docs-serve = { cmd = "python -m http.server -d docs/_build/html", depends-on = ["docs-build"], description = "Build and serve documentation" }
-docs-watch = { cmd = "sphinx-autobuild --open-browser -n -T -b html docs docs/_build/html", description = "Build and serve documentation with live reload", inputs = ["docs/"], outputs = ["docs/_build/html"] }
+docs-watch = { cmd = "sphinx-autobuild --open-browser -n -T -b html docs docs/_build/html", depends-on = ["docs-fetch-root-tag"], description = "Build and serve documentation with live reload", inputs = ["docs/"], outputs = ["docs/_build/html"] }
 docs-clean = { cmd = "rm -rf docs/_build", description = "Clean documentation build artifacts", inputs = ["docs/_build"] }
 docs-api = { cmd = "sphinx-apidoc -o docs/api/ --module-first --no-toc --force src/pyhs3", description = "Regenerate API documentation" }
 check-docstrings = { cmd = "pydocstyle src/pyhs3/", description = "Check docstring style" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ docs = [
   "sphinx-issues",
   "sphinxcontrib-mermaid",
   "sphinxcontrib-bibtex",
+  "sphinxcontrib-doxylink",
   "matplotlib",
   "hist[plot] > 2.7.0", # keep synced with dependencies
 ]
@@ -230,7 +231,8 @@ ignore_directives = [
 ignore_roles = [
     "cite:p",
     "cite:ps",
-    "hs3:label"
+    "hs3:label",
+    "root"
 ]
 
 [tool.codeflash]

--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -177,7 +177,7 @@ class ExponentialDist(Distribution):
         :hs3:label:`exponential_dist <hs3.exponential-distribution>`
 
     ROOT Reference:
-        :rootref:`RooExponential <classRooExponential.html>`
+        :root:`RooExponential`
     """
 
     type: Literal["exponential_dist"] = "exponential_dist"
@@ -281,7 +281,7 @@ class LandauDist(Distribution):
         Note: Landau distribution is not explicitly defined in the current HS3 specification.
 
     ROOT Reference:
-        :rootref:`RooLandau <classRooLandau.html>`
+        :root:`RooLandau`
     """
 
     type: Literal["landau_dist"] = "landau_dist"

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -61,7 +61,7 @@ class MixtureDist(Distribution):
             Only valid when using N coefficients (extended=True).
 
     ROOT Reference:
-        :rootref:`RooAddPdf <classRooAddPdf.html>`
+        :root:`RooAddPdf`
     """
 
     type: Literal["mixture_dist"] = "mixture_dist"

--- a/src/pyhs3/distributions/mathematical.py
+++ b/src/pyhs3/distributions/mathematical.py
@@ -124,7 +124,7 @@ class PolynomialDist(Distribution):
         we require all coefficients to be explicitly specified.
 
     ROOT Reference:
-        :rootref:`RooPolynomial <classRooPolynomial.html>`
+        :root:`RooPolynomial`
     """
 
     type: Literal["polynomial_dist"] = "polynomial_dist"
@@ -174,7 +174,7 @@ class BernsteinPolyDist(Distribution):
         The normalization to this interval is typically handled by the domain.
 
     ROOT Reference:
-        :rootref:`RooBernstein <classRooBernstein.html>`
+        :root:`RooBernstein`
     """
 
     type: Literal["bernstein_poly_dist"] = "bernstein_poly_dist"


### PR DESCRIPTION
## Summary

Replace the undefined `:rootref:` Sphinx role with `sphinxcontrib-doxylink`'s `:root:` role for automatic cross-referencing to ROOT C++ documentation using ROOT's Doxygen tag file.

**Changes:**
- Add `sphinxcontrib-doxylink` dependency to pixi.toml and pyproject.toml
- Create download script for ROOT Doxygen tag file (`docs/_scripts/fetch_root_tag.py`)
- Configure doxylink in `docs/conf.py` with ROOT.tag and documentation URL (v636)
- Replace 5 `:rootref:` occurrences with `:root:` across 3 distribution files:
  - `src/pyhs3/distributions/basic.py` (RooExponential, RooLandau)
  - `src/pyhs3/distributions/mathematical.py` (RooPolynomial, RooBernstein)
  - `src/pyhs3/distributions/composite.py` (RooAddPdf)
- Add `docs/ROOT.tag` to `.gitignore`
- Add `root` to rstcheck `ignore_roles` in `pyproject.toml`
- Add `suppress_warnings = ["sphinxcontrib.doxylink"]` to suppress tag file parser warnings

**Benefits:**
- Automatic link resolution (no need to specify HTML filenames)
- Links resolve to correct ROOT class documentation
- Downloads tag file automatically as part of docs build process

## Test Plan

- [x] ROOT.tag file downloads successfully via `pixi run docs-fetch-root-tag`
- [x] Script is idempotent (skips download if file exists)
- [x] Documentation builds without errors: `pixi run docs-build -W`
- [x] All ROOT class links resolve correctly to `https://root.cern/doc/v636/classRoo*.html`
- [x] Pre-commit hooks pass on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
