### PR TITLE
fix: Simplify likelihood.data -> string only

### DIFF
--- a/src/pyhs3/likelihoods.py
+++ b/src/pyhs3/likelihoods.py
@@ -31,7 +31,7 @@ class Likelihood(BaseModel):
 
     name: str = Field(..., repr=True)
     distributions: list[str] = Field(..., repr=False)
-    data: list[str | int | float | int] = Field(..., repr=False)
+    data: list[str] = Field(..., repr=False)
     aux_distributions: list[str] | None = Field(default=None, repr=False)
 
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -40,26 +40,6 @@ class TestLikelihood:
         assert likelihood.data == ["data1", "data2"]
         assert likelihood.aux_distributions == ["aux_dist1", "aux_dist2"]
 
-    def test_likelihood_creation_with_inline_data_values(self):
-        """Test Likelihood creation with inline numeric data values."""
-        likelihood = Likelihood(
-            name="constraint_likelihood", distributions=["single_dim_dist"], data=[1.0]
-        )
-        assert likelihood.name == "constraint_likelihood"
-        assert likelihood.distributions == ["single_dim_dist"]
-        assert likelihood.data == [1.0]
-
-    def test_likelihood_creation_mixed_data_types(self):
-        """Test Likelihood creation with mixed string and numeric data."""
-        likelihood = Likelihood(
-            name="mixed_likelihood",
-            distributions=["dist1", "dist2", "constraint_dist"],
-            data=["data1", "data2", 0.5],
-        )
-        assert likelihood.name == "mixed_likelihood"
-        assert likelihood.distributions == ["dist1", "dist2", "constraint_dist"]
-        assert likelihood.data == ["data1", "data2", 0.5]
-
     def test_likelihood_validation_requires_name(self):
         """Test that Likelihood validation requires name field."""
         with pytest.raises(ValueError, match="Field required"):


### PR DESCRIPTION
Until https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/72 is resolved, go back to a simpler version without assumptions.
