### PR TITLE
refactor: Introduce BoundedAxis base class for axes with finite bounds

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -102,6 +102,7 @@ Axes
    :nosignatures:
 
    Axis
+   BoundedAxis
    UnbinnedAxis
    ConstantAxis
    RegularAxis

--- a/src/pyhs3/axes.py
+++ b/src/pyhs3/axes.py
@@ -36,11 +36,9 @@ class Axis(NamedModel):
     model_config = ConfigDict()
 
 
-class UnbinnedAxis(Axis):
+class BoundedAxis(Axis):
     """
-    Axis for unbinned data.
-
-    Alias for Axis with required min/max bounds.
+    Axis with required finite min/max bounds.
 
     Attributes:
         name: Name of the axis/variable
@@ -52,12 +50,23 @@ class UnbinnedAxis(Axis):
     max: float = Field(..., repr=False)
 
     @model_validator(mode="after")
-    def check_min_le_max(self) -> UnbinnedAxis:
-        """Validate that max >= min when both are provided."""
+    def check_min_le_max(self) -> BoundedAxis:
+        """Validate that max >= min."""
         if self.max < self.min:
-            msg = f"UnbinnedAxis '{self.name}': max ({self.max}) must be >= min ({self.min})"
+            msg = f"{type(self).__name__} '{self.name}': max ({self.max}) must be >= min ({self.min})"
             raise ValueError(msg)
         return self
+
+
+class UnbinnedAxis(BoundedAxis):
+    """
+    Axis for unbinned data with required finite bounds.
+
+    Attributes:
+        name: Name of the axis/variable
+        min: Minimum value (required, inherited from BoundedAxis)
+        max: Maximum value (required, inherited from BoundedAxis)
+    """
 
     def to_hist(self) -> Any:
         """
@@ -92,26 +101,16 @@ class ConstantAxis(Axis):
     const: Literal[True] = Field(True, repr=False, init=False)
 
 
-class RegularAxis(Axis):
+class RegularAxis(BoundedAxis):
     """
     Attributes:
         name: Name of the axis/variable
-        min: Minimum value
-        max: Maximum value
+        min: Minimum value (inherited from BoundedAxis)
+        max: Maximum value (inherited from BoundedAxis)
         nbins: Number of bins (for regular binning)
     """
 
-    min: float = Field(..., repr=False)
-    max: float = Field(..., repr=False)
     nbins: int = Field(repr=False)
-
-    @model_validator(mode="after")
-    def check_min_le_max(self) -> RegularAxis:
-        """Validate that max >= min."""
-        if self.max < self.min:
-            msg = f"Axis '{self.name}': max ({self.max}) must be >= min ({self.min})"
-            raise ValueError(msg)
-        return self
 
     @model_validator(mode="after")
     def check_binning(self) -> RegularAxis:

--- a/tests/test_axes.py
+++ b/tests/test_axes.py
@@ -15,6 +15,7 @@ from pyhs3.axes import (
     Axis,
     BinnedAxes,
     BinnedAxis,
+    BoundedAxis,
     ConstantAxis,
     DomainCoordinateAxis,
     IrregularAxis,
@@ -41,6 +42,57 @@ class TestAxis:
         assert axis.name == "test_var"
         assert not hasattr(axis, "min")
         assert not hasattr(axis, "max")
+
+
+class TestBoundedAxis:
+    """Tests for the BoundedAxis class."""
+
+    def test_bounded_axis_creation(self):
+        """Test BoundedAxis creation with required min/max."""
+        axis = BoundedAxis(name="x", min=0.0, max=5.0)
+        assert axis.name == "x"
+        assert axis.min == 0.0
+        assert axis.max == 5.0
+
+    def test_bounded_axis_min_required(self):
+        """Test that BoundedAxis requires min."""
+        with pytest.raises(ValidationError, match="Field required"):
+            BoundedAxis(name="x", max=5.0)
+
+    def test_bounded_axis_max_required(self):
+        """Test that BoundedAxis requires max."""
+        with pytest.raises(ValidationError, match="Field required"):
+            BoundedAxis(name="x", min=0.0)
+
+    def test_bounded_axis_validation_max_less_than_min_raises_error(self):
+        """Test that BoundedAxis validation raises ValueError when max < min."""
+        with pytest.raises(
+            ValueError,
+            match=r"BoundedAxis 'test_param': max \(5\.0\) must be >= min \(10\.0\)",
+        ):
+            BoundedAxis(name="test_param", min=10.0, max=5.0)
+
+    def test_bounded_axis_validation_max_equal_min_allowed(self):
+        """Test that BoundedAxis allows max == min."""
+        axis = BoundedAxis(name="test_param", min=5.0, max=5.0)
+        assert axis.min == 5.0
+        assert axis.max == 5.0
+
+    def test_bounded_axis_validation_max_greater_than_min_allowed(self):
+        """Test that BoundedAxis allows max > min."""
+        axis = BoundedAxis(name="test_param", min=5.0, max=10.0)
+        assert axis.min == 5.0
+        assert axis.max == 10.0
+
+    def test_unbinned_axis_is_bounded_axis(self):
+        """Test that UnbinnedAxis is an instance of BoundedAxis."""
+        axis = UnbinnedAxis(name="x", min=0.0, max=5.0)
+        assert isinstance(axis, BoundedAxis)
+
+    def test_regular_axis_is_bounded_axis(self):
+        """Test that RegularAxis is an instance of BoundedAxis."""
+        axis = RegularAxis(name="x", min=0.0, max=5.0, nbins=10)
+        assert isinstance(axis, BoundedAxis)
 
 
 class TestUnbinnedAxis:


### PR DESCRIPTION
Add BoundedAxis as an intermediate base class between Axis and
UnbinnedAxis/RegularAxis. This eliminates duplication of min/max
fields and check_min_le_max validation logic that was independently
implemented in both UnbinnedAxis and RegularAxis.

Changes:
- Add BoundedAxis(Axis) with min/max fields and validation
- Update UnbinnedAxis to inherit from BoundedAxis
- Update RegularAxis to inherit from BoundedAxis
- Remove duplicate min/max fields and validators from both subclasses
- Add comprehensive test coverage for BoundedAxis
- Update API documentation to include BoundedAxis

The validator uses type(self).__name__ to preserve subclass names in
error messages (e.g., "UnbinnedAxis 'x': max..." vs "RegularAxis 'x': max...").

IrregularAxis and DomainCoordinateAxis are intentionally excluded as
they use @property-based min/max accessors with different semantics.

Fixes #179
