### PR TITLE
fix: Add type parameters to hist.Hist and simplify array assignment

### DIFF
--- a/src/pyhs3/data.py
+++ b/src/pyhs3/data.py
@@ -240,7 +240,7 @@ class UnbinnedData(Datum):
 
         return self
 
-    def to_hist(self) -> hist.Hist:
+    def to_hist(self) -> hist.Hist[hist.storage.Weight | hist.storage.Double]:
         """
         Convert to scikit-hep hist.Hist object by binning entries.
 
@@ -340,7 +340,7 @@ class BinnedData(Datum):
 
         return self
 
-    def to_hist(self) -> hist.Hist:
+    def to_hist(self) -> hist.Hist[hist.storage.Weight | hist.storage.Double]:
         """
         Convert to scikit-hep hist.Hist object for visualization.
 
@@ -395,13 +395,13 @@ class BinnedData(Datum):
             # Reshape both contents and variances
             contents_nd = np.array(self.contents).reshape(shape)
             variances_nd = np.square(self.uncertainty.sigma).reshape(shape)
-            # Set values with variances using view
-            h.view(flow=False)["value"] = contents_nd
-            h.view(flow=False)["variance"] = variances_nd
+
+            stacked = np.stack([contents_nd, variances_nd], axis=-1)
+            h[...] = stacked
         else:
             # Reshape and set contents using view
             contents_nd = np.array(self.contents).reshape(shape)
-            h.view(flow=False)[...] = contents_nd
+            h[...] = contents_nd
 
         return h
 

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -323,11 +323,9 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
             variances_nd = np.square(sample.data.errors).reshape(binning_shape)
 
             # Set values for this sample using integer indexing
-            # Note: We use integer index i here because h.view() returns a numpy array
-            # that doesn't support string indexing. The sample order matches the
-            # categorical axis order, so h.view()[i, ...] corresponds to sample.name
-            h.view(flow=False)[i, ...]["value"] = contents_nd
-            h.view(flow=False)[i, ...]["variance"] = variances_nd
+            # The sample order matches the categorical axis order, so h[i, ...] corresponds to sample.name
+            stacked = np.stack([contents_nd, variances_nd], axis=-1)
+            h[i, ...] = stacked
 
         return h
 

--- a/src/pyhs3/distributions/histfactory/samples.py
+++ b/src/pyhs3/distributions/histfactory/samples.py
@@ -28,7 +28,7 @@ class Sample(BaseModel):
     data: SampleData
     modifiers: Modifiers = Field(default_factory=Modifiers)
 
-    def to_hist(self, axes: Axes) -> hist.Hist:
+    def to_hist(self, axes: Axes) -> hist.Hist[hist.storage.Weight]:
         """
         Convert to scikit-hep hist.Hist object for visualization.
 
@@ -68,9 +68,8 @@ class Sample(BaseModel):
         contents_nd = np.array(self.data.contents).reshape(shape)
         variances_nd = np.square(self.data.errors).reshape(shape)
 
-        # Set values with variances using view
-        h.view(flow=False)["value"] = contents_nd
-        h.view(flow=False)["variance"] = variances_nd
+        stacked = np.stack([contents_nd, variances_nd], axis=-1)
+        h[...] = stacked
 
         return h
 


### PR DESCRIPTION
## Summary

- Add storage type parameters to `hist.Hist` return type annotations (fixes mypy "Missing type parameters for generic type" errors)
- Replace `h.view(flow=False)["field"]` with direct `h[...]` assignment using `np.stack` (fixes mypy array indexing errors and improves code clarity)
- Add `hist` dependency to mypy pre-commit hook in `.pre-commit-config.yaml`

## Changes

- `data.py`: Added type parameters to `UnbinnedData.to_hist()` and `BinnedData.to_hist()` return types, replaced view-based field assignment with direct assignment
- `samples.py`: Added type parameter to `Sample.to_hist()` return type, replaced view-based field assignment with direct assignment
- `histfactory/__init__.py`: Replaced view-based field assignment with direct assignment in `Workspace.to_hist()`
- `.pre-commit-config.yaml`: Added `hist` to mypy hook dependencies

## Test plan

- [x] All pre-commit hooks pass (including mypy with strict type checking)
- [x] All 714 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)