### PR TITLE
feat: Suggest upgrading ROOT and re-exporting the workspace on validation failure

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -884,11 +884,11 @@ environments:
       - conda: ./
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b0/8d87c7c8015ce8d4b2c5ee7a82a1d955f10138322c4f0cb387d7d2c1b2e7/blessed-1.30.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/04/2b4e111e0b902b1ac0b25e5e010af71c79fca093a3399bd7f8b82adcc536/blessed-1.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/6a/31515496e9f45cc59ac2590872d2808439fa65ed3404a99cc0cd2c0d3689/codeflash-0.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/7e/ddc864ec356282b53c7d2c8c5f1b5cc08e47810abdbb5dd2464a4ba73ae2/codeflash-0.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c4/57dd87630a289d729a8f2f65bd8d8353b9af977c878a4149e0995025eec6/codeflash_benchmark-0.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/99/b5/d8601971f072a90a2b50615d6668698a73b4796d6d5462ae78c0b3e2fc95/crosshair_tool-0.0.102-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/b5/f566c215c58d7d2b8d39104b6cda00f31a18bb480486cb7f0d68de6131f9/editor-1.7.0-py3-none-any.whl
@@ -906,7 +906,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/2f/804f58f0b856ab3bf21617cccf5b39206e6c4c94c2cd227bde125ea6105f/parameterized-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/6f/794a4e94e3640282e75013ce18e65f0a01afc8d71f733664b4a272f98bce/posthog-7.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c9/a3b871b0b590c49e38884af6dab58ab9711053bd5c39b8899b72e367b9f6/pylint_plugin_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/ac/5de3c91c7f9354444af251f053cc9953c89cce1defa74b907f67be4f770a/pylint_pydantic-0.4.1-py3-none-any.whl
@@ -915,12 +915,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/10/e4b1e0e5b6b6745c8098c275b69bc9d73e9542d5c7da4f137542b499ed44/readchar-4.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/b6/049c75d399ccf6e25abea0652b85bf7e7e101e0300aa9c1d284ad7061c0b/runs-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/49/d1/a71c36da6e2b8a4ed5e2970819b86ef13ba77ac40d9e333cb17df6a2c5db/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
@@ -1124,11 +1125,11 @@ environments:
       - conda: ./
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b0/8d87c7c8015ce8d4b2c5ee7a82a1d955f10138322c4f0cb387d7d2c1b2e7/blessed-1.30.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/04/2b4e111e0b902b1ac0b25e5e010af71c79fca093a3399bd7f8b82adcc536/blessed-1.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/6a/31515496e9f45cc59ac2590872d2808439fa65ed3404a99cc0cd2c0d3689/codeflash-0.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/7e/ddc864ec356282b53c7d2c8c5f1b5cc08e47810abdbb5dd2464a4ba73ae2/codeflash-0.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c4/57dd87630a289d729a8f2f65bd8d8353b9af977c878a4149e0995025eec6/codeflash_benchmark-0.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/7c/bd/3afb64fe1579be13b3199b659276c7c5be4303e0c578afa9c0ba1d6720f2/crosshair_tool-0.0.102.tar.gz
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/b5/f566c215c58d7d2b8d39104b6cda00f31a18bb480486cb7f0d68de6131f9/editor-1.7.0-py3-none-any.whl
@@ -1146,7 +1147,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/2f/804f58f0b856ab3bf21617cccf5b39206e6c4c94c2cd227bde125ea6105f/parameterized-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/6f/794a4e94e3640282e75013ce18e65f0a01afc8d71f733664b4a272f98bce/posthog-7.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c9/a3b871b0b590c49e38884af6dab58ab9711053bd5c39b8899b72e367b9f6/pylint_plugin_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/ac/5de3c91c7f9354444af251f053cc9953c89cce1defa74b907f67be4f770a/pylint_pydantic-0.4.1-py3-none-any.whl
@@ -1155,12 +1156,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/10/e4b1e0e5b6b6745c8098c275b69bc9d73e9542d5c7da4f137542b499ed44/readchar-4.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/b6/049c75d399ccf6e25abea0652b85bf7e7e101e0300aa9c1d284ad7061c0b/runs-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/96/2d/975c2dad292aa9994f982eb0b69cc6fda0223e4b6c4ea714550477d8ec3a/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
@@ -1372,11 +1374,11 @@ environments:
       - conda: ./
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b0/8d87c7c8015ce8d4b2c5ee7a82a1d955f10138322c4f0cb387d7d2c1b2e7/blessed-1.30.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/04/2b4e111e0b902b1ac0b25e5e010af71c79fca093a3399bd7f8b82adcc536/blessed-1.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/6a/31515496e9f45cc59ac2590872d2808439fa65ed3404a99cc0cd2c0d3689/codeflash-0.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/7e/ddc864ec356282b53c7d2c8c5f1b5cc08e47810abdbb5dd2464a4ba73ae2/codeflash-0.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c4/57dd87630a289d729a8f2f65bd8d8353b9af977c878a4149e0995025eec6/codeflash_benchmark-0.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/26/c8/95d8f27d832043392d467dcc8c280de940799450cd262dad40634effa3b4/crosshair_tool-0.0.102-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/b5/f566c215c58d7d2b8d39104b6cda00f31a18bb480486cb7f0d68de6131f9/editor-1.7.0-py3-none-any.whl
@@ -1394,7 +1396,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/2f/804f58f0b856ab3bf21617cccf5b39206e6c4c94c2cd227bde125ea6105f/parameterized-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/6f/794a4e94e3640282e75013ce18e65f0a01afc8d71f733664b4a272f98bce/posthog-7.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c9/a3b871b0b590c49e38884af6dab58ab9711053bd5c39b8899b72e367b9f6/pylint_plugin_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/ac/5de3c91c7f9354444af251f053cc9953c89cce1defa74b907f67be4f770a/pylint_pydantic-0.4.1-py3-none-any.whl
@@ -1403,12 +1405,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/10/e4b1e0e5b6b6745c8098c275b69bc9d73e9542d5c7da4f137542b499ed44/readchar-4.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/b6/049c75d399ccf6e25abea0652b85bf7e7e101e0300aa9c1d284ad7061c0b/runs-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/28/95/4c00680866280e008e81dd621fd4d3f54aa3dad1b76b857a19da1b2cc426/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
@@ -1615,11 +1618,11 @@ environments:
       - conda: ./
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b0/8d87c7c8015ce8d4b2c5ee7a82a1d955f10138322c4f0cb387d7d2c1b2e7/blessed-1.30.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/04/2b4e111e0b902b1ac0b25e5e010af71c79fca093a3399bd7f8b82adcc536/blessed-1.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/6a/31515496e9f45cc59ac2590872d2808439fa65ed3404a99cc0cd2c0d3689/codeflash-0.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/7e/ddc864ec356282b53c7d2c8c5f1b5cc08e47810abdbb5dd2464a4ba73ae2/codeflash-0.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c4/57dd87630a289d729a8f2f65bd8d8353b9af977c878a4149e0995025eec6/codeflash_benchmark-0.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/90/b2/e6f9efaf17ca90eed426e066360e87d07acecf81c05797567088421bb80d/crosshair_tool-0.0.102-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/b5/f566c215c58d7d2b8d39104b6cda00f31a18bb480486cb7f0d68de6131f9/editor-1.7.0-py3-none-any.whl
@@ -1637,7 +1640,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/2f/804f58f0b856ab3bf21617cccf5b39206e6c4c94c2cd227bde125ea6105f/parameterized-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/6f/794a4e94e3640282e75013ce18e65f0a01afc8d71f733664b4a272f98bce/posthog-7.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c9/a3b871b0b590c49e38884af6dab58ab9711053bd5c39b8899b72e367b9f6/pylint_plugin_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/ac/5de3c91c7f9354444af251f053cc9953c89cce1defa74b907f67be4f770a/pylint_pydantic-0.4.1-py3-none-any.whl
@@ -1646,12 +1649,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/10/e4b1e0e5b6b6745c8098c275b69bc9d73e9542d5c7da4f137542b499ed44/readchar-4.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/b6/049c75d399ccf6e25abea0652b85bf7e7e101e0300aa9c1d284ad7061c0b/runs-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/8f/2f/1f36fda564518d84593f2740d5905ac127d590baf5c5753cef2a88a89c15/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
@@ -1857,11 +1861,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/75/f9/f1c10e223c7b56a38109a3f2eb4e7fe9a757ea3ed3a166754fb30f65e466/ansicon-1.89.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b0/8d87c7c8015ce8d4b2c5ee7a82a1d955f10138322c4f0cb387d7d2c1b2e7/blessed-1.30.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/04/2b4e111e0b902b1ac0b25e5e010af71c79fca093a3399bd7f8b82adcc536/blessed-1.33.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/6a/31515496e9f45cc59ac2590872d2808439fa65ed3404a99cc0cd2c0d3689/codeflash-0.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/7e/ddc864ec356282b53c7d2c8c5f1b5cc08e47810abdbb5dd2464a4ba73ae2/codeflash-0.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6b/c4/57dd87630a289d729a8f2f65bd8d8353b9af977c878a4149e0995025eec6/codeflash_benchmark-0.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/50/3c/f2df50a43eafd19e04303cdbe681e1a74e515a8930185c1008e660ebbdf6/crosshair_tool-0.0.102-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/b5/f566c215c58d7d2b8d39104b6cda00f31a18bb480486cb7f0d68de6131f9/editor-1.7.0-py3-none-any.whl
@@ -1880,7 +1884,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/2f/804f58f0b856ab3bf21617cccf5b39206e6c4c94c2cd227bde125ea6105f/parameterized-0.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/6f/794a4e94e3640282e75013ce18e65f0a01afc8d71f733664b4a272f98bce/posthog-7.9.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/8b/d0d7e51f928ec6e555c943f7c07a712b992e9cf061d52cbf37fbf8622c05/pygls-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/c9/a3b871b0b590c49e38884af6dab58ab9711053bd5c39b8899b72e367b9f6/pylint_plugin_utils-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/ac/5de3c91c7f9354444af251f053cc9953c89cce1defa74b907f67be4f770a/pylint_pydantic-0.4.1-py3-none-any.whl
@@ -1889,12 +1893,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/10/e4b1e0e5b6b6745c8098c275b69bc9d73e9542d5c7da4f137542b499ed44/readchar-4.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/b6/049c75d399ccf6e25abea0652b85bf7e7e101e0300aa9c1d284ad7061c0b/runs-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/54/57c411a6e8f7bd7848c8b66e4dcaffa586bf4c02e63f2280db0327a4e6eb/unidiff-0.7.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
@@ -8285,10 +8290,10 @@ packages:
   purls: []
   size: 18592
   timestamp: 1765819189183
-- pypi: https://files.pythonhosted.org/packages/64/b0/8d87c7c8015ce8d4b2c5ee7a82a1d955f10138322c4f0cb387d7d2c1b2e7/blessed-1.30.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/22/04/2b4e111e0b902b1ac0b25e5e010af71c79fca093a3399bd7f8b82adcc536/blessed-1.33.0-py3-none-any.whl
   name: blessed
-  version: 1.30.0
-  sha256: 4061a9f10dd22798716c2548ba36385af6a29d856c897f367c6ccc927e0b3a5a
+  version: 1.33.0
+  sha256: 1bc8ecac6d139286ea51ec1683433528ce75b0c60db77b7d881112bf9fc85b0f
   requires_dist:
   - wcwidth>=0.6
   - jinxed>=1.1.0 ; sys_platform == 'win32'
@@ -10151,17 +10156,18 @@ packages:
   - pkg:pypi/cmarkgfm?source=hash-mapping
   size: 122566
   timestamp: 1760363252204
-- pypi: https://files.pythonhosted.org/packages/1e/6a/31515496e9f45cc59ac2590872d2808439fa65ed3404a99cc0cd2c0d3689/codeflash-0.20.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ef/7e/ddc864ec356282b53c7d2c8c5f1b5cc08e47810abdbb5dd2464a4ba73ae2/codeflash-0.20.3-py3-none-any.whl
   name: codeflash
-  version: 0.20.1
-  sha256: 23ca9822db8a59b5714cd55a783cfb42d06aa3b866e3e589aba404c085ea4a2a
+  version: 0.20.3
+  sha256: a002f14127d9db0879d6c99c1f955cae2e6e7cf381b8039d8354f053d754c04b
   requires_dist:
   - click>=8.1.0
   - codeflash-benchmark
   - coverage>=7.6.4
-  - crosshair-tool>=0.0.78
+  - crosshair-tool>=0.0.78 ; python_full_version < '3.15'
   - dill>=0.3.8
-  - filelock
+  - filelock<3.20.3 ; python_full_version < '3.10'
+  - filelock>=3.20.3 ; python_full_version >= '3.10'
   - gitpython>=3.1.31
   - humanize>=4.0.0
   - inquirer>=3.0.0
@@ -10182,6 +10188,7 @@ packages:
   - rich>=13.8.1
   - sentry-sdk>=1.40.6,<3.0.0
   - tomlkit>=0.11.7
+  - tree-sitter-java>=0.23.0
   - tree-sitter-javascript>=0.23.0
   - tree-sitter-typescript>=0.23.0
   - tree-sitter>=0.23.0
@@ -10745,38 +10752,38 @@ packages:
   - pkg:pypi/contourpy?source=hash-mapping
   size: 247437
   timestamp: 1769155978556
-- pypi: https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129
+  version: 7.13.5
+  sha256: 6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601
+  version: 7.13.5
+  sha256: 380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505
+  version: 7.13.5
+  sha256: 2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552
+  version: 7.13.5
+  sha256: fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl
+- pypi: https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl
   name: coverage
-  version: 7.13.4
-  sha256: 29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689
+  version: 7.13.5
+  sha256: 9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
@@ -23118,10 +23125,10 @@ packages:
   license_family: MIT
   size: 25877
   timestamp: 1764896838868
-- pypi: https://files.pythonhosted.org/packages/df/6f/794a4e94e3640282e75013ce18e65f0a01afc8d71f733664b4a272f98bce/posthog-7.9.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/65/a9/7a803aed5a5649cf78ea7b31e90d0080181ba21f739243e1741a1e607f1f/posthog-7.9.12-py3-none-any.whl
   name: posthog
-  version: 7.9.4
-  sha256: 414125ddd7a48b9c67feb24d723df1f666af41ad10f8a9a8bbaf5e3b536a2e26
+  version: 7.9.12
+  sha256: 7175bd1698a566bfea98a016c64e3456399f8046aeeca8f1d04ae5bf6c5a38d0
   requires_dist:
   - requests>=2.7,<3.0
   - six>=1.5
@@ -23884,6 +23891,7 @@ packages:
   - numpy
   - sympy
   - pydantic
+  - packaging
   - hist
   - python >=3.10
   - python *
@@ -28189,10 +28197,10 @@ packages:
   - pkg:pypi/secretstorage?source=hash-mapping
   size: 34275
   timestamp: 1763046783366
-- pypi: https://files.pythonhosted.org/packages/47/d4/2fdf854bc3b9c7f55219678f812600a20a138af2dd847d99004994eada8f/sentry_sdk-2.53.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl
   name: sentry-sdk
-  version: 2.53.0
-  sha256: 46e1ed8d84355ae54406c924f6b290c3d61f4048625989a723fd622aab838899
+  version: 2.55.0
+  sha256: 97026981cb15699394474a196b88503a393cbc58d182ece0d3abe12b9bd978d4
   requires_dist:
   - urllib3>=1.26.11
   - certifi
@@ -28336,10 +28344,10 @@ packages:
   license: BSL-1.0
   size: 587027
   timestamp: 1756274982526
-- pypi: https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl
   name: smmap
-  version: 5.0.2
-  sha256: b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e
+  version: 5.0.3
+  sha256: c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f
   requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
   sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
@@ -28942,6 +28950,41 @@ packages:
   - tree-sitter-python>=0.23.6 ; extra == 'tests'
   - tree-sitter-rust>=0.23.2 ; extra == 'tests'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: tree-sitter-java
+  version: 0.23.5
+  sha256: 370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1
+  requires_dist:
+  - tree-sitter~=0.22 ; extra == 'core'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  name: tree-sitter-java
+  version: 0.23.5
+  sha256: 9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7
+  requires_dist:
+  - tree-sitter~=0.22 ; extra == 'core'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl
+  name: tree-sitter-java
+  version: 0.23.5
+  sha256: 24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69
+  requires_dist:
+  - tree-sitter~=0.22 ; extra == 'core'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl
+  name: tree-sitter-java
+  version: 0.23.5
+  sha256: 355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df
+  requires_dist:
+  - tree-sitter~=0.22 ; extra == 'core'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl
+  name: tree-sitter-java
+  version: 0.23.5
+  sha256: 1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7
+  requires_dist:
+  - tree-sitter~=0.22 ; extra == 'core'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl
   name: tree-sitter-javascript
   version: 0.25.0
@@ -29059,10 +29102,10 @@ packages:
   license_family: MIT
   size: 13310
   timestamp: 1771292312903
-- pypi: https://files.pythonhosted.org/packages/11/db/e7474719e90062df673057e865f94f67da2d0b4f671d8051020c74962c77/typeshed_client-2.8.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/86/50/42c0cadd4d62b0d98929db479346b7da6e4ab8346a4de39ed80176fb39b7/typeshed_client-2.9.0-py3-none-any.whl
   name: typeshed-client
-  version: 2.8.2
-  sha256: 4cf886d976c777689cd31889f13abf5bfb7797c82519b07e5969e541380c75ee
+  version: 2.9.0
+  sha256: 9383660241a4864fd4af971e533b735bd8c5b3d2f88f7ac279e41699ebe1369c
   requires_dist:
   - importlib-resources>=1.4.0
   - typing-extensions>=4.5.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,6 +28,7 @@ pytensor = ">=2.33.0"
 numpy = "*"
 sympy = "*"
 pydantic = "*"
+packaging = "*"
 hist = "*"
 
 # pytensor >=2.33 does not exist for win-64 for py310

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     'numpy',
     'sympy',
     'pydantic',
+    'packaging',
     'hist >= 2.7.0',
 ]
 

--- a/src/pyhs3/metadata.py
+++ b/src/pyhs3/metadata.py
@@ -7,6 +7,9 @@ package information, authorship, and publication details following the HS3 speci
 
 from __future__ import annotations
 
+from typing import ClassVar
+
+from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -44,6 +47,8 @@ class Metadata(BaseModel):
         description: Short description or abstract (optional)
     """
 
+    MIN_ROOT_VERSION: ClassVar[str] = "6.38"
+
     model_config = ConfigDict()
 
     hs3_version: str = Field(..., repr=False)
@@ -51,3 +56,27 @@ class Metadata(BaseModel):
     authors: list[str] | None = Field(default=None, repr=False)
     publications: list[str] | None = Field(default=None, repr=False)
     description: str | None = Field(default=None, repr=False)
+
+    def root_version_hint(self) -> str | None:
+        """
+        Check if ROOT version in metadata is older than minimum required.
+
+        Returns:
+            Hint string if ROOT version is older than MIN_ROOT_VERSION, None otherwise.
+        """
+        if self.packages is None:
+            return None
+
+        for pkg in self.packages:
+            if pkg.name == "ROOT":
+                try:
+                    if Version(pkg.version) < Version(self.MIN_ROOT_VERSION):
+                        return (
+                            f"This workspace was created with ROOT {pkg.version}, "
+                            f"but pyhs3 requires ROOT {self.MIN_ROOT_VERSION} or newer. "
+                            f"Please upgrade ROOT and regenerate the workspace."
+                        )
+                except InvalidVersion:
+                    return None
+
+        return None

--- a/src/pyhs3/metadata.py
+++ b/src/pyhs3/metadata.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class PackageInfo(BaseModel):
@@ -25,10 +25,29 @@ class PackageInfo(BaseModel):
         version: Version string of the package
     """
 
+    MIN_ROOT_VERSION: ClassVar[str] = "6.38"
+
     model_config = ConfigDict()
 
     name: str = Field(repr=True)
     version: str = Field(repr=False)
+
+    @model_validator(mode="after")
+    def validate_root_version(self) -> PackageInfo:
+        """Validate that ROOT version meets minimum requirement."""
+        if self.name != "ROOT":
+            return self
+        try:
+            if Version(self.version) < Version(self.MIN_ROOT_VERSION):
+                msg = (
+                    f"ROOT version {self.version} is older than the minimum"
+                    f" required version {self.MIN_ROOT_VERSION}."
+                    f" Please upgrade ROOT and regenerate the workspace."
+                )
+                raise ValueError(msg)
+        except InvalidVersion:
+            pass
+        return self
 
 
 class Metadata(BaseModel):
@@ -47,8 +66,6 @@ class Metadata(BaseModel):
         description: Short description or abstract (optional)
     """
 
-    MIN_ROOT_VERSION: ClassVar[str] = "6.38"
-
     model_config = ConfigDict()
 
     hs3_version: str = Field(..., repr=False)
@@ -56,27 +73,3 @@ class Metadata(BaseModel):
     authors: list[str] | None = Field(default=None, repr=False)
     publications: list[str] | None = Field(default=None, repr=False)
     description: str | None = Field(default=None, repr=False)
-
-    def root_version_hint(self) -> str | None:
-        """
-        Check if ROOT version in metadata is older than minimum required.
-
-        Returns:
-            Hint string if ROOT version is older than MIN_ROOT_VERSION, None otherwise.
-        """
-        if self.packages is None:
-            return None
-
-        for pkg in self.packages:
-            if pkg.name == "ROOT":
-                try:
-                    if Version(pkg.version) < Version(self.MIN_ROOT_VERSION):
-                        return (
-                            f"This workspace was created with ROOT {pkg.version}, "
-                            f"but pyhs3 requires ROOT {self.MIN_ROOT_VERSION} or newer. "
-                            f"Please upgrade ROOT and regenerate the workspace."
-                        )
-                except InvalidVersion:
-                    return None
-
-        return None

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -182,6 +182,23 @@ class Workspace(BaseModel):
         else:
             errors.append(f"Analysis '{analysis.name}' references unknown domains")
 
+    @staticmethod
+    def _get_root_version_hint(spec_dict: dict[str, Any]) -> str | None:
+        """
+        Extract ROOT version hint from workspace spec_dict metadata.
+
+        Args:
+            spec_dict: The workspace specification dictionary
+
+        Returns:
+            Hint string if ROOT version is older than required, None otherwise
+        """
+        try:
+            metadata = Metadata.model_validate(spec_dict.get("metadata", {}))
+            return metadata.root_version_hint()
+        except ValidationError:
+            return None
+
     @classmethod
     def load(
         cls,
@@ -209,10 +226,19 @@ class Workspace(BaseModel):
             return cls(**spec_dict)
         except ValidationError as e:
             error_summary = cls._format_validation_error(e, path, verbose)
+            hint = cls._get_root_version_hint(spec_dict)
+            if hint:
+                error_summary += f"\n\n{hint}"
 
             if suppress_traceback:
                 sys.tracebacklimit = 0
             raise WorkspaceValidationError(error_summary) from None
+        except WorkspaceValidationError as e:
+            hint = cls._get_root_version_hint(spec_dict)
+            if hint:
+                error_with_hint = f"{e}\n\n{hint}"
+                raise WorkspaceValidationError(error_with_hint) from e
+            raise
 
     @classmethod
     def _format_validation_error(

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -182,23 +182,6 @@ class Workspace(BaseModel):
         else:
             errors.append(f"Analysis '{analysis.name}' references unknown domains")
 
-    @staticmethod
-    def _get_root_version_hint(spec_dict: dict[str, Any]) -> str | None:
-        """
-        Extract ROOT version hint from workspace spec_dict metadata.
-
-        Args:
-            spec_dict: The workspace specification dictionary
-
-        Returns:
-            Hint string if ROOT version is older than required, None otherwise
-        """
-        try:
-            metadata = Metadata.model_validate(spec_dict.get("metadata", {}))
-            return metadata.root_version_hint()
-        except ValidationError:
-            return None
-
     @classmethod
     def load(
         cls,
@@ -226,19 +209,9 @@ class Workspace(BaseModel):
             return cls(**spec_dict)
         except ValidationError as e:
             error_summary = cls._format_validation_error(e, path, verbose)
-            hint = cls._get_root_version_hint(spec_dict)
-            if hint:
-                error_summary += f"\n\n{hint}"
-
             if suppress_traceback:
                 sys.tracebacklimit = 0
             raise WorkspaceValidationError(error_summary) from None
-        except WorkspaceValidationError as e:
-            hint = cls._get_root_version_hint(spec_dict)
-            if hint:
-                error_with_hint = f"{e}\n\n{hint}"
-                raise WorkspaceValidationError(error_with_hint) from e
-            raise
 
     @classmethod
     def _format_validation_error(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from pyhs3 import Workspace
 from pyhs3.analyses import Analyses, Analysis
@@ -169,105 +170,54 @@ class TestWorkspaceRepr:
 
 
 class TestRootVersionHint:
-    """Tests for ROOT version hint functionality."""
+    """Tests for ROOT version validation functionality."""
 
-    def test_metadata_root_version_hint_old_version(self):
-        """Test that old ROOT version (6.34.04) returns hint."""
-        metadata = Metadata(
-            hs3_version="1.0.0",
-            packages=[PackageInfo(name="ROOT", version="6.34.04")],
-        )
-        hint = metadata.root_version_hint()
-        assert hint is not None
-        assert "6.34.04" in hint
-        assert "6.38" in hint
+    def test_packageinfo_validator_old_version(self):
+        """Test that old ROOT version (6.34.04) raises ValidationError."""
+        with pytest.raises(ValidationError, match=r"ROOT version 6.34.04 is older"):
+            PackageInfo(name="ROOT", version="6.34.04")
 
-    def test_metadata_root_version_hint_new_version(self):
-        """Test that new ROOT version (6.38.0) returns None."""
-        metadata = Metadata(
-            hs3_version="1.0.0",
-            packages=[PackageInfo(name="ROOT", version="6.38.0")],
-        )
-        hint = metadata.root_version_hint()
-        assert hint is None
+    def test_packageinfo_validator_new_version(self):
+        """Test that new ROOT version (6.38.0) succeeds."""
+        pkg = PackageInfo(name="ROOT", version="6.38.0")
+        assert pkg.name == "ROOT"
+        assert pkg.version == "6.38.0"
 
-    def test_metadata_root_version_hint_exactly_min_version(self):
-        """Test that exactly version 6.38 returns None."""
-        metadata = Metadata(
-            hs3_version="1.0.0",
-            packages=[PackageInfo(name="ROOT", version="6.38")],
-        )
-        hint = metadata.root_version_hint()
-        assert hint is None
+    def test_packageinfo_validator_exactly_min_version(self):
+        """Test that exactly version 6.38 succeeds."""
+        pkg = PackageInfo(name="ROOT", version="6.38")
+        assert pkg.name == "ROOT"
+        assert pkg.version == "6.38"
 
-    def test_metadata_root_version_hint_no_packages(self):
-        """Test that missing packages field returns None."""
-        metadata = Metadata(hs3_version="1.0.0")
-        hint = metadata.root_version_hint()
-        assert hint is None
+    def test_packageinfo_validator_non_root_package(self):
+        """Test that non-ROOT packages succeed regardless of version."""
+        pkg = PackageInfo(name="pyhf", version="0.7.6")
+        assert pkg.name == "pyhf"
+        # Even old version strings pass for non-ROOT packages
+        pkg2 = PackageInfo(name="pyhf", version="0.1.0")
+        assert pkg2.version == "0.1.0"
 
-    def test_metadata_root_version_hint_empty_packages(self):
-        """Test that empty packages list returns None."""
-        metadata = Metadata(hs3_version="1.0.0", packages=[])
-        hint = metadata.root_version_hint()
-        assert hint is None
+    def test_packageinfo_validator_invalid_version(self):
+        """Test that invalid version string succeeds (can't compare)."""
+        # Invalid versions can't be compared, so they pass
+        pkg = PackageInfo(name="ROOT", version="invalid.version")
+        assert pkg.version == "invalid.version"
 
-    def test_metadata_root_version_hint_no_root_package(self):
-        """Test that packages without ROOT returns None."""
-        metadata = Metadata(
-            hs3_version="1.0.0",
-            packages=[PackageInfo(name="pyhf", version="0.7.6")],
-        )
-        hint = metadata.root_version_hint()
-        assert hint is None
-
-    def test_metadata_root_version_hint_invalid_version(self):
-        """Test that invalid version string returns None."""
-        metadata = Metadata(
-            hs3_version="1.0.0",
-            packages=[PackageInfo(name="ROOT", version="invalid.version")],
-        )
-        hint = metadata.root_version_hint()
-        assert hint is None
-
-    def test_workspace_get_root_version_hint_valid_old_root(self):
-        """Test _get_root_version_hint with valid spec_dict containing old ROOT."""
-        spec_dict = {
-            "metadata": {
-                "hs3_version": "1.0.0",
-                "packages": [{"name": "ROOT", "version": "6.34.04"}],
-            }
-        }
-        hint = Workspace._get_root_version_hint(spec_dict)
-        assert hint is not None
-        assert "6.34.04" in hint
-
-    def test_workspace_get_root_version_hint_missing_metadata(self):
-        """Test _get_root_version_hint with missing metadata key returns None."""
-        spec_dict = {"analyses": []}
-        hint = Workspace._get_root_version_hint(spec_dict)
-        assert hint is None
-
-    def test_workspace_get_root_version_hint_malformed_metadata(self):
-        """Test _get_root_version_hint with malformed metadata returns None."""
-        spec_dict = {"metadata": "bad"}
-        hint = Workspace._get_root_version_hint(spec_dict)
-        assert hint is None
-
-    def test_workspace_get_root_version_hint_metadata_missing_required(self):
-        """Test _get_root_version_hint with metadata missing required field returns None."""
-        spec_dict = {"metadata": {"packages": []}}
-        hint = Workspace._get_root_version_hint(spec_dict)
-        assert hint is None
+    def test_metadata_propagates_root_validation_error(self):
+        """Test that Metadata with old ROOT in packages raises ValidationError."""
+        with pytest.raises(ValidationError, match=r"ROOT version 6.34.04 is older"):
+            Metadata(
+                hs3_version="1.0.0",
+                packages=[PackageInfo(name="ROOT", version="6.34.04")],
+            )
 
     def test_workspace_load_validation_error_with_old_root(self, tmp_path):
-        """Test Workspace.load() with ValidationError appends hint for old ROOT."""
+        """Test Workspace.load() with old ROOT shows ROOT version in error."""
         invalid_workspace = {
             "metadata": {
                 "hs3_version": "1.0.0",
                 "packages": [{"name": "ROOT", "version": "6.34.04"}],
             },
-            "analyses": [{"invalid": "field"}],  # Invalid analysis
         }
         workspace_path = tmp_path / "workspace.json"
         workspace_path.write_text(json.dumps(invalid_workspace))
@@ -276,11 +226,11 @@ class TestRootVersionHint:
             Workspace.load(workspace_path)
 
         error_msg = str(exc_info.value)
-        assert "6.34.04" in error_msg
+        assert "ROOT version 6.34.04 is older" in error_msg
         assert "6.38" in error_msg
 
     def test_workspace_load_validation_error_with_new_root(self, tmp_path):
-        """Test Workspace.load() with ValidationError does not append hint for new ROOT."""
+        """Test Workspace.load() with new ROOT and other errors doesn't mention ROOT."""
         invalid_workspace = {
             "metadata": {
                 "hs3_version": "1.0.0",
@@ -295,31 +245,5 @@ class TestRootVersionHint:
             Workspace.load(workspace_path)
 
         error_msg = str(exc_info.value)
-        assert "6.38" not in error_msg or "6.38.0" in error_msg  # Should not have hint
-
-    def test_workspace_load_fk_error_with_old_root(self, tmp_path):
-        """Test Workspace.load() with FK resolution error appends hint for old ROOT."""
-        # Valid Pydantic structure but invalid FK reference
-        workspace_with_fk_error = {
-            "metadata": {
-                "hs3_version": "1.0.0",
-                "packages": [{"name": "ROOT", "version": "6.34.04"}],
-            },
-            "analyses": [
-                {
-                    "name": "test_analysis",
-                    "domains": ["nonexistent_domain"],  # FK error
-                    "likelihood": "test_likelihood",
-                }
-            ],
-            "likelihoods": [{"name": "test_likelihood", "distribution": "test_dist"}],
-        }
-        workspace_path = tmp_path / "workspace_fk.json"
-        workspace_path.write_text(json.dumps(workspace_with_fk_error))
-
-        with pytest.raises(WorkspaceValidationError) as exc_info:
-            Workspace.load(workspace_path)
-
-        error_msg = str(exc_info.value)
-        assert "6.34.04" in error_msg
-        assert "6.38" in error_msg
+        # Error should be about the invalid analysis, not ROOT version
+        assert "ROOT version" not in error_msg or "6.38.0" in error_msg

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -7,13 +7,15 @@ covering branches in core.py model_post_init.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from pyhs3 import Workspace
 from pyhs3.analyses import Analyses, Analysis
 from pyhs3.exceptions import WorkspaceValidationError
 from pyhs3.likelihoods import Likelihood, Likelihoods
-from pyhs3.metadata import Metadata
+from pyhs3.metadata import Metadata, PackageInfo
 
 
 class TestWorkspaceNoneCollections:
@@ -164,3 +166,160 @@ class TestWorkspaceRepr:
         # The repr should be a useful string representation
         assert isinstance(repr_str, str)
         assert len(repr_str) > 0
+
+
+class TestRootVersionHint:
+    """Tests for ROOT version hint functionality."""
+
+    def test_metadata_root_version_hint_old_version(self):
+        """Test that old ROOT version (6.34.04) returns hint."""
+        metadata = Metadata(
+            hs3_version="1.0.0",
+            packages=[PackageInfo(name="ROOT", version="6.34.04")],
+        )
+        hint = metadata.root_version_hint()
+        assert hint is not None
+        assert "6.34.04" in hint
+        assert "6.38" in hint
+
+    def test_metadata_root_version_hint_new_version(self):
+        """Test that new ROOT version (6.38.0) returns None."""
+        metadata = Metadata(
+            hs3_version="1.0.0",
+            packages=[PackageInfo(name="ROOT", version="6.38.0")],
+        )
+        hint = metadata.root_version_hint()
+        assert hint is None
+
+    def test_metadata_root_version_hint_exactly_min_version(self):
+        """Test that exactly version 6.38 returns None."""
+        metadata = Metadata(
+            hs3_version="1.0.0",
+            packages=[PackageInfo(name="ROOT", version="6.38")],
+        )
+        hint = metadata.root_version_hint()
+        assert hint is None
+
+    def test_metadata_root_version_hint_no_packages(self):
+        """Test that missing packages field returns None."""
+        metadata = Metadata(hs3_version="1.0.0")
+        hint = metadata.root_version_hint()
+        assert hint is None
+
+    def test_metadata_root_version_hint_empty_packages(self):
+        """Test that empty packages list returns None."""
+        metadata = Metadata(hs3_version="1.0.0", packages=[])
+        hint = metadata.root_version_hint()
+        assert hint is None
+
+    def test_metadata_root_version_hint_no_root_package(self):
+        """Test that packages without ROOT returns None."""
+        metadata = Metadata(
+            hs3_version="1.0.0",
+            packages=[PackageInfo(name="pyhf", version="0.7.6")],
+        )
+        hint = metadata.root_version_hint()
+        assert hint is None
+
+    def test_metadata_root_version_hint_invalid_version(self):
+        """Test that invalid version string returns None."""
+        metadata = Metadata(
+            hs3_version="1.0.0",
+            packages=[PackageInfo(name="ROOT", version="invalid.version")],
+        )
+        hint = metadata.root_version_hint()
+        assert hint is None
+
+    def test_workspace_get_root_version_hint_valid_old_root(self):
+        """Test _get_root_version_hint with valid spec_dict containing old ROOT."""
+        spec_dict = {
+            "metadata": {
+                "hs3_version": "1.0.0",
+                "packages": [{"name": "ROOT", "version": "6.34.04"}],
+            }
+        }
+        hint = Workspace._get_root_version_hint(spec_dict)
+        assert hint is not None
+        assert "6.34.04" in hint
+
+    def test_workspace_get_root_version_hint_missing_metadata(self):
+        """Test _get_root_version_hint with missing metadata key returns None."""
+        spec_dict = {"analyses": []}
+        hint = Workspace._get_root_version_hint(spec_dict)
+        assert hint is None
+
+    def test_workspace_get_root_version_hint_malformed_metadata(self):
+        """Test _get_root_version_hint with malformed metadata returns None."""
+        spec_dict = {"metadata": "bad"}
+        hint = Workspace._get_root_version_hint(spec_dict)
+        assert hint is None
+
+    def test_workspace_get_root_version_hint_metadata_missing_required(self):
+        """Test _get_root_version_hint with metadata missing required field returns None."""
+        spec_dict = {"metadata": {"packages": []}}
+        hint = Workspace._get_root_version_hint(spec_dict)
+        assert hint is None
+
+    def test_workspace_load_validation_error_with_old_root(self, tmp_path):
+        """Test Workspace.load() with ValidationError appends hint for old ROOT."""
+        invalid_workspace = {
+            "metadata": {
+                "hs3_version": "1.0.0",
+                "packages": [{"name": "ROOT", "version": "6.34.04"}],
+            },
+            "analyses": [{"invalid": "field"}],  # Invalid analysis
+        }
+        workspace_path = tmp_path / "workspace.json"
+        workspace_path.write_text(json.dumps(invalid_workspace))
+
+        with pytest.raises(WorkspaceValidationError) as exc_info:
+            Workspace.load(workspace_path)
+
+        error_msg = str(exc_info.value)
+        assert "6.34.04" in error_msg
+        assert "6.38" in error_msg
+
+    def test_workspace_load_validation_error_with_new_root(self, tmp_path):
+        """Test Workspace.load() with ValidationError does not append hint for new ROOT."""
+        invalid_workspace = {
+            "metadata": {
+                "hs3_version": "1.0.0",
+                "packages": [{"name": "ROOT", "version": "6.38.0"}],
+            },
+            "analyses": [{"invalid": "field"}],  # Invalid analysis
+        }
+        workspace_path = tmp_path / "workspace.json"
+        workspace_path.write_text(json.dumps(invalid_workspace))
+
+        with pytest.raises(WorkspaceValidationError) as exc_info:
+            Workspace.load(workspace_path)
+
+        error_msg = str(exc_info.value)
+        assert "6.38" not in error_msg or "6.38.0" in error_msg  # Should not have hint
+
+    def test_workspace_load_fk_error_with_old_root(self, tmp_path):
+        """Test Workspace.load() with FK resolution error appends hint for old ROOT."""
+        # Valid Pydantic structure but invalid FK reference
+        workspace_with_fk_error = {
+            "metadata": {
+                "hs3_version": "1.0.0",
+                "packages": [{"name": "ROOT", "version": "6.34.04"}],
+            },
+            "analyses": [
+                {
+                    "name": "test_analysis",
+                    "domains": ["nonexistent_domain"],  # FK error
+                    "likelihood": "test_likelihood",
+                }
+            ],
+            "likelihoods": [{"name": "test_likelihood", "distribution": "test_dist"}],
+        }
+        workspace_path = tmp_path / "workspace_fk.json"
+        workspace_path.write_text(json.dumps(workspace_with_fk_error))
+
+        with pytest.raises(WorkspaceValidationError) as exc_info:
+            Workspace.load(workspace_path)
+
+        error_msg = str(exc_info.value)
+        assert "6.34.04" in error_msg
+        assert "6.38" in error_msg


### PR DESCRIPTION
This will add a hint to the `pyhs3.Workspace.load` that suggests re-exporting the ROOT workspace if it is able to determine that the ROOT version is older, as a quick fix for some common validation errors that occur due to using a buggier ROOT export from older versions.

/cc @Phmonski