### PR TITLE
fix: histosys variations computed against sample nominal (#219)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ module = [
   "sympy.*",  # https://github.com/sympy/sympy/pull/26158
   "jax.*",
   "pytensor.link.jax.*",
+  "pytensor.compile.function",  # removed in pytensor >= 3; replaced by pytensor.compile.maker
 ]
 ignore_missing_imports = true
 

--- a/src/pyhs3/compile.py
+++ b/src/pyhs3/compile.py
@@ -13,7 +13,7 @@ try:
     from pytensor.compile.maker import function
 except ImportError:
     # pytensor 2
-    from pytensor.compile.function import (  # type: ignore[import-not-found, no-redef]
+    from pytensor.compile.function import (  # type: ignore[no-redef]
         function,
     )
 

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -219,8 +219,15 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
     def _process_sample(
         self, context: Context, sample: Sample, total_bins: int
     ) -> TensorVar:
-        """Process a single sample with its modifiers."""
-        # Get nominal bin contents
+        """Process a single sample with its modifiers.
+
+        The HistFactory formula is lambda = (N + sum(delta_histosys(N))) * prod(kappa_multiplicative).
+        Additive variations (histosys) must each be computed against the sample
+        nominal N, then summed; multiplicative modifiers apply to the combined
+        result. Applying modifiers sequentially against accumulating rates would
+        cause histosys to compute its variation against already-scaled rates,
+        violating the formula when a multiplicative modifier precedes it.
+        """
         contents = sample.data.contents
         if len(contents) != total_bins:
             msg = (
@@ -230,13 +237,25 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
 
         nominal_rates = pt.as_tensor_variable(contents)
 
-        # Apply modifiers using pre-computed results where possible
-        modified_rates = nominal_rates
-
+        # Pass 1: accumulate additive variations against the nominal.
+        # modifier.apply(ctx, nominal) returns nominal + variation; subtract to
+        # isolate the variation so multiple histosys modifiers each reference
+        # the same nominal rather than each other's output.
+        additive_sum = pt.zeros(total_bins)
         for modifier in sample.modifiers:
-            modified_rates = modifier.apply(context, modified_rates)
+            if modifier.is_additive:
+                additive_sum = additive_sum + (
+                    modifier.apply(context, nominal_rates) - nominal_rates
+                )
 
-        return cast(TensorVar, modified_rates)
+        rates = nominal_rates + additive_sum
+
+        # Pass 2: apply multiplicative modifiers to (nominal + Σ additive).
+        for modifier in sample.modifiers:
+            if modifier.is_multiplicative:
+                rates = modifier.apply(context, rates)
+
+        return cast(TensorVar, rates)
 
     def _build_main_model(
         self, context: Context, expected_rates: TensorVar

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -1569,6 +1569,7 @@ class TestHistoSysNominalRates:
 
         normfactor * (N + histosys_variation) must equal (N + histosys_variation) * normfactor.
         The current sequential approach makes order matter, which is wrong.
+        Also verifies the same invariance holds for normsys (also multiplicative).
         """
         histosys_spec = {
             "name": "alpha",
@@ -1581,6 +1582,13 @@ class TestHistoSysNominalRates:
             },
         }
         normfactor_spec = {"name": "mu", "type": "normfactor", "parameter": "mu"}
+        normsys_spec = {
+            "name": "mu",
+            "type": "normsys",
+            "parameter": "mu",
+            "constraint": "Gauss",
+            "data": {"hi": 1.2, "lo": 0.8},
+        }
 
         dist_hf_first = self._make_channel([histosys_spec, normfactor_spec])
         dist_nf_first = self._make_channel([normfactor_spec, histosys_spec])
@@ -1599,3 +1607,19 @@ class TestHistoSysNominalRates:
         result_nf = f_nf(2.0, 0.5)
 
         np.testing.assert_allclose(result_hf, result_nf, rtol=1e-12)
+
+        # Same invariance for normsys (multiplicative, like normfactor, but with
+        # hi/lo interpolation rather than direct scaling).
+        dist_ns_first = self._make_channel([normsys_spec, histosys_spec])
+        dist_sn_first = self._make_channel([histosys_spec, normsys_spec])
+
+        expr_ns = dist_ns_first._compute_expected_rates(context, 2)
+        expr_sn = dist_sn_first._compute_expected_rates(context, 2)
+
+        f_ns = function([mu_var, alpha_var], expr_ns)
+        f_sn = function([mu_var, alpha_var], expr_sn)
+
+        result_ns = f_ns(0.5, 0.5)
+        result_sn = f_sn(0.5, 0.5)
+
+        np.testing.assert_allclose(result_ns, result_sn, rtol=1e-12)

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -1455,3 +1455,147 @@ class TestHistFactoryChannelHistConversion:
         # We should be able to recover the errors by taking sqrt of variances
         recovered_errors = np.sqrt(h["data", :].variances())
         assert np.allclose(recovered_errors, [10.0, 12.0, 11.0])
+
+
+class TestHistoSysNominalRates:
+    """Tests for issue #219: histosys variations must be computed against sample nominal.
+
+    The HistFactory formula is lambda = (N + sum(delta_histosys(N))) * prod(kappa_multiplicative).
+    Each histosys variation is relative to the sample nominal N, not to the
+    incrementally-modified rates. When a multiplicative modifier (normfactor,
+    normsys) runs before histosys in the modifier list, the buggy sequential
+    application computes δ against the already-scaled rates instead of N.
+    """
+
+    def _make_channel(self, modifiers: list[dict]) -> HistFactoryDistChannel:
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0, 20.0], "errors": [1.0, 1.0]},
+                "modifiers": modifiers,
+            }
+        ]
+        return HistFactoryDistChannel(name="ch", axes=axes, samples=samples)
+
+    def test_histosys_with_normfactor_uses_nominal(self):
+        """Histosys variation must be against nominal, not normfactor-scaled rates.
+
+        nominal=[10, 20], histosys hi=[15, 25] lo=[5, 15], normfactor mu=2, alpha=0.5.
+        Correct: (N + variation_against_N) * mu = [12.5, 22.5] * 2 = [25.0, 45.0].
+        Buggy (normfactor first): rates=[20, 40], variation computed against [20, 40].
+        """
+        # normfactor listed first — this is the ordering that exposes the bug
+        dist = self._make_channel(
+            [
+                {"name": "mu", "type": "normfactor", "parameter": "mu"},
+                {
+                    "name": "alpha",
+                    "type": "histosys",
+                    "parameter": "alpha",
+                    "constraint": "Gauss",
+                    "data": {
+                        "hi": {"contents": [15.0, 25.0]},
+                        "lo": {"contents": [5.0, 15.0]},
+                    },
+                },
+            ]
+        )
+
+        mu_var = pt.dscalar("mu")
+        alpha_var = pt.dscalar("alpha")
+        context = Context({"mu": mu_var, "alpha": alpha_var})
+
+        expr = dist._compute_expected_rates(context, 2)
+        f = function([mu_var, alpha_var], expr)
+        result = f(2.0, 0.5)
+
+        # hi/lo are symmetric around nominal ([15-10]==[10-5]==5), so at alpha=0.5
+        # the variation equals 0.5*(hi-N)=[2.5, 2.5] for all interpolation methods.
+        # Correct: (N + [2.5, 2.5]) * 2 = [12.5, 22.5] * 2 = [25, 45].
+        np.testing.assert_allclose(result, [25.0, 45.0], rtol=1e-12)
+
+    def test_two_histosys_variations_sum_against_nominal(self):
+        """Two histosys modifiers on the same sample must both compute against the nominal.
+
+        If variations chain against each other's output, the second modifier
+        uses a different 'nominal' than intended.
+        nominal=[10.0], histosys1 hi=[15] lo=[5], histosys2 hi=[12] lo=[8], code0, both alpha=0.5.
+        Correct: 10 + 0.5*(15-10) + 0.5*(12-10) = 10 + 2.5 + 1.0 = 13.5.
+        """
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [10.0], "errors": [1.0]},
+                "modifiers": [
+                    {
+                        "name": "alpha1",
+                        "type": "histosys",
+                        "parameter": "alpha1",
+                        "constraint": "Gauss",
+                        "data": {
+                            "hi": {"contents": [15.0]},
+                            "lo": {"contents": [5.0]},
+                        },
+                    },
+                    {
+                        "name": "alpha2",
+                        "type": "histosys",
+                        "parameter": "alpha2",
+                        "constraint": "Gauss",
+                        "data": {
+                            "hi": {"contents": [12.0]},
+                            "lo": {"contents": [8.0]},
+                        },
+                    },
+                ],
+            }
+        ]
+        dist = HistFactoryDistChannel(name="ch", axes=axes, samples=samples)
+
+        alpha1_var = pt.dscalar("alpha1")
+        alpha2_var = pt.dscalar("alpha2")
+        context = Context({"alpha1": alpha1_var, "alpha2": alpha2_var})
+
+        expr = dist._compute_expected_rates(context, 1)
+        f = function([alpha1_var, alpha2_var], expr)
+        result = f(0.5, 0.5)
+
+        np.testing.assert_allclose(result, [13.5], rtol=1e-12)
+
+    def test_modifier_order_invariant(self):
+        """Expected rates are the same regardless of histosys/normfactor ordering.
+
+        normfactor * (N + histosys_variation) must equal (N + histosys_variation) * normfactor.
+        The current sequential approach makes order matter, which is wrong.
+        """
+        histosys_spec = {
+            "name": "alpha",
+            "type": "histosys",
+            "parameter": "alpha",
+            "constraint": "Gauss",
+            "data": {
+                "hi": {"contents": [15.0, 25.0]},
+                "lo": {"contents": [5.0, 15.0]},
+            },
+        }
+        normfactor_spec = {"name": "mu", "type": "normfactor", "parameter": "mu"}
+
+        dist_hf_first = self._make_channel([histosys_spec, normfactor_spec])
+        dist_nf_first = self._make_channel([normfactor_spec, histosys_spec])
+
+        mu_var = pt.dscalar("mu")
+        alpha_var = pt.dscalar("alpha")
+        context = Context({"mu": mu_var, "alpha": alpha_var})
+
+        expr_hf = dist_hf_first._compute_expected_rates(context, 2)
+        expr_nf = dist_nf_first._compute_expected_rates(context, 2)
+
+        f_hf = function([mu_var, alpha_var], expr_hf)
+        f_nf = function([mu_var, alpha_var], expr_nf)
+
+        result_hf = f_hf(2.0, 0.5)
+        result_nf = f_nf(2.0, 0.5)
+
+        np.testing.assert_allclose(result_hf, result_nf, rtol=1e-12)

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -1520,7 +1520,7 @@ class TestHistoSysNominalRates:
 
         If variations chain against each other's output, the second modifier
         uses a different 'nominal' than intended.
-        nominal=[10.0], histosys1 hi=[15] lo=[5], histosys2 hi=[12] lo=[8], code0, both alpha=0.5.
+        nominal=[10.0], histosys1 hi=[15] lo=[5], histosys2 hi=[12] lo=[8], both alpha=0.5.
         Correct: 10 + 0.5*(15-10) + 0.5*(12-10) = 10 + 2.5 + 1.0 = 13.5.
         """
         axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}]


### PR DESCRIPTION
## Summary

Fixes #219. The `HistoSysModifier.apply` was computing variations against the accumulated (already-modified) rates rather than the sample's nominal rates, violating the HistFactory formula:

`lambda = (N + sum(delta_histosys(N))) * prod(kappa_multiplicative)`

When a multiplicative modifier (e.g. `normfactor`) appeared before `histosys` in `sample.modifiers`, the histosys variation was computed against `N * mu` instead of `N`. Similarly, multiple histosys modifiers would chain against each other's output rather than all reference the same nominal.

## Fix

Restructures `_process_sample` in `HistFactoryDistChannel` to use a two-pass approach:
- **Pass 1**: each additive modifier (histosys) is called with `nominal_rates`; we extract just the variation `modifier.apply(ctx, nominal) - nominal` and accumulate
- **Pass 2**: each multiplicative modifier (normfactor, normsys) is applied to `nominal + sum(variations)`

No changes to the `Modifier` ABC or individual modifier classes.

## Also includes

- Backward-compatible `pytensor.compile.maker`/`pytensor.compile.function` import (try pytensor >= 3 path first, fall back to pytensor < 3)
- Corresponding `mypy` override and pixi environment pinned to pytensor 2.x for now

## Test plan

- [x] `test_histosys_with_normfactor_uses_nominal` -- normfactor-first ordering, alpha=0.5, verifies correct formula
- [x] `test_two_histosys_variations_sum_against_nominal` -- two histosys on same sample both reference original nominal
- [x] `test_modifier_order_invariant` -- [histosys, normfactor] vs [normfactor, histosys] produce identical results
- [x] Full test suite: 914 passed, 3 skipped, 1 xfailed
- [x] Pre-commit (ruff, mypy, codespell, etc.) all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected histogram factory modifier calculation so additive variations are computed against each sample’s nominal bin values before multiplicative modifiers are applied, preventing chained-scaling errors.

* **Tests**
  * Added regression tests validating modifier interpolation behavior across multiple modifier combinations and ordering.

* **Chores**
  * Updated type-checking/mypy configuration for compatibility with the newer runtime library.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scipp-atlas/pyhs3/pull/220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->