### PR TITLE
fix: HistFactory sample errors

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,6 +92,36 @@ Distributions
    QQZZBackgroundDist
    FastVerticalInterpHistPdf2D2Dist
 
+HistFactory
+-----------
+
+.. currentmodule:: pyhs3.distributions.histfactory
+
+.. autosummary::
+   :toctree: _generated/
+   :nosignatures:
+
+   samples.Sample
+   samples.Samples
+   data.SampleData
+   modifiers.Modifier
+   modifiers.ModifierData
+   modifiers.HasConstraint
+   modifiers.ParameterModifier
+   modifiers.ParametersModifier
+   modifiers.NormFactorModifier
+   modifiers.NormSysModifier
+   modifiers.HistoSysModifier
+   modifiers.ShapeFactorModifier
+   modifiers.ShapeSysModifier
+   modifiers.StatErrorModifier
+   modifiers.NormSysData
+   modifiers.HistoSysData
+   modifiers.HistoSysDataContents
+   modifiers.ShapeSysData
+   modifiers.StatErrorData
+   modifiers.Modifiers
+
 Axes
 ----
 

--- a/src/pyhs3/distributions/histfactory/data.py
+++ b/src/pyhs3/distributions/histfactory/data.py
@@ -11,7 +11,33 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 
 class SampleData(BaseModel):
-    """Sample data containing bin contents and errors."""
+    """Sample data containing bin contents and optional per-bin uncertainties.
+
+    This class represents the binned values for a single sample in a HistFactory-
+    style model, along with optional statistical uncertainties ("errors") per bin.
+
+    .. note::
+
+        - The ``errors`` field is optional in serialized form. If omitted, it is
+          interpreted as an array of zeros with the same length as ``contents``.
+          This follows the convention used in ROOT HistFactory/HS3 workflows,
+          where some samples may not carry explicit bin-by-bin uncertainties
+          (e.g. when BBlight is not applied).
+        - Internally, errors are always materialized and accessible via the
+          ``errors`` property.
+        - If provided, ``errors`` must have the same length as ``contents``.
+
+    Parameters:
+        contents : list[float]
+            The bin contents (yields) for the sample.
+        errors : list[float] | None
+            Optional serialized representation of per-bin uncertainties. This is
+            aliased to ``"errors"`` when exporting. If ``None``, errors are implicitly
+            treated as zeros and omitted from serialization.
+
+    Raises:
+        ValueError: If ``contents`` and ``errors`` are both provided and have different lengths.
+    """
 
     model_config = ConfigDict(serialize_by_alias=True)
 
@@ -36,6 +62,18 @@ class SampleData(BaseModel):
 
     @property
     def errors(self) -> list[float]:
+        """Return the per-bin uncertainties for the sample.
+
+        This property always returns a list of the same length as ``contents``.
+
+        - If uncertainties were explicitly provided, they are returned as-is.
+        - If the ``errors`` field was omitted during initialization (e.g. in HS3
+          JSON where missing errors imply zeros), this returns a zero-filled
+          list.
+
+        Returns:
+            list[float]: The per-bin uncertainties corresponding to ``contents``.
+        """
         return self._errors
 
 

--- a/src/pyhs3/distributions/histfactory/data.py
+++ b/src/pyhs3/distributions/histfactory/data.py
@@ -7,22 +7,36 @@ with bin contents and errors.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 
 class SampleData(BaseModel):
     """Sample data containing bin contents and errors."""
 
+    model_config = ConfigDict(serialize_by_alias=True)
+
     contents: list[float]
-    errors: list[float]
+    v_errors: list[float] | None = Field(
+        default=None, alias="errors", repr=False, exclude_if=lambda v: v is None
+    )
+    _errors: list[float] = PrivateAttr()
 
     @model_validator(mode="after")
-    def validate_lengths(self) -> SampleData:
+    def set_default_and_validate(self) -> SampleData:
         """Ensure contents and errors have same length."""
-        if len(self.contents) != len(self.errors):
-            msg = f"Sample data contents ({len(self.contents)}) and errors ({len(self.errors)}) must have same length"
-            raise ValueError(msg)
+        if self.v_errors is None:
+            self._errors = [0.0] * len(self.contents)
+        else:
+            self._errors = self.v_errors
+
+            if len(self.contents) != len(self.v_errors):
+                msg = f"Sample data contents ({len(self.contents)}) and errors ({len(self.v_errors)}) must have same length"
+                raise ValueError(msg)
         return self
+
+    @property
+    def errors(self) -> list[float]:
+        return self._errors
 
 
 __all__ = ["SampleData"]

--- a/tests/test_histfactory_samples.py
+++ b/tests/test_histfactory_samples.py
@@ -18,16 +18,17 @@ hist = pytest.importorskip("hist", reason="hist not installed")
 class TestSampleData:
     """Test SampleData validation and functionality."""
 
+    def test_valid_sampledata_without_errors(self):
+        """Test valid SampleData with contents and errors of same length all zeros."""
+        data = SampleData(contents=[1.0, 2.0, 3.0])
+        assert data.contents == [1.0, 2.0, 3.0]
+        assert data.errors == [0.0, 0.0, 0.0]
+
     def test_valid_sampledata_with_errors(self):
         """Test valid SampleData with matching contents and errors."""
         data = SampleData(contents=[1.0, 2.0, 3.0], errors=[0.1, 0.2, 0.3])
         assert data.contents == [1.0, 2.0, 3.0]
         assert data.errors == [0.1, 0.2, 0.3]
-
-    def test_sampledata_requires_errors(self):
-        """Test that SampleData requires errors field."""
-        with pytest.raises(ValueError, match="Field required"):
-            SampleData(contents=[1.0, 2.0, 3.0])  # Missing errors field
 
     def test_sampledata_mismatched_lengths_raises_error(self):
         """Test that SampleData raises error when contents and errors have different lengths."""
@@ -50,6 +51,18 @@ class TestSampleData:
             match="Sample data contents \\(0\\) and errors \\(1\\) must have same length",
         ):
             SampleData(contents=[], errors=[0.1])
+
+    def test_sampledata_roundtrip(self):
+        """Test SampleData roundtrips properly"""
+        assert SampleData(contents=[1.0], errors=[0.1]).model_dump() == {
+            "contents": [1.0],
+            "errors": [0.1],
+        }
+        assert SampleData(contents=[], errors=[]).model_dump() == {
+            "contents": [],
+            "errors": [],
+        }
+        assert SampleData(contents=[1.0]).model_dump() == {"contents": [1.0]}
 
 
 class TestSample:


### PR DESCRIPTION
Allow HistFactory SampleData with optional errors (default to an array of zeros).

Implements part of #187. Progress as part of https://github.com/scipp-atlas/pyhs3/issues/109#issuecomment-3451954639 .
