### PR TITLE
fix: log_prob, no temp sum

### DIFF
--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -234,8 +234,18 @@ class Model:
                     stacklevel=2,
                 )
                 # (N,) → (N, 1) so it broadcasts correctly against (N, M) log_pdf
-                weights_t = pt.constant(np.asarray(weights, dtype=np.float64))[:, None]
-                terms.append(pt.sum(weights_t * log_pdf, axis=0) / pt.sum(weights_t))  # type: ignore[no-untyped-call]
+                weights_arr = np.asarray(weights, dtype=np.float64)
+                total_weight = float(np.sum(weights_arr))
+                if not np.isfinite(total_weight) or np.isclose(total_weight, 0.0):
+                    msg = (
+                        f"'{datum.name}' has invalid total weight ({total_weight}); "
+                        "sum of weights must be finite and non-zero."
+                    )
+                    raise ValueError(msg)
+                weights_t = pt.constant(weights_arr)[:, None]
+                terms.append(
+                    pt.sum(weights_t * log_pdf, axis=0) / np.float64(total_weight)  # type: ignore[no-untyped-call]
+                )
             else:
                 terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
 

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -204,9 +204,11 @@ class Model:
             msg = "log_prob requires a likelihood context; build via ws.model(analysis)"
             raise RuntimeError(msg)
 
-        # Accumulate with + so shapes broadcast correctly across the parameter axis.
-        # Summing over axis 0 (events) yields shape (M,) — the parameter batch size.
-        lp: TensorVar = pt.constant(np.float64(0.0))
+        # Collect per-channel and aux terms into a flat list, then combine with a
+        # single n-ary pt.add so that PyTensor sees one Elemwise{add} node rather
+        # than a left-deep chain of binary Adds.  Summing over axis 0 (events)
+        # yields shape (M,) per term — the parameter batch size.
+        terms: list[TensorVar] = []
 
         for dist_obj, datum in zip(
             self._likelihood.distributions, self._likelihood.data, strict=True
@@ -233,18 +235,22 @@ class Model:
                 )
                 # (N,) → (N, 1) so it broadcasts correctly against (N, M) log_pdf
                 weights_t = pt.constant(np.asarray(weights, dtype=np.float64))[:, None]
-                lp = lp + pt.sum(weights_t * log_pdf, axis=0)  # type: ignore[no-untyped-call]
+                terms.append(pt.sum(weights_t * log_pdf, axis=0) / pt.sum(weights_t))  # type: ignore[no-untyped-call]
             else:
-                lp = lp + pt.sum(log_pdf, axis=0)  # type: ignore[no-untyped-call]
+                terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
 
         # Auxiliary distributions (constraint terms) are scalars; they broadcast
         # onto the parameter-scan axis when non-scalar params are present.
         if self._likelihood.aux_distributions:
             for aux_name in self._likelihood.aux_distributions:
                 if aux_name in self.distributions:
-                    lp = lp + pt.log(self.distributions[aux_name])
+                    terms.append(pt.log(self.distributions[aux_name]))
 
-        return lp
+        if not terms:
+            return pt.constant(np.float64(0.0))
+        if len(terms) == 1:
+            return terms[0]
+        return cast(TensorVar, pt.add(*terms))
 
     @staticmethod
     def _ensure_array(

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -260,7 +260,7 @@ class Model:
             return pt.constant(np.float64(0.0))
         if len(terms) == 1:
             return terms[0]
-        return cast(TensorVar, pt.add(*terms))
+        return cast(TensorVar, pt.add(*terms))  # pylint: disable=no-value-for-parameter
 
     @staticmethod
     def _ensure_array(

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -271,6 +271,70 @@ def test_log_prob_warns_for_weighted_data():
         _ = model.log_prob
 
 
+@pytest.mark.parametrize(
+    "weights",
+    [
+        [0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, -1.0, 0.0, 0.0, 0.0],
+    ],
+    ids=["all-zero", "net-zero"],
+)
+def test_log_prob_raises_for_zero_total_weight(weights):
+    ws_w = Workspace(
+        **{
+            **_WS_DICT,
+            "data": [
+                {
+                    "name": "data1",
+                    "type": "unbinned",
+                    "axes": [{"name": "x_obs", "min": -10.0, "max": 10.0}],
+                    "entries": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+                    "weights": weights,
+                },
+                _WS_DICT["data"][1],
+            ],
+        }
+    )
+    model = ws_w.model(ws_w.analyses["A"], progress=False)
+    with (
+        pytest.warns(UserWarning, match="weights"),
+        pytest.raises(ValueError, match="invalid total weight"),
+    ):
+        _ = model.log_prob
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [
+        [1.0, float("inf"), 1.0, 1.0, 1.0],
+        [1.0, float("nan"), 1.0, 1.0, 1.0],
+    ],
+    ids=["inf", "nan"],
+)
+def test_log_prob_raises_for_nonfinite_weight(weights):
+    ws_w = Workspace(
+        **{
+            **_WS_DICT,
+            "data": [
+                {
+                    "name": "data1",
+                    "type": "unbinned",
+                    "axes": [{"name": "x_obs", "min": -10.0, "max": 10.0}],
+                    "entries": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+                    "weights": weights,
+                },
+                _WS_DICT["data"][1],
+            ],
+        }
+    )
+    model = ws_w.model(ws_w.analyses["A"], progress=False)
+    with (
+        pytest.warns(UserWarning, match="weights"),
+        pytest.raises(ValueError, match="invalid total weight"),
+    ):
+        _ = model.log_prob
+
+
 def test_model_data_from_analysis():
     ws = _ws()
     model = ws.model(ws.analyses["A"])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal assembly of log-probability terms for clearer, more robust combination of contributions.

* **Bug Fixes**
  * Weighted-event likelihoods are now normalized by total weight and will raise an error for non-finite or zero total weights.
  * Returns a consistent zero-valued result when no contributing terms exist.

* **Tests**
  * Added validation tests for zero and non-finite weights, asserting the expected warning and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->