### PR TITLE
feat(model): bake const=True parameters as pt.constant at build time

### DIFF
--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -331,7 +331,7 @@ class Model:
                         # Bake as a compile-time constant so it is invisible to
                         # explicit_graph_inputs and JAX transpilation.
                         self.parameters[node_name] = pt.constant(
-                            np.float64(param_point.value)
+                            np.float64(param_point.value), name=node_name
                         )
                     else:
                         # Create a symbolic free variable with domain bounds.

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -304,37 +304,45 @@ class Model:
                 )
 
                 if node_type == "parameter":
-                    # Create parameter tensor with domain bounds applied
-                    domain_bounds = (
-                        self.domain.get(node_name, (None, None))
-                        if self.domain
-                        else (None, None)
-                    )
                     param_point = (
                         self.parameterset.get(node_name) if self.parameterset else None
                     )
-                    # Determine default kind: vector for observables, scalar otherwise
-                    default_kind: Callable[..., TensorVar]
-                    if "_observed" in node_name or node_name in context.observables:
-                        default_kind = pt.vector
-                    else:
-                        default_kind = pt.scalar
 
-                    # Allow explicit override from ParameterPoint.kind
-                    if param_point and param_point.kind is not None:
-                        param_kind = param_point.kind
-                        if param_kind is not default_kind:
-                            warnings.warn(
-                                f"Parameter '{node_name}' has kind override"
-                                f" {param_kind.__name__} (default would be"
-                                f" {default_kind.__name__})",
-                                stacklevel=2,
-                            )
+                    if param_point and param_point.const:
+                        # Bake as a compile-time constant so it is invisible to
+                        # explicit_graph_inputs and JAX transpilation.
+                        self.parameters[node_name] = pt.constant(
+                            np.float64(param_point.value)
+                        )
                     else:
-                        param_kind = default_kind
-                    self.parameters[node_name] = create_bounded_tensor(
-                        node_name, domain_bounds, param_kind
-                    )
+                        # Create a symbolic free variable with domain bounds.
+                        domain_bounds = (
+                            self.domain.get(node_name, (None, None))
+                            if self.domain
+                            else (None, None)
+                        )
+                        # Determine default kind: vector for observables, scalar otherwise
+                        default_kind: Callable[..., TensorVar]
+                        if "_observed" in node_name or node_name in context.observables:
+                            default_kind = pt.vector
+                        else:
+                            default_kind = pt.scalar
+
+                        # Allow explicit override from ParameterPoint.kind
+                        if param_point and param_point.kind is not None:
+                            param_kind = param_point.kind
+                            if param_kind is not default_kind:
+                                warnings.warn(
+                                    f"Parameter '{node_name}' has kind override"
+                                    f" {param_kind.__name__} (default would be"
+                                    f" {default_kind.__name__})",
+                                    stacklevel=2,
+                                )
+                        else:
+                            param_kind = default_kind
+                        self.parameters[node_name] = create_bounded_tensor(
+                            node_name, domain_bounds, param_kind
+                        )
 
                 elif node_type == "constant":
                     # Constants are pre-created by distributions - add to parameters

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -169,9 +169,11 @@ class Model:
         """Symbolic joint log-probability expression for the full likelihood.
 
         Returned as a PyTensor ``TensorVar`` scalar.  Observable data and
-        physics parameters are **all symbolic free inputs** — the expression
-        is suitable for JAX transpilation, gradient computation, or direct
-        PyTensor compilation.
+        parameters listed in :attr:`free_params` are symbolic free inputs;
+        parameters with ``const=True`` are baked as compile-time constants
+        and do not appear as free inputs.  The expression is suitable for
+        JAX transpilation, gradient computation, or direct PyTensor
+        compilation.
 
         Normalization denominators are fixed constants (axis bounds baked at
         ``Model`` construction time).  For unweighted data, the same compiled/JAX

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -330,9 +330,23 @@ class Model:
                     if param_point and param_point.const:
                         # Bake as a compile-time constant so it is invisible to
                         # explicit_graph_inputs and JAX transpilation.
-                        self.parameters[node_name] = pt.constant(
-                            np.float64(param_point.value), name=node_name
+                        val = np.float64(param_point.value)
+                        domain_bounds = (
+                            self.domain.get(node_name, (None, None))
+                            if self.domain
+                            else (None, None)
                         )
+                        lower, upper = domain_bounds
+                        if (lower is not None and val < lower) or (
+                            upper is not None and val > upper
+                        ):
+                            warnings.warn(
+                                f"Parameter '{node_name}' has const=True with value"
+                                f" {val} outside domain [{lower}, {upper}];"
+                                f" using the specified value as-is.",
+                                stacklevel=2,
+                            )
+                        self.parameters[node_name] = pt.constant(val, name=node_name)
                     else:
                         # Create a symbolic free variable with domain bounds.
                         domain_bounds = (

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -120,10 +120,10 @@ class Model:
         ``ws.model(likelihood)``.  Raises ``RuntimeError`` otherwise.
 
         Returns a dict suitable for passing directly to a compiled or JAX
-        function alongside :attr:`nominal_params`::
+        function alongside :attr:`free_params`::
 
             jg = pyhs3.jaxify(model.log_prob)
-            jg(**model.data, **model.nominal_params)
+            jg(**model.data, **model.free_params)
         """
         if self._likelihood is None:
             msg = "data requires a likelihood context; build via ws.model(analysis)"
@@ -134,15 +134,34 @@ class Model:
     def nominal_params(self) -> dict[str, float]:
         """Default parameter values from the workspace parameter set.
 
-        Returns a dict suitable for passing to a compiled or JAX function
-        alongside :attr:`data`::
+        Returns all parameters, including those marked ``const=True`` (which
+        are baked as :func:`pytensor.tensor.constant` in the symbolic graph
+        and are therefore not free inputs to a jaxified expression).
 
-            jg = pyhs3.jaxify(model.log_prob)
-            jg(**model.data, **model.nominal_params)
+        Use :attr:`free_params` when passing parameters to a jaxified callable
+        to avoid supplying spurious keyword arguments.
         """
         result: dict[str, float] = {}
         for pp in self.parameterset:
             result[pp.name] = float(pp.value)
+        return result
+
+    @property
+    def free_params(self) -> dict[str, float]:
+        """Non-constant parameter values from the workspace parameter set.
+
+        Like :attr:`nominal_params` but excludes parameters whose
+        ``ParameterPoint.const`` flag is ``True``.  These are the parameters
+        that remain as free symbolic inputs after model construction, making
+        this dict the correct one to pass to a jaxified callable::
+
+            jg = pyhs3.jaxify(model.log_prob)
+            jg(**model.data, **model.free_params)
+        """
+        result: dict[str, float] = {}
+        for pp in self.parameterset:
+            if not pp.const:
+                result[pp.name] = float(pp.value)
         return result
 
     @property
@@ -161,7 +180,7 @@ class Model:
         to use different weights, a new ``Model`` must be built.
 
         The workspace defaults for evaluation are available via :attr:`data`
-        and :attr:`nominal_params`.
+        and :attr:`free_params`.
 
         Only available when the model was built via ``ws.model(analysis)`` or
         ``ws.model(likelihood)``.  Raises ``RuntimeError`` otherwise.
@@ -171,7 +190,7 @@ class Model:
             model = ws.model(ws.analyses["CombinedPdf_combData"])
             nll = -2 * model.log_prob
             jg = pyhs3.jaxify(nll)
-            val = jg(**model.data, **model.nominal_params)
+            val = jg(**model.data, **model.free_params)
         """
         if self._likelihood is None:
             msg = "log_prob requires a likelihood context; build via ws.model(analysis)"

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -256,6 +256,73 @@ class Model:
         """
         return np.asarray(value, dtype=np.float64)
 
+    def _build_parameter_node(self, node_name: str, context: Context) -> TensorVar:
+        """Build a parameter node: baked constant (const=True) or bounded free variable."""
+        param_point = self.parameterset.get(node_name) if self.parameterset else None
+        domain_bounds = (
+            self.domain.get(node_name, (None, None)) if self.domain else (None, None)
+        )
+        if param_point and param_point.const:
+            # Bake as a compile-time constant so it is invisible to
+            # explicit_graph_inputs and JAX transpilation.
+            val = np.float64(param_point.value)
+            lower, upper = domain_bounds
+            if (lower is not None and val < lower) or (
+                upper is not None and val > upper
+            ):
+                warnings.warn(
+                    f"Parameter '{node_name}' has const=True with value"
+                    f" {val} outside domain [{lower}, {upper}];"
+                    f" using the specified value as-is.",
+                    stacklevel=2,
+                )
+            return pt.constant(val, name=node_name)
+
+        # Free variable: determine default kind (vector for observables, scalar otherwise)
+        default_kind: Callable[..., TensorVar]
+        if "_observed" in node_name or node_name in context.observables:
+            default_kind = pt.vector
+        else:
+            default_kind = pt.scalar
+
+        # Allow explicit override from ParameterPoint.kind
+        if param_point and param_point.kind is not None:
+            param_kind = param_point.kind
+            if param_kind is not default_kind:
+                warnings.warn(
+                    f"Parameter '{node_name}' has kind override"
+                    f" {param_kind.__name__} (default would be"
+                    f" {default_kind.__name__})",
+                    stacklevel=2,
+                )
+        else:
+            param_kind = default_kind
+        return create_bounded_tensor(node_name, domain_bounds, param_kind)
+
+    def _build_constant_node(
+        self, node_name: str, constants_map: dict[str, TensorVar]
+    ) -> TensorVar:
+        """Build a constant node from the pre-computed constants map."""
+        return constants_map[node_name]
+
+    def _build_function_node(
+        self, node_name: str, functions: Functions, context: Context
+    ) -> TensorVar:
+        """Build a function node by evaluating its symbolic expression."""
+        return functions[node_name].expression(context)
+
+    def _build_modifier_node(
+        self, node_name: str, modifiers_map: dict[str, Any], context: Context
+    ) -> TensorVar:
+        """Build a modifier node by evaluating its symbolic expression."""
+        return cast(TensorVar, modifiers_map[node_name].expression(context))
+
+    def _build_distribution_node(
+        self, node_name: str, distributions: Distributions, context: Context
+    ) -> TensorVar:
+        """Build a distribution node by evaluating its symbolic expression."""
+        return distributions[node_name].expression(context)
+
     def _build_dependency_graph(
         self,
         functions: Functions,
@@ -269,15 +336,12 @@ class Model:
         and parameters by building a complete dependency graph first, then evaluating
         in topological order.
         """
-        # Build dependency graph using the networks module
         graph, constants_map, modifiers_map = build_dependency_graph(
             self.parameterset, functions, distributions
         )
 
-        # Get topological order (handles cycle detection internally)
         sorted_nodes = graph.topological_sort()
 
-        # Evaluate nodes in topological order with optional progress bar
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}", style="cyan"),
@@ -286,8 +350,8 @@ class Model:
             TimeElapsedColumn(),
             TimeRemainingColumn(),
             expand=True,
-            transient=True,  # Progress bar disappears when finished
-            disable=not progress,  # Disable progress bar if progress=False
+            transient=True,
+            disable=not progress,
         ) as progress_bar:
             task = progress_bar.add_task(
                 "Building expressions...", total=len(sorted_nodes)
@@ -300,107 +364,48 @@ class Model:
                 ] = node_data["type"]
                 node_name = node_data["name"]
 
-                # Truncate long names to prevent jumpiness
                 max_name_length = 60
-                display_name = node_name
-                if len(node_name) > max_name_length:
-                    display_name = node_name[: max_name_length - 3] + "..."
-
-                # Update progress description with current entity (fixed width)
+                display_name = (
+                    node_name[: max_name_length - 3] + "..."
+                    if len(node_name) > max_name_length
+                    else node_name
+                )
                 progress_bar.update(
                     task,
                     description=f"Building {node_type:<12}: {display_name:<{max_name_length}}",
                 )
 
-                # Build context with all currently available entities
-                context_data = {
-                    **self.parameters,
-                    **self.functions,
-                    **self.distributions,
-                    **self.modifiers,
-                }
                 context = Context(
-                    parameters=context_data,
+                    parameters={
+                        **self.parameters,
+                        **self.functions,
+                        **self.distributions,
+                        **self.modifiers,
+                    },
                     observables=self._observables,
                 )
 
                 if node_type == "parameter":
-                    param_point = (
-                        self.parameterset.get(node_name) if self.parameterset else None
+                    self.parameters[node_name] = self._build_parameter_node(
+                        node_name, context
                     )
-
-                    if param_point and param_point.const:
-                        # Bake as a compile-time constant so it is invisible to
-                        # explicit_graph_inputs and JAX transpilation.
-                        val = np.float64(param_point.value)
-                        domain_bounds = (
-                            self.domain.get(node_name, (None, None))
-                            if self.domain
-                            else (None, None)
-                        )
-                        lower, upper = domain_bounds
-                        if (lower is not None and val < lower) or (
-                            upper is not None and val > upper
-                        ):
-                            warnings.warn(
-                                f"Parameter '{node_name}' has const=True with value"
-                                f" {val} outside domain [{lower}, {upper}];"
-                                f" using the specified value as-is.",
-                                stacklevel=2,
-                            )
-                        self.parameters[node_name] = pt.constant(val, name=node_name)
-                    else:
-                        # Create a symbolic free variable with domain bounds.
-                        domain_bounds = (
-                            self.domain.get(node_name, (None, None))
-                            if self.domain
-                            else (None, None)
-                        )
-                        # Determine default kind: vector for observables, scalar otherwise
-                        default_kind: Callable[..., TensorVar]
-                        if "_observed" in node_name or node_name in context.observables:
-                            default_kind = pt.vector
-                        else:
-                            default_kind = pt.scalar
-
-                        # Allow explicit override from ParameterPoint.kind
-                        if param_point and param_point.kind is not None:
-                            param_kind = param_point.kind
-                            if param_kind is not default_kind:
-                                warnings.warn(
-                                    f"Parameter '{node_name}' has kind override"
-                                    f" {param_kind.__name__} (default would be"
-                                    f" {default_kind.__name__})",
-                                    stacklevel=2,
-                                )
-                        else:
-                            param_kind = default_kind
-                        self.parameters[node_name] = create_bounded_tensor(
-                            node_name, domain_bounds, param_kind
-                        )
-
                 elif node_type == "constant":
-                    # Constants are pre-created by distributions - add to parameters
-                    self.parameters[node_name] = constants_map[node_name]
-
+                    self.parameters[node_name] = self._build_constant_node(
+                        node_name, constants_map
+                    )
                 elif node_type == "function":
-                    # Functions are evaluated by design
-                    self.functions[node_name] = functions[node_name].expression(context)
-
+                    self.functions[node_name] = self._build_function_node(
+                        node_name, functions, context
+                    )
                 elif node_type == "modifier":
-                    # Modifiers are evaluated and stored for later use by distributions
-                    # Use pre-built modifiers map for efficient O(1) lookup
-                    self.modifiers[node_name] = modifiers_map[node_name].expression(
-                        context
+                    self.modifiers[node_name] = self._build_modifier_node(
+                        node_name, modifiers_map, context
                     )
-
                 else:  # node_type == "distribution"
-                    # Distributions are evaluated by design
-                    self.distributions[node_name] = distributions[node_name].expression(
-                        context
+                    self.distributions[node_name] = self._build_distribution_node(
+                        node_name, distributions, context
                     )
 
-                # Advance progress
                 progress_bar.advance(task)
 
     def _get_compiled_function(

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -374,7 +374,7 @@ class Workspace(BaseModel):
         - :class:`~pyhs3.analyses.Analysis` — all context (domain, parameter
           set, observables) is derived from the analysis; gains access to
           :attr:`~pyhs3.model.Model.log_prob`, :attr:`~pyhs3.model.Model.data`,
-          and :attr:`~pyhs3.model.Model.nominal_params`.
+          and :attr:`~pyhs3.model.Model.free_params`.
         - :class:`~pyhs3.likelihoods.Likelihood` — observable bounds are derived
           from the likelihood's data; ``domain`` and ``parameter_set`` fall back
           to workspace defaults (index 0) unless overridden.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1124,3 +1125,50 @@ class TestConstParameters:
         result_free = model_free.pdf("gauss", x=x_val, mu=mu_val, sigma=np.array(1.0))
 
         npt.assert_allclose(result_const, result_free)
+
+    def test_const_outside_domain_warns(self):
+        """const value outside domain emits a warning; the stored value is unchanged."""
+        ws = hs3.Workspace(
+            metadata={"hs3_version": "0.2"},
+            distributions=[
+                {
+                    "name": "gauss",
+                    "type": "gaussian_dist",
+                    "x": "x",
+                    "mean": "mu",
+                    "sigma": "sigma",
+                }
+            ],
+            parameter_points=[
+                {
+                    "name": "defaults",
+                    "parameters": [
+                        {"name": "mu", "value": 0.0},
+                        # sigma=5.0 but domain cap is 2.0
+                        {"name": "sigma", "value": 5.0, "const": True},
+                    ],
+                }
+            ],
+            domains=[
+                {
+                    "name": "d",
+                    "type": "product_domain",
+                    "axes": [
+                        {"name": "x", "min": -5.0, "max": 5.0},
+                        {"name": "sigma", "min": 0.1, "max": 2.0},
+                    ],
+                }
+            ],
+        )
+        with pytest.warns(UserWarning, match="outside domain"):
+            model = ws.model(0)
+
+        # Value must NOT be clipped — use exactly what const said.
+        npt.assert_allclose(model.parameters["sigma"].data, 5.0)
+
+    def test_const_inside_domain_no_warning(self, workspace_with_const):
+        """const value inside domain must not produce any warning."""
+        # workspace_with_const has sigma=1.0, domain x in [-5, 5] (sigma unconstrained)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            workspace_with_const.model(0)  # must not raise

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1166,9 +1166,9 @@ class TestConstParameters:
         # Value must NOT be clipped — use exactly what const said.
         npt.assert_allclose(model.parameters["sigma"].data, 5.0)
 
-    def test_const_inside_domain_no_warning(self, workspace_with_const):
-        """const value inside domain must not produce any warning."""
-        # workspace_with_const has sigma=1.0, domain x in [-5, 5] (sigma unconstrained)
+    def test_const_no_declared_domain_no_warning(self, workspace_with_const):
+        """const value with no declared domain must not produce any warning."""
+        # workspace_with_const has sigma=1.0; the domain only declares x, not sigma
         with warnings.catch_warnings():
             warnings.simplefilter("error", UserWarning)
             workspace_with_const.model(0)  # must not raise

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,8 +5,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import numpy.testing as npt
 import pytensor.tensor as pt
 import pytest
+from pytensor.graph.traversal import explicit_graph_inputs
+from pytensor.tensor.basic import TensorConstant
 
 import pyhs3 as hs3
 
@@ -1018,3 +1021,65 @@ class TestModelParameterOrdering:
         # Should raise an error when distribution doesn't exist
         with pytest.raises(KeyError):
             model.parsort("nonexistent_dist", ["x", "mu"])
+
+
+class TestConstParameters:
+    """Test that parameters with const=True are baked as pt.constant in the model."""
+
+    @pytest.fixture
+    def workspace_with_const(self):
+        return hs3.Workspace(
+            metadata={"hs3_version": "0.2"},
+            distributions=[
+                {
+                    "name": "gauss",
+                    "type": "gaussian_dist",
+                    "x": "x",
+                    "mean": "mu",
+                    "sigma": "sigma",
+                }
+            ],
+            parameter_points=[
+                {
+                    "name": "defaults",
+                    "parameters": [
+                        {"name": "mu", "value": 0.0},
+                        {"name": "sigma", "value": 1.0, "const": True},
+                    ],
+                }
+            ],
+            domains=[
+                {
+                    "name": "d",
+                    "type": "product_domain",
+                    "axes": [{"name": "x", "min": -5.0, "max": 5.0}],
+                }
+            ],
+        )
+
+    def test_const_parameter_is_tensor_constant(self, workspace_with_const):
+        """const=True parameters must be baked as TensorConstant."""
+        model = workspace_with_const.model(0)
+        assert isinstance(model.parameters["sigma"], TensorConstant), (
+            "sigma has const=True but was not baked as a TensorConstant"
+        )
+
+    def test_const_parameter_value_matches(self, workspace_with_const):
+        """TensorConstant value must match the ParameterPoint value."""
+        model = workspace_with_const.model(0)
+        npt.assert_allclose(model.parameters["sigma"].data, 1.0)
+
+    def test_free_parameter_is_not_constant(self, workspace_with_const):
+        """mu has const=False (default) and must remain a free symbolic variable."""
+        model = workspace_with_const.model(0)
+        assert not isinstance(model.parameters["mu"], TensorConstant)
+
+    def test_const_parameter_absent_from_graph_inputs(self, workspace_with_const):
+        """explicit_graph_inputs must not include const parameters."""
+        model = workspace_with_const.model(0)
+        dist_expr = model.distributions["gauss"]
+        free_names = {v.name for v in explicit_graph_inputs([dist_expr])}
+        assert "sigma" not in free_names, (
+            "sigma (const=True) must not appear as a free graph input"
+        )
+        assert "mu" in free_names

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1083,3 +1083,44 @@ class TestConstParameters:
             "sigma (const=True) must not appear as a free graph input"
         )
         assert "mu" in free_names
+
+    def test_pdf_with_const_sigma_matches_explicit_sigma(self, workspace_with_const):
+        """Forward-pass result must match whether sigma is baked or passed explicitly."""
+        model_const = workspace_with_const.model(0)
+
+        workspace_free = hs3.Workspace(
+            metadata={"hs3_version": "0.2"},
+            distributions=[
+                {
+                    "name": "gauss",
+                    "type": "gaussian_dist",
+                    "x": "x",
+                    "mean": "mu",
+                    "sigma": "sigma",
+                }
+            ],
+            parameter_points=[
+                {
+                    "name": "defaults",
+                    "parameters": [
+                        {"name": "mu", "value": 0.0},
+                        {"name": "sigma", "value": 1.0},  # free, not const
+                    ],
+                }
+            ],
+            domains=[
+                {
+                    "name": "d",
+                    "type": "product_domain",
+                    "axes": [{"name": "x", "min": -5.0, "max": 5.0}],
+                }
+            ],
+        )
+        model_free = workspace_free.model(0)
+
+        x_val, mu_val = np.array(1.5), np.array(0.5)
+
+        result_const = model_const.pdf("gauss", x=x_val, mu=mu_val)
+        result_free = model_free.pdf("gauss", x=x_val, mu=mu_val, sigma=np.array(1.0))
+
+        npt.assert_allclose(result_const, result_free)

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -289,6 +289,34 @@ def test_model_nominal_params_from_analysis():
     assert p["mean"] == pytest.approx(2.0)
 
 
+def test_model_free_params_excludes_const():
+    """free_params must omit const=True parameters; nominal_params must keep them."""
+    ws = Workspace(
+        **{
+            **_WS_DICT,
+            "parameter_points": [
+                {
+                    "name": "params",
+                    "parameters": [
+                        {"name": "mean", "value": 2.0},
+                        {"name": "fixed_scale", "value": 3.0, "const": True},
+                    ],
+                }
+            ],
+        }
+    )
+    model = ws.model(ws.analyses["A"])
+
+    # nominal_params includes const parameters
+    assert "mean" in model.nominal_params
+    assert "fixed_scale" in model.nominal_params
+
+    # free_params excludes const parameters
+    assert "mean" in model.free_params
+    assert "fixed_scale" not in model.free_params
+    assert model.free_params["mean"] == pytest.approx(2.0)
+
+
 def test_model_data_raises_without_likelihood():
     ws = _ws()
     model = ws.model(0)  # legacy, no likelihood


### PR DESCRIPTION
## Summary

- Parameters with `const=True` in their `ParameterPoint` specification are now stored as `TensorConstant` instead of free symbolic `TensorVariable` nodes in `Model._build_dependency_graph`.
- `explicit_graph_inputs` skips `TensorConstant` nodes by design, so these parameters are automatically invisible to `jaxify()` without any manual post-processing by the caller.
- Observables are unaffected: they either have no `const` field (default `False`) or have `const=False`.

## Motivation

The diHiggs bbyy validation workspace has 28 719 parameters in `default_values`, of which 28 536 have `const=True`. Previously every consumer of `model.log_prob` that wanted to call `jaxify()` had to manually iterate all symbolic inputs, classify them, and call `clone_replace` to bake the fixed ones. With this change, `model.log_prob` already has the right number of free inputs (≈170 for that workspace) without any extra bookkeeping.

## Test plan

- [ ] `TestConstParameters::test_const_parameter_is_tensor_constant` — `const=True` param stored as `TensorConstant`
- [ ] `TestConstParameters::test_const_parameter_value_matches` — value matches `ParameterPoint.value`
- [ ] `TestConstParameters::test_free_parameter_is_not_constant` — `const=False` param remains a free variable
- [ ] `TestConstParameters::test_const_parameter_absent_from_graph_inputs` — `explicit_graph_inputs` does not return the constant
- [ ] Full suite (`884 passed`) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Model.free_params to expose only non-constant parameters; constant parameters are now baked into compiled models and removed from runtime inputs.
* **Documentation**
  * Docstrings and examples updated to recommend using free_params for jaxified/compiled callables.
* **Tests**
  * New tests validate constant-parameter baking, correct inclusion/exclusion between nominal and free parameter sets, and warn when a baked constant lies outside its declared domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->