### PR TITLE
feat: Implement Barlow-Beeston lite for staterror modifier

### DIFF
--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -19,12 +19,14 @@ from pyhs3.axes import BinnedAxes
 from pyhs3.context import Context
 
 # Import existing distributions for constraint terms
+from pyhs3.distributions.basic import GaussianDist, PoissonDist
 from pyhs3.distributions.core import Distribution
 from pyhs3.distributions.histfactory.data import SampleData
 from pyhs3.distributions.histfactory.modifiers import (
     HasConstraint,
     Modifier,
     ParameterModifier,
+    StatErrorModifier,
 )
 from pyhs3.distributions.histfactory.samples import Sample, Samples
 from pyhs3.networks import HasDependencies, HasInternalNodes
@@ -99,6 +101,10 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
     type: Literal["histfactory_dist"] = "histfactory_dist"
     axes: BinnedAxes = Field(..., json_schema_extra={"preprocess": False})
     samples: Samples = Field(..., json_schema_extra={"preprocess": False})
+    barlow_beeston_method: Literal["full", "lite"] = Field(
+        default="lite",
+        json_schema_extra={"preprocess": False},
+    )
     _normalizable: bool = PrivateAttr(default=False)
 
     def get_internal_nodes(self) -> list[Any]:
@@ -211,11 +217,22 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         seen: set[str] = set()
         constraint_probs: list[TensorVar] = []
         for dedup_key, modifier, sample_data in self.constraint_specs():
+            # Skip StatErrorModifier in lite mode - constraint built at channel level
+            if self.barlow_beeston_method == "lite" and isinstance(
+                modifier, StatErrorModifier
+            ):
+                continue
             if dedup_key is not None:
                 if dedup_key in seen:
                     continue
                 seen.add(dedup_key)
             constraint_probs.append(modifier.make_constraint(context, sample_data))
+
+        # Add channel-level BB-lite constraint if in lite mode
+        if self.barlow_beeston_method == "lite":
+            lite_constraint = self._make_barlow_beeston_lite_constraint(context)
+            if lite_constraint is not None:
+                constraint_probs.append(lite_constraint)
 
         if not constraint_probs:
             return pt.constant(1.0)
@@ -224,6 +241,106 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
     def _get_total_bins(self) -> int:
         """Calculate total number of bins across all axes."""
         return self.axes.get_total_bins()
+
+    def _find_staterror_modifier(self) -> StatErrorModifier | None:
+        """Find the first staterror modifier from any sample.
+
+        In BB-lite mode, staterror modifiers share gamma parameters across samples,
+        so we only need one modifier to get the parameter names and constraint type.
+        """
+        for sample in self.samples:
+            for modifier in sample.modifiers:
+                if isinstance(modifier, StatErrorModifier):
+                    return modifier
+        return None
+
+    def _make_barlow_beeston_lite_constraint(
+        self, context: Context
+    ) -> TensorVar | None:
+        """Build BB-lite constraint from combined sample uncertainties.
+
+        BB-lite uses shared gamma parameters across samples with a channel-level
+        constraint built from combined MC statistical uncertainties.
+
+        The constraint can be either Poisson or Gaussian:
+        - Poisson: Poisson(tau | gamma * tau) where tau = (nu/sigma)^2
+        - Gaussian: N(1.0 | gamma, relerr) where relerr = sigma/nu
+
+        Combined uncertainties from samples:
+        - total_nominal = sum(sample.data.contents)
+        - total_sigma = sqrt(sum(sample.data.errors^2))
+        """
+        total_bins = self._get_total_bins()
+
+        # Find staterror modifier to get gamma params and constraint type
+        staterror_mod = self._find_staterror_modifier()
+        if staterror_mod is None:
+            return None
+
+        gamma_params = staterror_mod.parameters
+        constraint_type = staterror_mod.constraint
+
+        # Compute combined uncertainties from sample.data.errors
+        total_nominal = np.zeros(total_bins)
+        total_variance = np.zeros(total_bins)
+
+        for sample in self.samples:
+            # Only include samples that have the staterror modifier
+            has_staterror = any(
+                isinstance(mod, StatErrorModifier) for mod in sample.modifiers
+            )
+            if has_staterror:
+                total_nominal += np.array(sample.data.contents)
+                total_variance += np.square(sample.data.errors)
+
+        total_sigma = np.sqrt(total_variance)
+
+        augmented_context = dict(context)
+        dists: list[GaussianDist | PoissonDist] = []
+
+        for i, param_name in enumerate(gamma_params):
+            nu, sigma = total_nominal[i], total_sigma[i]
+
+            # Skip bins with zero or invalid values
+            if nu <= 0 or sigma <= 0:
+                continue
+
+            if constraint_type == "Poisson":
+                # Poisson: Poisson(tau | gamma * tau) where tau = (nu/sigma)^2
+                tau = (nu / sigma) ** 2
+                scaled_name = f"{param_name}_scaled"
+                augmented_context[scaled_name] = context[param_name] * tau
+                dists.append(
+                    PoissonDist(
+                        name=f"constraint_bblite_{self.name}_{i}",
+                        x=float(tau),
+                        mean=scaled_name,
+                    )
+                )
+            else:  # "Gauss"
+                # Gaussian: N(1.0 | gamma, relerr) where relerr = sigma / nu
+                relerr = sigma / nu
+                sigma_name = f"{param_name}_sigma"
+                augmented_context[sigma_name] = pt.constant(relerr)
+                dists.append(
+                    GaussianDist(
+                        name=f"constraint_bblite_{self.name}_{i}",
+                        x=1.0,
+                        mean=param_name,
+                        sigma=sigma_name,
+                    )
+                )
+
+        if not dists:
+            return None
+
+        # Evaluate all distributions with augmented context and multiply
+        factors = []
+        for dist in dists:
+            dist_ctx = Context({**augmented_context, **dist.constants})
+            factors.append(dist.expression(dist_ctx))
+
+        return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
 
     def _compute_expected_rates(self, context: Context, total_bins: int) -> TensorVar:
         """

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -301,8 +301,8 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         for i, param_name in enumerate(gamma_params):
             nu, sigma = total_nominal[i], total_sigma[i]
 
-            # Skip bins with zero or invalid values
-            if nu <= 0 or sigma <= 0:
+            # Skip bins with zero nominal yield; sigma=0 is caught by the parsing layer
+            if nu <= 0:
                 continue
 
             if constraint_type == "Poisson":

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -13,7 +13,7 @@ from typing import Any, Literal, cast
 import hist
 import numpy as np
 import pytensor.tensor as pt
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, model_validator
 
 from pyhs3.axes import BinnedAxes
 from pyhs3.context import Context
@@ -106,6 +106,32 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         json_schema_extra={"preprocess": False},
     )
     _normalizable: bool = PrivateAttr(default=False)
+
+    @model_validator(mode="after")
+    def _validate_staterror(self) -> HistFactoryDistChannel:
+        total_bins = self.axes.get_total_bins()
+        for sample in self.samples:
+            for mod in sample.modifiers:
+                if not isinstance(mod, StatErrorModifier):
+                    continue
+                if self.barlow_beeston_method == "full" and mod.data is None:
+                    msg = (
+                        f"StatErrorModifier '{mod.name}' in channel '{self.name}' "
+                        f"requires 'data' (uncertainties) in BB-full mode"
+                    )
+                    raise ValueError(msg)
+                if self.barlow_beeston_method == "lite" and mod.data is not None:
+                    msg = (
+                        f"StatErrorModifier '{mod.name}' in channel '{self.name}' "
+                        f"must not specify 'data' in BB-lite mode; per-bin errors "
+                        f"come from the sample data"
+                    )
+                    raise ValueError(msg)
+                if not mod.parameters:
+                    mod.parameters = [
+                        f"staterror_{self.name}_bin{i}" for i in range(total_bins)
+                    ]
+        return self
 
     def get_internal_nodes(self) -> list[Any]:
         """

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -402,8 +402,8 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
     type: Literal["staterror"] = "staterror"
     application: Literal["multiplicative"] = Field("multiplicative", exclude=True)
     parameters: list[str]
-    constraint: Literal["Gauss"] = "Gauss"
-    data: StatErrorData
+    constraint: Literal["Gauss", "Poisson"] = "Gauss"
+    data: StatErrorData | None = None
 
     @property
     def auxdata(self) -> list[float]:
@@ -427,7 +427,15 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
         return cast("TensorVar", rates * factors)
 
     def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
-        """Create constraint term using PyTensor operations."""
+        """Create constraint term using PyTensor operations.
+
+        Only used in BB-full mode. In BB-lite mode, constraints are built at channel level.
+        """
+        if self.data is None:
+            msg = (
+                "StatErrorModifier.data is required for BB-full mode (make_constraint)"
+            )
+            raise ValueError(msg)
 
         # Barlow-Beeston method: per-bin Gaussian constraints with relative uncertainties
         name = f"constraint_{self.name}"

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -401,7 +401,7 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
 
     type: Literal["staterror"] = "staterror"
     application: Literal["multiplicative"] = Field("multiplicative", exclude=True)
-    parameters: list[str]
+    parameters: list[str] = Field(default_factory=list)
     constraint: Literal["Gauss", "Poisson"] = "Gauss"
     data: StatErrorData | None = None
 

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -437,7 +437,6 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
             )
             raise ValueError(msg)
 
-        # Barlow-Beeston method: per-bin Gaussian constraints with relative uncertainties
         name = f"constraint_{self.name}"
         augmented_context = dict(context)
         dists = []
@@ -445,21 +444,31 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
         for i, (parameter, uncertainty) in enumerate(
             zip(self.parameters, self.data.uncertainties, strict=False)
         ):
-            # Calculate relative uncertainty: sigma = uncertainty / nominal_yield
             nominal_yield = sample_data.contents[i]
+            # sigma_value is the relative uncertainty = uncertainty / nominal_yield
             sigma_value = uncertainty / nominal_yield if nominal_yield > 0 else 1.0
 
-            # Create sigma parameter in augmented context
-            sigma_param_name = f"{parameter}_sigma"
-            augmented_context[sigma_param_name] = pt.constant(sigma_value)
-
-            # Create Gaussian constraint: N(auxdata=1.0 | mean=parameter, sigma=relative_uncertainty)
-            dist = GaussianDist(
-                name=f"{name}_{parameter}",
-                x=1.0,  # Auxiliary data (typically 1.0 for staterror)
-                mean=parameter,
-                sigma=sigma_param_name,
-            )
+            if self.constraint == "Poisson":
+                # Poisson: Poisson(tau | gamma * tau) where tau = (nominal/uncertainty)^2
+                # Equivalently: tau = 1/sigma_value^2
+                tau = 1.0 / sigma_value**2
+                scaled_name = f"{parameter}_scaled"
+                augmented_context[scaled_name] = context[parameter] * tau
+                dist: GaussianDist | PoissonDist = PoissonDist(
+                    name=f"{name}_{parameter}",
+                    x=float(tau),
+                    mean=scaled_name,
+                )
+            else:  # "Gauss"
+                # Gaussian: N(1.0 | gamma, sigma_value)
+                sigma_param_name = f"{parameter}_sigma"
+                augmented_context[sigma_param_name] = pt.constant(sigma_value)
+                dist = GaussianDist(
+                    name=f"{name}_{parameter}",
+                    x=1.0,
+                    mean=parameter,
+                    sigma=sigma_param_name,
+                )
             dists.append(dist)
 
         if not dists:

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -449,6 +449,9 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
             sigma_value = uncertainty / nominal_yield if nominal_yield > 0 else 1.0
 
             if self.constraint == "Poisson":
+                # Skip zero-yield bins: tau = (nu/sigma)^2 is undefined when nu <= 0
+                if nominal_yield <= 0:
+                    continue
                 # Poisson: Poisson(tau | gamma * tau) where tau = (nominal/uncertainty)^2
                 # Equivalently: tau = 1/sigma_value^2
                 tau = 1.0 / sigma_value**2

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -672,7 +672,6 @@ class TestConstraintValidator:
             "name": "stat",
             "type": "staterror",
             "parameters": ["gamma_0"],
-            "data": {"uncertainties": [1.0]},
         }
         sr = _make_channel("SR", [10.0], [shared_staterror])
         cr = _make_channel("CR", [50.0], [shared_staterror])

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -2565,3 +2565,41 @@ class TestBarlowBeestonLite:
         sigma_value = 2.0 / 100.0
         expected = 1.0 / (sigma_value * np.sqrt(2 * np.pi))
         np.testing.assert_allclose(result_val, expected, rtol=1e-6)
+
+    def test_lite_positive_yield_zero_sigma_not_skipped(self):
+        """A bin with nu > 0 and sigma = 0 must not be silently dropped from the constraint.
+
+        If `sigma <= 0` fires when `nu > 0`, the gamma parameter floats free:
+        _compute_expected_rates() still scales rates by gamma but no constraint is added.
+        The parsing layer prevents sigma=0 with nu>0, so this check is dead code that
+        masks validation failures rather than surfacing them.
+        """
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0], "errors": [0.0]},  # nu=10, sigma=0
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        context = Context({"gamma_bin0": pt.constant(1.0)})
+
+        # With the old condition `nu <= 0 or sigma <= 0`, this bin (nu=10, sigma=0) was
+        # silently dropped → method returned None.  After the fix (`nu <= 0` only), the
+        # bin is included and the method returns a TensorVar (not None).
+        result = channel._make_barlow_beeston_lite_constraint(context)
+        assert result is not None

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -598,7 +598,12 @@ class TestPyhfPrecisionValidation:
             },
         ]
 
-        dist = HistFactoryDistChannel(name="singlechannel", axes=axes, samples=samples)
+        dist = HistFactoryDistChannel(
+            name="singlechannel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="full",
+        )
 
         # Create context
         mu_var = pt.dscalar("mu")
@@ -1773,3 +1778,364 @@ class TestHistoSysNominalRates:
         result_sn = f_sn(0.5, 0.5)
 
         np.testing.assert_allclose(result_ns, result_sn, rtol=1e-12)
+
+
+class TestBarlowBeestonLite:
+    """Test Barlow-Beeston lite implementation for staterror modifier."""
+
+    def test_staterror_modifier_without_data(self):
+        """Test that StatErrorModifier accepts data=None for lite mode."""
+        modifier = StatErrorModifier(
+            name="stat_error",
+            type="staterror",
+            parameters=["gamma_bin0", "gamma_bin1"],
+            constraint="Gauss",
+            data=None,
+        )
+        assert modifier.data is None
+        assert modifier.parameters == ["gamma_bin0", "gamma_bin1"]
+
+    def test_staterror_modifier_poisson_constraint(self):
+        """Test that StatErrorModifier accepts constraint='Poisson'."""
+        modifier = StatErrorModifier(
+            name="stat_error",
+            type="staterror",
+            parameters=["gamma_bin0", "gamma_bin1"],
+            constraint="Poisson",
+            data=None,
+        )
+        assert modifier.constraint == "Poisson"
+
+    def test_lite_field_accepted(self):
+        """Test that HistFactoryDistChannel accepts barlow_beeston_method='lite'."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [5.0, 3.0], "errors": [1.0, 1.0]},
+                "modifiers": [],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_lite_default(self):
+        """Test that barlow_beeston_method defaults to 'lite'."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [5.0, 3.0], "errors": [1.0, 1.0]},
+                "modifiers": [],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+        )
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_lite_combined_uncertainties(self):
+        """Test that BB-lite computes combined uncertainties correctly.
+
+        Combined uncertainty should be: sigma = sqrt(sum(errors^2))
+        Relative error should be: relerr = sigma / total_nominal
+        """
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [3.0, 4.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+            {
+                "name": "background",
+                "data": {"contents": [20.0, 30.0], "errors": [4.0, 5.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # Expected combined values:
+        # total_nominal = [10+20, 20+30] = [30, 50]
+        # total_sigma = [sqrt(9+16), sqrt(16+25)] = [5, sqrt(41)]
+        # relerr = [5/30, sqrt(41)/50] = [0.1667, 0.1281]
+
+        # Verify the channel was created correctly
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_lite_poisson_constraint(self):
+        """Test BB-lite Poisson constraint with tau = (nu/sigma)^2."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [100.0, 200.0], "errors": [10.0, 14.14]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Poisson",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # For Poisson: tau = (nu/sigma)^2
+        # Bin 0: tau = (100/10)^2 = 100
+        # Bin 1: tau = (200/14.14)^2 ≈ 200
+
+        # Verify the channel was created correctly
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_lite_gaussian_constraint(self):
+        """Test BB-lite Gaussian constraint with relerr = sigma/nu."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [100.0, 200.0], "errors": [10.0, 20.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # For Gaussian: relerr = sigma/nu
+        # Bin 0: relerr = 10/100 = 0.1
+        # Bin 1: relerr = 20/200 = 0.1
+
+        # Verify the channel was created correctly
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_lite_gamma_modifies_rates(self):
+        """Test that shared gamma parameters scale all sample rates in BB-lite."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [3.0, 4.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+            {
+                "name": "background",
+                "data": {"contents": [20.0, 30.0], "errors": [4.0, 5.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # With gamma_bin0 = 1.2, both samples should be scaled by 1.2 in bin 0
+        context = Context({"gamma_bin0": 1.2, "gamma_bin1": 1.0})
+        total_bins = channel._get_total_bins()
+        rates = channel._compute_expected_rates(context, total_bins)
+
+        # Expected: signal[0] = 10 * 1.2 = 12, background[0] = 20 * 1.2 = 24
+        # Total rate in bin 0 should be 12 + 24 = 36
+        # Total rate in bin 1 should be 20 + 30 = 50 (gamma_bin1 = 1.0)
+        rates_eval = rates.eval()
+        assert np.isclose(rates_eval[0], 36.0), f"Expected 36.0, got {rates_eval[0]}"
+        assert np.isclose(rates_eval[1], 50.0), f"Expected 50.0, got {rates_eval[1]}"
+
+    def test_lite_skips_per_sample_constraint(self):
+        """Test that per-sample make_constraint() is not called in lite mode."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [3.0, 4.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # In lite mode, the constraint should come from the channel, not per-sample
+        # This is verified by checking that extended_likelihood works without
+        # modifier.data being present
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_full_mode_backward_compatible(self):
+        """Test that barlow_beeston_method='full' uses original behavior."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [3.0, 4.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                        "data": {
+                            "uncertainties": [0.3, 0.2],  # relative uncertainties
+                        },
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="full",
+        )
+
+        # Full mode should use per-sample constraints as before
+        assert channel.barlow_beeston_method == "full"
+
+    def test_lite_with_other_modifiers(self):
+        """Test that BB-lite works alongside normsys and normfactor modifiers."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [3.0, 4.0]},
+                "modifiers": [
+                    {
+                        "name": "mu",
+                        "type": "normfactor",
+                        "parameter": "mu",
+                    },
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    },
+                ],
+            },
+            {
+                "name": "background",
+                "data": {"contents": [20.0, 30.0], "errors": [4.0, 5.0]},
+                "modifiers": [
+                    {
+                        "name": "bkg_norm",
+                        "type": "normsys",
+                        "parameter": "bkg_norm",
+                        "constraint": "Gauss",
+                        "data": {"hi": 1.1, "lo": 0.9},
+                    },
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    },
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # All modifiers should work together
+        assert channel.barlow_beeston_method == "lite"
+
+    def test_lite_zero_yield_bin(self):
+        """Test that bins with nu=0 or sigma=0 are skipped gracefully."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 3}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {
+                    "contents": [10.0, 0.0, 20.0],  # bin 1 has zero yield
+                    "errors": [3.0, 0.0, 4.0],
+                },
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1", "gamma_bin2"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # Should handle zero bins without error
+        # Constraint should only be built for bins 0 and 2
+        assert channel.barlow_beeston_method == "lite"

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -7,6 +7,7 @@ Test the HistFactoryDist class with various modifiers and configurations.
 from __future__ import annotations
 
 import json
+import math
 import platform
 import warnings
 
@@ -631,6 +632,137 @@ class TestPyhfPrecisionValidation:
         pyhs3_logpdf = total_func(mu, staterror_bin_0, np.array([observed]))
 
         # Validate precision (use reasonable tolerances for staterror)
+        assert pyhs3_expected[0] == pytest.approx(pyhf_expected[0], abs=1e-12), (
+            f"Expected rates differ: pyhf={pyhf_expected[0]}, pyhs3={pyhs3_expected[0]}"
+        )
+        assert float(pyhs3_logpdf) == pytest.approx(pyhf_logpdf, abs=1e-12), (
+            f"Log PDF differs: pyhf={pyhf_logpdf}, pyhs3={float(pyhs3_logpdf)}"
+        )
+
+    def test_staterror_lite_precision_vs_pyhf(self):
+        """Test that BB-lite staterror (multi-sample, shared gamma) achieves perfect
+        precision vs pyhf.
+
+        pyhf's staterror is itself Barlow-Beeston lite with a shared Gaussian constraint
+        over samples with the same modifier name.  pyhs3 lite mode with matching errors
+        must produce identical logpdf and expected rates.
+        """
+        mu = 1.0
+        gamma = 1.0  # staterror gamma at nominal
+        observed = 30.0  # signal(10) + bkg1(15) + bkg2(5) = 30
+
+        # pyhf: two backgrounds with the same staterror name
+        # pyhf combines sigma_total = sqrt(3^2 + 4^2) = 5 over nu_total = 15+5 = 20
+        pyhf_spec = {
+            "channels": [
+                {
+                    "name": "singlechannel",
+                    "samples": [
+                        {
+                            "name": "signal",
+                            "data": [10],
+                            "modifiers": [
+                                {"name": "mu", "type": "normfactor", "data": None}
+                            ],
+                        },
+                        {
+                            "name": "background1",
+                            "data": [15],
+                            "modifiers": [
+                                {
+                                    "name": "stat_error",
+                                    "type": "staterror",
+                                    "data": [3.0],
+                                }
+                            ],
+                        },
+                        {
+                            "name": "background2",
+                            "data": [5],
+                            "modifiers": [
+                                {
+                                    "name": "stat_error",
+                                    "type": "staterror",
+                                    "data": [4.0],
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ]
+        }
+
+        pyhf_model = pyhf.Model(pyhf_spec)
+        pyhf_params = [mu, gamma]
+        pyhf_data = [int(observed), *pyhf_model.config.auxdata]
+
+        pyhf_expected = pyhf_model.expected_actualdata(pyhf_params)
+        pyhf_logpdf = pyhf_model.logpdf(pyhf_params, pyhf_data).item()
+
+        # pyhs3 lite mode: signal + 2 backgrounds with shared staterror parameters
+        # errors match pyhf staterror data so sigma_combined = sqrt(3^2+4^2) = 5
+        axes = [{"name": "observable", "min": 0.0, "max": 1.0, "nbins": 1}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0], "errors": [1.0]},
+                "modifiers": [{"name": "mu", "type": "normfactor", "parameter": "mu"}],
+            },
+            {
+                "name": "background1",
+                "data": {"contents": [15.0], "errors": [3.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["stat_error"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+            {
+                "name": "background2",
+                "data": {"contents": [5.0], "errors": [4.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["stat_error"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+
+        dist = HistFactoryDistChannel(
+            name="singlechannel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        # Create symbolic context
+        mu_var = pt.dscalar("mu")
+        gamma_var = pt.dscalar("stat_error")
+        observed_data_var = pt.dvector("singlechannel_observed")
+
+        context = Context(
+            {
+                "mu": mu_var,
+                "stat_error": gamma_var,
+                "singlechannel_observed": observed_data_var,
+            }
+        )
+
+        expected_rates = dist._compute_expected_rates(context, 1)
+        total_expr = dist.log_expression(context)
+
+        rates_func = function([mu_var, gamma_var], expected_rates)
+        total_func = function([mu_var, gamma_var, observed_data_var], total_expr)
+
+        pyhs3_expected = rates_func(mu, gamma)
+        pyhs3_logpdf = total_func(mu, gamma, np.array([observed]))
+
         assert pyhs3_expected[0] == pytest.approx(pyhf_expected[0], abs=1e-12), (
             f"Expected rates differ: pyhf={pyhf_expected[0]}, pyhs3={pyhs3_expected[0]}"
         )
@@ -1886,8 +2018,19 @@ class TestBarlowBeestonLite:
         # total_sigma = [sqrt(9+16), sqrt(16+25)] = [5, sqrt(41)]
         # relerr = [5/30, sqrt(41)/50] = [0.1667, 0.1281]
 
-        # Verify the channel was created correctly
-        assert channel.barlow_beeston_method == "lite"
+        # At gamma=1.0 the exponent is 0: N(1|1, relerr) = 1/(relerr * sqrt(2*pi))
+        context = Context(
+            {"gamma_bin0": pt.constant(1.0), "gamma_bin1": pt.constant(1.0)}
+        )
+        constraint = channel._make_barlow_beeston_lite_constraint(context)
+        assert constraint is not None
+        constraint_val = float(constraint.eval())
+
+        total_nominal = np.array([30.0, 50.0])
+        total_sigma = np.array([5.0, np.sqrt(41.0)])
+        relerr = total_sigma / total_nominal
+        expected = float(np.prod(1.0 / (relerr * np.sqrt(2 * np.pi))))
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-6)
 
     def test_lite_poisson_constraint(self):
         """Test BB-lite Poisson constraint with tau = (nu/sigma)^2."""
@@ -1915,10 +2058,30 @@ class TestBarlowBeestonLite:
 
         # For Poisson: tau = (nu/sigma)^2
         # Bin 0: tau = (100/10)^2 = 100
-        # Bin 1: tau = (200/14.14)^2 ≈ 200
+        # Bin 1: tau = (200/14.14)^2 ≈ 200.06
 
-        # Verify the channel was created correctly
-        assert channel.barlow_beeston_method == "lite"
+        # At gamma=1.0: Poisson(tau | gamma*tau=tau) = exp(tau*log(tau) - tau - lgamma(tau+1))
+        context = Context(
+            {"gamma_bin0": pt.constant(1.0), "gamma_bin1": pt.constant(1.0)}
+        )
+        constraint = channel._make_barlow_beeston_lite_constraint(context)
+        assert constraint is not None
+        constraint_val = float(constraint.eval())
+
+        nu = np.array([100.0, 200.0])
+        sigma = np.array([10.0, 14.14])
+        tau = (nu / sigma) ** 2
+        # Generalized Poisson PMF: exp(x*log(mu) - mu - lgamma(x+1)) with x=mu=tau
+        log_factors = (
+            tau * np.log(tau)
+            - tau
+            - np.array([math.lgamma(float(t) + 1.0) for t in tau])
+        )
+        expected = float(np.exp(np.sum(log_factors)))
+        # PyTensor stores integer-valued tau (100.0) as float32, which reduces gammaln
+        # precision slightly compared to the float64 math.lgamma reference.  rtol=1e-4
+        # covers this implementation detail while still catching formula errors.
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-4)
 
     def test_lite_gaussian_constraint(self):
         """Test BB-lite Gaussian constraint with relerr = sigma/nu."""
@@ -1948,8 +2111,22 @@ class TestBarlowBeestonLite:
         # Bin 0: relerr = 10/100 = 0.1
         # Bin 1: relerr = 20/200 = 0.1
 
-        # Verify the channel was created correctly
-        assert channel.barlow_beeston_method == "lite"
+        # At off-nominal gamma=[0.9, 1.1], the Gaussian exponent is non-trivial:
+        # N(1.0 | gamma, relerr) = exp(-0.5*((1.0-gamma)/relerr)^2) / (relerr*sqrt(2*pi))
+        context = Context(
+            {"gamma_bin0": pt.constant(0.9), "gamma_bin1": pt.constant(1.1)}
+        )
+        constraint = channel._make_barlow_beeston_lite_constraint(context)
+        assert constraint is not None
+        constraint_val = float(constraint.eval())
+
+        relerr = 0.1
+        gamma_vals = np.array([0.9, 1.1])
+        factors = np.exp(-0.5 * ((1.0 - gamma_vals) / relerr) ** 2) / (
+            relerr * np.sqrt(2 * np.pi)
+        )
+        expected = float(np.prod(factors))
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-6)
 
     def test_lite_gamma_modifies_rates(self):
         """Test that shared gamma parameters scale all sample rates in BB-lite."""
@@ -2023,10 +2200,25 @@ class TestBarlowBeestonLite:
             barlow_beeston_method="lite",
         )
 
-        # In lite mode, the constraint should come from the channel, not per-sample
-        # This is verified by checking that extended_likelihood works without
-        # modifier.data being present
-        assert channel.barlow_beeston_method == "lite"
+        # In lite mode, make_constraint() must NOT be called on the data=None modifier —
+        # that would raise ValueError.  Success proves the per-sample path was skipped.
+        context = Context(
+            {
+                "gamma_bin0": pt.constant(1.0),
+                "gamma_bin1": pt.constant(1.0),
+            }
+        )
+
+        # extended_likelihood must complete without raising ValueError
+        result = channel.extended_likelihood(context)
+        result_val = float(result.eval())
+
+        # The result must equal the lite channel-level constraint (no per-sample term)
+        lite_constraint = channel._make_barlow_beeston_lite_constraint(context)
+        assert lite_constraint is not None
+        np.testing.assert_allclose(
+            result_val, float(lite_constraint.eval()), rtol=1e-10
+        )
 
     def test_full_mode_backward_compatible(self):
         """Test that barlow_beeston_method='full' uses original behavior."""
@@ -2106,8 +2298,31 @@ class TestBarlowBeestonLite:
             barlow_beeston_method="lite",
         )
 
-        # All modifiers should work together
-        assert channel.barlow_beeston_method == "lite"
+        # In lite mode: extended_likelihood = normsys_constraint * lite_staterror_constraint
+        # Crucially, make_constraint() is NOT called on the data=None staterror modifiers —
+        # that would raise ValueError.  The test succeeds only if the staterror was skipped.
+        context = Context(
+            {
+                "mu": pt.constant(1.0),
+                "bkg_norm": pt.constant(0.0),
+                "gamma_bin0": pt.constant(1.0),
+                "gamma_bin1": pt.constant(1.0),
+            }
+        )
+        result_val = float(channel.extended_likelihood(context).eval())
+
+        # normsys at alpha=0: N(0 | 0, 1) = 1/sqrt(2*pi)
+        normsys_val = 1.0 / np.sqrt(2 * np.pi)
+
+        # lite staterror (both samples have staterror):
+        # total_nominal=[10+20, 20+30]=[30,50], total_sigma=[sqrt(9+16), sqrt(16+25)]=[5,sqrt(41)]
+        total_sigma = np.array([5.0, np.sqrt(41.0)])
+        total_nominal = np.array([30.0, 50.0])
+        relerr = total_sigma / total_nominal
+        lite_val = float(np.prod(1.0 / (relerr * np.sqrt(2 * np.pi))))
+
+        expected = normsys_val * lite_val
+        np.testing.assert_allclose(result_val, expected, rtol=1e-6)
 
     def test_lite_zero_yield_bin(self):
         """Test that bins with nu=0 or sigma=0 are skipped gracefully."""
@@ -2136,6 +2351,217 @@ class TestBarlowBeestonLite:
             barlow_beeston_method="lite",
         )
 
-        # Should handle zero bins without error
-        # Constraint should only be built for bins 0 and 2
-        assert channel.barlow_beeston_method == "lite"
+        # Bin 1 (nu=0, sigma=0) must be skipped; only bins 0 and 2 contribute.
+        context = Context(
+            {
+                "gamma_bin0": pt.constant(1.0),
+                "gamma_bin1": pt.constant(1.0),  # skipped — not used
+                "gamma_bin2": pt.constant(1.0),
+            }
+        )
+        constraint = channel._make_barlow_beeston_lite_constraint(context)
+        assert constraint is not None  # bins 0 and 2 are still valid
+
+        constraint_val = float(constraint.eval())
+
+        # relerr_0 = 3/10 = 0.3, relerr_2 = 4/20 = 0.2; exponent=0 at gamma=1
+        expected = float(
+            (1.0 / (0.3 * np.sqrt(2 * np.pi))) * (1.0 / (0.2 * np.sqrt(2 * np.pi)))
+        )
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-6)
+
+    def test_lite_constraint_none_without_staterror(self):
+        """_make_barlow_beeston_lite_constraint returns None when no staterror modifier
+        is present; extended_likelihood falls back to pt.constant(1.0)."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [5.0, 3.0], "errors": [1.0, 1.0]},
+                "modifiers": [{"name": "mu", "type": "normfactor", "parameter": "mu"}],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        context = Context({"mu": pt.constant(1.0)})
+
+        # No staterror modifier in any sample
+        assert channel._find_staterror_modifier() is None
+        # The private method returns None — staterror_mod is None guard fires
+        assert channel._make_barlow_beeston_lite_constraint(context) is None
+
+        # With no constraints at all, extended_likelihood returns constant 1.0
+        result_val = float(channel.extended_likelihood(context).eval())
+        assert result_val == pytest.approx(1.0)
+
+    def test_lite_constraint_none_all_bins_skipped(self):
+        """_make_barlow_beeston_lite_constraint returns None when every bin satisfies
+        the nu<=0 or sigma<=0 skip condition (the 'if not dists: return None' branch)."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                # All contents are zero → total_nominal=0 for every bin → all skipped
+                "data": {"contents": [0.0, 0.0], "errors": [1.0, 1.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        context = Context(
+            {
+                "gamma_bin0": pt.constant(1.0),
+                "gamma_bin1": pt.constant(1.0),
+            }
+        )
+
+        # All bins have nu=0; every bin is skipped → method returns None
+        assert channel._make_barlow_beeston_lite_constraint(context) is None
+
+        # extended_likelihood with no valid constraints returns constant 1.0
+        result_val = float(channel.extended_likelihood(context).eval())
+        assert result_val == pytest.approx(1.0)
+
+    def test_lite_excludes_non_staterror_samples(self):
+        """BB-lite only accumulates uncertainty from samples carrying a staterror
+        modifier; samples without staterror are excluded from the combined sigma."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0], "errors": [2.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+            {
+                "name": "background",
+                # errors=[5.0] would change the combined sigma if included
+                "data": {"contents": [20.0], "errors": [5.0]},
+                "modifiers": [],  # no staterror — must NOT contribute
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+
+        context = Context({"gamma_bin0": pt.constant(1.0)})
+        constraint = channel._make_barlow_beeston_lite_constraint(context)
+        assert constraint is not None
+        constraint_val = float(constraint.eval())
+
+        # Only signal contributes: nu=10, sigma=2, relerr=0.2
+        # N(1|1, 0.2) = 1 / (0.2 * sqrt(2*pi))
+        expected = 1.0 / (0.2 * np.sqrt(2 * np.pi))
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-6)
+
+        # Verify: if background (errors=5) were included, the result would differ.
+        # total_nominal would be 10+20=30 (both samples), total_sigma=sqrt(4+25)=sqrt(29)
+        relerr_if_included = np.sqrt(2.0**2 + 5.0**2) / (10.0 + 20.0)
+        wrong_expected = 1.0 / (relerr_if_included * np.sqrt(2 * np.pi))
+        assert not np.isclose(constraint_val, wrong_expected, rtol=1e-3)
+
+    def test_find_staterror_modifier_none(self):
+        """_find_staterror_modifier() returns None when no sample carries a staterror
+        modifier, and returns the modifier when one is present."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}]
+
+        # Channel without staterror
+        channel_no_stat = HistFactoryDistChannel(
+            name="no_stat",
+            axes=axes,
+            samples=[
+                {
+                    "name": "signal",
+                    "data": {"contents": [10.0], "errors": [1.0]},
+                    "modifiers": [
+                        {"name": "mu", "type": "normfactor", "parameter": "mu"}
+                    ],
+                }
+            ],
+        )
+        assert channel_no_stat._find_staterror_modifier() is None
+
+        # Channel with staterror
+        channel_with_stat = HistFactoryDistChannel(
+            name="with_stat",
+            axes=axes,
+            samples=[
+                {
+                    "name": "signal",
+                    "data": {"contents": [10.0], "errors": [2.0]},
+                    "modifiers": [
+                        {
+                            "name": "stat_error",
+                            "type": "staterror",
+                            "parameters": ["gamma_bin0"],
+                            "constraint": "Gauss",
+                        }
+                    ],
+                }
+            ],
+        )
+        found = channel_with_stat._find_staterror_modifier()
+        assert found is not None
+        assert found.type == "staterror"
+        assert found.parameters == ["gamma_bin0"]
+
+    def test_extended_likelihood_full_mode(self):
+        """In full mode, extended_likelihood calls per-sample make_constraint on each
+        staterror modifier (not the channel-level lite path)."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [100.0], "errors": [2.0]},
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0"],
+                        "constraint": "Gauss",
+                        "data": {"uncertainties": [2.0]},  # required for full mode
+                    }
+                ],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="full",
+        )
+
+        context = Context({"gamma_bin0": pt.constant(1.0)})
+        result_val = float(channel.extended_likelihood(context).eval())
+
+        # Full mode: N(1.0 | gamma=1.0, sigma_value) where sigma_value = unc/nominal
+        # sigma_value = 2.0 / 100.0 = 0.02; at gamma=1 the exponent is 0
+        sigma_value = 2.0 / 100.0
+        expected = 1.0 / (sigma_value * np.sqrt(2 * np.pi))
+        np.testing.assert_allclose(result_val, expected, rtol=1e-6)

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -23,6 +23,8 @@ try:
 except ImportError:
     HAS_PYHF = False
 
+from pydantic import ValidationError
+
 import pyhs3
 from pyhs3.axes import BinnedAxes
 from pyhs3.context import Context
@@ -2603,3 +2605,149 @@ class TestBarlowBeestonLite:
         # bin is included and the method returns a TensorVar (not None).
         result = channel._make_barlow_beeston_lite_constraint(context)
         assert result is not None
+
+    def test_full_mode_default_parameter_names(self):
+        """BB-full: omitting 'parameters' defaults to staterror_{channel}_bin{i}."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [1.0, 2.0]},
+                "modifiers": [
+                    {
+                        "name": "staterror",
+                        "type": "staterror",
+                        "constraint": "Gauss",
+                        "data": {"uncertainties": [0.1, 0.2]},
+                    }
+                ],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="full",
+        )
+        mod = channel._find_staterror_modifier()
+        assert mod is not None
+        assert mod.parameters == [
+            "staterror_test_channel_bin0",
+            "staterror_test_channel_bin1",
+        ]
+
+    def test_full_mode_missing_data_raises(self):
+        """BB-full: a staterror with no modifier 'data' is an invalid spec."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [1.0, 2.0]},
+                "modifiers": [
+                    {
+                        "name": "staterror",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                    }
+                ],
+            }
+        ]
+        with pytest.raises(ValidationError, match="requires 'data'"):
+            HistFactoryDistChannel(
+                name="test_channel",
+                axes=axes,
+                samples=samples,
+                barlow_beeston_method="full",
+            )
+
+    def test_lite_mode_default_parameter_names(self):
+        """BB-lite: omitting 'parameters' defaults to staterror_{channel}_bin{i}."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [1.0, 2.0]},
+                "modifiers": [
+                    {
+                        "name": "staterror",
+                        "type": "staterror",
+                        "constraint": "Gauss",
+                    }
+                ],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+        )
+        mod = channel._find_staterror_modifier()
+        assert mod is not None
+        assert mod.parameters == [
+            "staterror_test_channel_bin0",
+            "staterror_test_channel_bin1",
+        ]
+
+    def test_lite_mode_with_data_raises(self):
+        """BB-lite: a staterror with modifier 'data' is an invalid spec."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [1.0, 2.0]},
+                "modifiers": [
+                    {
+                        "name": "staterror",
+                        "type": "staterror",
+                        "parameters": ["gamma_bin0", "gamma_bin1"],
+                        "constraint": "Gauss",
+                        "data": {"uncertainties": [0.1, 0.2]},
+                    }
+                ],
+            }
+        ]
+        with pytest.raises(ValidationError, match="must not specify 'data'"):
+            HistFactoryDistChannel(
+                name="test_channel",
+                axes=axes,
+                samples=samples,
+            )
+
+    def test_lite_default_names_shared_across_samples(self):
+        """BB-lite: bare staterror in two samples gets same channel-scoped parameter names."""
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [1.0, 2.0]},
+                "modifiers": [
+                    {
+                        "name": "staterror",
+                        "type": "staterror",
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+            {
+                "name": "background",
+                "data": {"contents": [5.0, 8.0], "errors": [0.5, 0.8]},
+                "modifiers": [
+                    {
+                        "name": "staterror",
+                        "type": "staterror",
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+        channel = HistFactoryDistChannel(
+            name="SR",
+            axes=axes,
+            samples=samples,
+        )
+        expected = ["staterror_SR_bin0", "staterror_SR_bin1"]
+        for sample in channel.samples:
+            for mod in sample.modifiers:
+                if isinstance(mod, StatErrorModifier):
+                    assert mod.parameters == expected

--- a/tests/test_histfactory_modifiers.py
+++ b/tests/test_histfactory_modifiers.py
@@ -518,6 +518,36 @@ class TestStatErrorModifier:
         # rtol=1e-4 to accommodate PyTensor float32 gammaln precision
         np.testing.assert_allclose(constraint_val, expected, rtol=1e-4)
 
+    def test_make_constraint_poisson_skips_zero_yield_bin(self):
+        """make_constraint() with Poisson must skip bins where nominal_yield <= 0.
+
+        When nominal_yield=0 the formula tau=(nu/sigma)^2 is undefined.  Without
+        the skip the code fell back to sigma_value=1 → tau=1, silently inserting a
+        spurious Poisson(1 | gamma) factor.
+        """
+        data = StatErrorData(uncertainties=[1.0, 1.0])
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0", "gamma_stat_bin1"],
+            constraint="Poisson",
+            data=data,
+        )
+
+        context = Context(
+            {"gamma_stat_bin0": pt.constant(1.0), "gamma_stat_bin1": pt.constant(1.0)}
+        )
+        # bin 0: nominal_yield=0 (skip), bin 1: nominal_yield=10 (include)
+        sample_data = SampleData(contents=[0.0, 10.0], errors=[0.0, 1.0])
+
+        constraint = modifier.make_constraint(context, sample_data)
+        constraint_val = float(constraint.eval())
+
+        # Only bin 1 contributes: sigma_value=1/10=0.1, tau=100
+        tau = 1.0 / 0.1**2  # 100
+        log_factor = tau * np.log(tau) - tau - math.lgamma(tau + 1.0)
+        expected = float(np.exp(log_factor))
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-4)
+
 
 class TestModifierConstraintTypes:
     """Test different constraint types for modifiers."""

--- a/tests/test_histfactory_modifiers.py
+++ b/tests/test_histfactory_modifiers.py
@@ -465,6 +465,25 @@ class TestStatErrorModifier:
         # Should return 1.0 when there are no constraints
         assert constraint_val == pytest.approx(1.0)
 
+    def test_make_constraint_requires_data(self):
+        """Test that make_constraint raises ValueError when data=None (BB-full mode guard).
+
+        In BB-lite mode the StatErrorModifier carries no per-bin StatErrorData;
+        make_constraint() must never be called on such a modifier (the channel
+        builds the constraint at a higher level). This guards against accidentally
+        calling the per-sample path in lite mode.
+        """
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0"],
+            data=None,
+        )
+        context = Context({"gamma_stat_bin0": pt.constant(1.0)})
+        sample_data = SampleData(contents=[50.0], errors=[2.0])
+
+        with pytest.raises(ValueError, match="data is required for BB-full mode"):
+            modifier.make_constraint(context, sample_data)
+
 
 class TestModifierConstraintTypes:
     """Test different constraint types for modifiers."""

--- a/tests/test_histfactory_modifiers.py
+++ b/tests/test_histfactory_modifiers.py
@@ -6,6 +6,8 @@ Test coverage for all modifier types and their constraint handling.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytensor.tensor as pt
 import pytest
@@ -483,6 +485,38 @@ class TestStatErrorModifier:
 
         with pytest.raises(ValueError, match="data is required for BB-full mode"):
             modifier.make_constraint(context, sample_data)
+
+    def test_make_constraint_poisson_constraint(self):
+        """make_constraint() with constraint='Poisson' builds Poisson (not Gaussian) terms.
+
+        For each bin: Poisson(tau | gamma * tau) where tau = (nominal / uncertainty)^2.
+        """
+        data = StatErrorData(uncertainties=[1.0, 2.0])
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0", "gamma_stat_bin1"],
+            constraint="Poisson",
+            data=data,
+        )
+
+        context = Context(
+            {"gamma_stat_bin0": pt.constant(1.0), "gamma_stat_bin1": pt.constant(1.0)}
+        )
+        sample_data = SampleData(contents=[10.0, 20.0], errors=[1.0, 2.0])
+
+        constraint = modifier.make_constraint(context, sample_data)
+        constraint_val = float(constraint.eval())
+
+        # sigma_value = uncertainty/nominal = [1/10, 2/20] = [0.1, 0.1]
+        # tau = 1/sigma_value^2 = [100, 100]
+        # At gamma=1.0: Poisson(tau | tau) = exp(tau*log(tau) - tau - lgamma(tau+1))
+        tau = np.array([1.0 / 0.1**2, 1.0 / 0.1**2])  # [100, 100]
+        log_factors = (
+            tau * np.log(tau) - tau - np.array([math.lgamma(t + 1.0) for t in tau])
+        )
+        expected = float(np.exp(np.sum(log_factors)))
+        # rtol=1e-4 to accommodate PyTensor float32 gammaln precision
+        np.testing.assert_allclose(constraint_val, expected, rtol=1e-4)
 
 
 class TestModifierConstraintTypes:


### PR DESCRIPTION
Implements Barlow-Beeston lite (BB-lite) for the `staterror` modifier in pyhs3's HistFactory
distribution. BB-lite uses shared gamma parameters across all samples in a channel, with a
single channel-level constraint built from the combined MC statistical uncertainties, as
opposed to BB-full which builds a per-sample Gaussian constraint from the modifier's own
uncertainty data.

## Key changes

- Add `barlow_beeston_method` field to `HistFactoryDistChannel` (defaults to `"lite"`)
- Implement `_make_barlow_beeston_lite_constraint()` supporting both Poisson and Gaussian variants
- Modify `extended_likelihood()` to skip per-sample constraints in lite mode
- Fix `make_constraint()` to actually build a Poisson constraint when `constraint="Poisson"` (was always building Gaussian)
- Fix skip condition in `_make_barlow_beeston_lite_constraint`: only skip bins with `nu <= 0`; `sigma=0` with `nu > 0` is a parsing-layer concern, not a silent drop
- Make `StatErrorModifier.parameters` optional (default `[]`) for staterror only — other modifier types keep the required field
- Add `@model_validator(mode="after")` on `HistFactoryDistChannel` to:
  - Default omitted `parameters` to `staterror_{channel}_bin{i}` (channel-scoped, 0-based), matching the HS3 convention for bare staterror blocks
  - Enforce BB-full requires modifier `data`; raise `ValidationError` if absent
  - Enforce BB-lite forbids modifier `data`; raise `ValidationError` if present (errors belong on the sample)

## BB-lite vs BB-full

| | BB-lite (default) | BB-full |
|---|---|---|
| Gamma params | Shared across samples per channel | Per-sample |
| Constraint | Channel-level, combined uncertainties | Per-sample Gaussian from modifier data |
| Modifier `data` | **Forbidden** (errors on sample) | **Required** |
| Parameter names | Auto-derived as `staterror_{ch}_bin{i}` if omitted | Must be explicit or omitted for auto-default |

## Constraint math

- **Gaussian**: `N(1.0 | gamma, sigma/nu)` where `sigma = sqrt(sum(errors^2))` across samples
- **Poisson**: `Poisson(tau | gamma * tau)` where `tau = (nu / sigma)^2`

## Tests

- Precision comparisons against pyhf for both Gaussian and Poisson BB-lite constraints
- Shared gamma parameters correctly modify all sample rates
- Default parameter naming from bare staterror spec (`{"name":"staterror","type":"staterror"}`)
- BB-full raises `ValidationError` when modifier `data` is absent
- BB-lite raises `ValidationError` when modifier `data` is present
- Two-sample channel with bare staterror gets the same channel-scoped parameter names
- Backward compatibility with BB-full mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added BB-lite statistical error handling per channel, with `lite` as the default mode.
  * Extended `StatErrorModifier` constraints to support both Gaussian and Poisson forms.
  * Improved staterror validation: BB-full mode now requires staterror data.

* **Tests**
  * Added precision and regression tests comparing BB-lite behavior against PyHF, including shared staterror handling and Poisson/Gaussian coverage.
  * Added unit tests for required-data validation and lite-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->