### PR TITLE
fix: add missing doctest extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
     "sphinx.ext.ifconfig",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
- Resolves #160 (adding `sphinx.ext.doctest` to list of extensions)