### PR TITLE
feat(model): build HFDC constraints once per parameter at model level

### DIFF
--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -7,6 +7,7 @@ with samples and modifiers as defined in the HS3 specification.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any, Literal, cast
 
 import hist
@@ -174,61 +175,52 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         # Build main Poisson model for observed data
         return self._build_main_model(context, expected_rates)
 
-    def extended_likelihood(
-        self, context: Context, _data: TensorVar | None = None
-    ) -> TensorVar:
-        """
-        Build constraint model for nuisance parameters.
-
-        Args:
-            context: Mapping of parameter names to PyTensor variables
-            data: Not used for HistFactory constraints (observed data is in main model)
-
-        Returns:
-            PyTensor expression for the constraint likelihood terms
-        """
-        constraint_probs = []
-
-        # Collect all constraint terms from modifiers
-        for sample in self.samples:
-            for modifier in sample.modifiers:
-                if isinstance(modifier, HasConstraint):
-                    prob = modifier.make_constraint(context, sample.data)
-                    constraint_probs.append(prob)
-
-        if not constraint_probs:
-            return pt.constant(1.0)
-
-        # Multiply all constraint probabilities
-        return cast(TensorVar, pt.prod(pt.stack(constraint_probs)))  # type: ignore[no-untyped-call]
-
-    def constraint_modifiers(
+    def constraint_specs(
         self,
-    ) -> tuple[
-        dict[str, tuple[HasConstraint, SampleData]],
-        list[tuple[HasConstraint, SampleData]],
-    ]:
-        """Return constraint modifiers split for model-level deduplication.
+    ) -> Iterator[tuple[str | None, HasConstraint, SampleData]]:
+        """Yield ``(dedup_key, modifier, sample_data)`` for each constraint modifier.
 
-        The first element groups ``ParameterModifier`` constraints (normsys,
-        histosys) keyed by their single parameter so the model can dedup across
-        channels sharing a nuisance parameter — first-seen wins, validated for
-        consistency at workspace construction.
-
-        The second element lists ``ParametersModifier`` constraints (shapesys,
-        staterror) which are per-channel by validation and emitted as-is.
+        ``dedup_key`` is the modifier's parameter name for single-parameter
+        modifiers (``normsys``, ``histosys``); callers may use it to dedup
+        constraints when multiple modifier instances reference the same nuisance
+        parameter — within a channel or across channels in a joint fit.  For
+        multi-parameter modifiers (``shapesys``, ``staterror``) ``dedup_key``
+        is ``None`` — these constraints are channel-local by workspace validation
+        and are always emitted as-is.
         """
-        single: dict[str, tuple[HasConstraint, SampleData]] = {}
-        multi: list[tuple[HasConstraint, SampleData]] = []
         for sample in self.samples:
             for modifier in sample.modifiers:
                 if not isinstance(modifier, HasConstraint):
                     continue
                 if isinstance(modifier, ParameterModifier):
-                    single.setdefault(modifier.parameter, (modifier, sample.data))
+                    yield modifier.parameter, modifier, sample.data
                 elif isinstance(modifier, ParametersModifier):
-                    multi.append((modifier, sample.data))
-        return single, multi
+                    yield None, modifier, sample.data
+
+    def extended_likelihood(
+        self, context: Context, _data: TensorVar | None = None
+    ) -> TensorVar:
+        """Build constraint product for this channel.
+
+        Constraints are deduped by parameter — multiple ``ParameterModifier``
+        instances sharing one nuisance parameter (e.g., two ``normsys`` on
+        different samples both pointing at ``alpha_lumi``) emit a single
+        constraint factor, not one per modifier.  ``ParametersModifier``
+        constraints (``shapesys``, ``staterror``) carry per-bin nominal yields
+        and are always emitted per-modifier.
+        """
+        seen: set[str] = set()
+        constraint_probs: list[TensorVar] = []
+        for dedup_key, modifier, sample_data in self.constraint_specs():
+            if dedup_key is not None:
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+            constraint_probs.append(modifier.make_constraint(context, sample_data))
+
+        if not constraint_probs:
+            return pt.constant(1.0)
+        return cast(TensorVar, pt.prod(pt.stack(constraint_probs)))  # type: ignore[no-untyped-call]
 
     def _get_total_bins(self) -> int:
         """Calculate total number of bins across all axes."""

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -25,7 +25,6 @@ from pyhs3.distributions.histfactory.modifiers import (
     HasConstraint,
     Modifier,
     ParameterModifier,
-    ParametersModifier,
 )
 from pyhs3.distributions.histfactory.samples import Sample, Samples
 from pyhs3.networks import HasDependencies, HasInternalNodes
@@ -194,7 +193,7 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
                     continue
                 if isinstance(modifier, ParameterModifier):
                     yield modifier.parameter, modifier, sample.data
-                elif isinstance(modifier, ParametersModifier):
+                else:
                     yield None, modifier, sample.data
 
     def extended_likelihood(

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -19,7 +19,13 @@ from pyhs3.context import Context
 
 # Import existing distributions for constraint terms
 from pyhs3.distributions.core import Distribution
-from pyhs3.distributions.histfactory.modifiers import HasConstraint, Modifier
+from pyhs3.distributions.histfactory.data import SampleData
+from pyhs3.distributions.histfactory.modifiers import (
+    HasConstraint,
+    Modifier,
+    ParameterModifier,
+    ParametersModifier,
+)
 from pyhs3.distributions.histfactory.samples import Sample, Samples
 from pyhs3.networks import HasDependencies, HasInternalNodes
 from pyhs3.typing.aliases import TensorVar
@@ -195,6 +201,34 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
 
         # Multiply all constraint probabilities
         return cast(TensorVar, pt.prod(pt.stack(constraint_probs)))  # type: ignore[no-untyped-call]
+
+    def constraint_modifiers(
+        self,
+    ) -> tuple[
+        dict[str, tuple[HasConstraint, SampleData]],
+        list[tuple[HasConstraint, SampleData]],
+    ]:
+        """Return constraint modifiers split for model-level deduplication.
+
+        The first element groups ``ParameterModifier`` constraints (normsys,
+        histosys) keyed by their single parameter so the model can dedup across
+        channels sharing a nuisance parameter — first-seen wins, validated for
+        consistency at workspace construction.
+
+        The second element lists ``ParametersModifier`` constraints (shapesys,
+        staterror) which are per-channel by validation and emitted as-is.
+        """
+        single: dict[str, tuple[HasConstraint, SampleData]] = {}
+        multi: list[tuple[HasConstraint, SampleData]] = []
+        for sample in self.samples:
+            for modifier in sample.modifiers:
+                if not isinstance(modifier, HasConstraint):
+                    continue
+                if isinstance(modifier, ParameterModifier):
+                    single.setdefault(modifier.parameter, (modifier, sample.data))
+                elif isinstance(modifier, ParametersModifier):
+                    multi.append((modifier, sample.data))
+        return single, multi
 
     def _get_total_bins(self) -> int:
         """Calculate total number of bins across all axes."""

--- a/src/pyhs3/likelihoods.py
+++ b/src/pyhs3/likelihoods.py
@@ -56,7 +56,12 @@ class Likelihood(NamedModel):
         FKListSerializer,
         FKListSchema,
     ] = Field(..., repr=False)
-    aux_distributions: list[str] | None = Field(default=None, repr=False)
+    aux_distributions: Annotated[
+        list[str] | Distributions | None,
+        make_fk_list_validator(Distribution),
+        FKListSerializer,
+        FKListSchema,
+    ] = Field(default=None, repr=False)
 
     def validate_unique_axis_names(self, workspace: Workspace | None = None) -> None:
         """Raise ValueError if any observable axis name appears more than once.

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -443,17 +443,23 @@ class Model:
         self._hfdc_poisson[node_name] = dist.likelihood(context)
 
         # Collect constraint expressions, deduped across channels by parameter name.
+        # Only channels referenced by the active likelihood contribute constraints —
+        # all HFDC distributions are still evaluated so logpdf() works for any channel.
         # Single-parameter modifiers carry a dedup_key; multi-parameter modifiers
         # (shapesys/staterror) have dedup_key=None and are emitted per-channel because
         # the workspace validator forbids cross-channel sharing of those parameters.
-        for dedup_key, modifier, sample_data in dist.constraint_specs():
-            if dedup_key is not None:
-                if dedup_key in self._hfdc_constraint_params_seen:
-                    continue
-                self._hfdc_constraint_params_seen.add(dedup_key)
-            self._hfdc_constraints.append(
-                modifier.make_constraint(context, sample_data)
-            )
+        if self._likelihood is None or any(
+            (d if isinstance(d, str) else d.name) == node_name
+            for d in self._likelihood.distributions
+        ):
+            for dedup_key, modifier, sample_data in dist.constraint_specs():
+                if dedup_key is not None:
+                    if dedup_key in self._hfdc_constraint_params_seen:
+                        continue
+                    self._hfdc_constraint_params_seen.add(dedup_key)
+                self._hfdc_constraints.append(
+                    modifier.make_constraint(context, sample_data)
+                )
 
         return dist.expression(context)
 

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -49,6 +49,20 @@ class Model:
     and distributions, ensuring proper evaluation order through topological
     sorting of the computation graph.
 
+    **HFDC constraint storage.** For ``HistFactoryDistChannel`` distributions,
+    ``self.distributions[name]`` stores the full per-channel expression
+    (main Poisson x constraint product) so that ``logpdf(name, **params)``
+    matches pyhf/cabinetry semantics for callers asking about a single
+    channel's probability.  ``self._hfdc_poisson[name]`` stores only the
+    main Poisson term; ``log_prob`` uses it to assemble the joint NLL without
+    double-counting constraint factors when multiple channels share a nuisance
+    parameter.  Constraint expressions are appended to
+    ``self._hfdc_constraints`` exactly once per unique dedup key across all
+    channels: single-parameter modifiers (``normsys``, ``histosys``) are
+    deduped by parameter name using ``self._hfdc_constraint_params_seen``;
+    multi-parameter modifiers (``shapesys``, ``staterror``) are channel-local
+    by workspace validation and always emitted as-is.
+
     HS3 Reference:
         Models are computational representations of :hs3:label:`HS3 workspaces <hs3.file-format>`.
     """
@@ -413,19 +427,17 @@ class Model:
             return dist.expression(context)
 
         # Poisson-only term; the full expression is returned below for logpdf.
-        poisson = dist.likelihood(context)
-        self._hfdc_poisson[node_name] = poisson
+        self._hfdc_poisson[node_name] = dist.likelihood(context)
 
-        # Collect constraint expressions, deduped across channels by parameter.
-        single, multi = dist.constraint_modifiers()
-        for param, (modifier, sample_data) in single.items():
-            if param not in self._hfdc_constraint_params_seen:
-                self._hfdc_constraint_params_seen.add(param)
-                self._hfdc_constraints.append(
-                    modifier.make_constraint(context, sample_data)
-                )
-        for modifier, sample_data in multi:
-            # Per-channel (shapesys/staterror) — validator forbids cross-channel sharing.
+        # Collect constraint expressions, deduped across channels by parameter name.
+        # Single-parameter modifiers carry a dedup_key; multi-parameter modifiers
+        # (shapesys/staterror) have dedup_key=None and are emitted per-channel because
+        # the workspace validator forbids cross-channel sharing of those parameters.
+        for dedup_key, modifier, sample_data in dist.constraint_specs():
+            if dedup_key is not None:
+                if dedup_key in self._hfdc_constraint_params_seen:
+                    continue
+                self._hfdc_constraint_params_seen.add(dedup_key)
             self._hfdc_constraints.append(
                 modifier.make_constraint(context, sample_data)
             )

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -283,14 +283,20 @@ class Model:
         # Auxiliary distributions (constraint terms) are scalars; they broadcast
         # onto the parameter-scan axis when non-scalar params are present.
         if self._likelihood.aux_distributions:
-            for aux_name in self._likelihood.aux_distributions:
-                if aux_name in self.distributions:
-                    terms.append(pt.log(self.distributions[aux_name]))
+            terms.extend(
+                pt.log(
+                    self.distributions[
+                        aux_name if isinstance(aux_name, str) else aux_name.name
+                    ]
+                )
+                for aux_name in self._likelihood.aux_distributions
+            )
 
         # HFDC constraint terms: collected once per unique nuisance parameter
         # across all channels during graph construction.
-        for constraint_expr in self._hfdc_constraints:
-            terms.append(pt.log(constraint_expr))
+        terms.extend(
+            pt.log(constraint_expr) for constraint_expr in self._hfdc_constraints
+        )
 
         if not terms:
             return pt.constant(np.float64(0.0))

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -322,26 +322,33 @@ class Model:
         """
         return np.asarray(value, dtype=np.float64)
 
+    def _try_bake_hfdc_observed(self, node_name: str) -> TensorVar | None:
+        """Return a baked constant for an HFDC ``{name}_observed`` parameter, or None.
+
+        When a likelihood pairs an HFDC distribution with a BinnedData object,
+        the observed bin counts are baked in as compile-time constants so that
+        they are invisible to ``explicit_graph_inputs`` and JAX transpilation.
+        """
+        if self._likelihood is None or not node_name.endswith("_observed"):
+            return None
+        dist_name = node_name[: -len("_observed")]
+        for dist_obj, datum in zip(
+            self._likelihood.distributions, self._likelihood.data, strict=True
+        ):
+            if isinstance(datum, str) or not isinstance(datum, BinnedData):
+                continue
+            actual_dist_name = dist_obj if isinstance(dist_obj, str) else dist_obj.name
+            if actual_dist_name == dist_name:
+                return pt.constant(
+                    np.asarray(datum.contents, dtype=np.float64), name=node_name
+                )
+        return None
+
     def _build_parameter_node(self, node_name: str, context: Context) -> TensorVar:
         """Build a parameter node: baked constant (const=True) or bounded free variable."""
-        # Bake HFDC observed data as a 1-D constant when the model was built with a
-        # likelihood that pairs this channel's BinnedData with an HFDC distribution.
-        # This keeps the observed counts out of the free-input set so that
-        # explicit_graph_inputs and JAX transpilation only see the nuisance parameters.
-        if self._likelihood is not None and node_name.endswith("_observed"):
-            dist_name = node_name[: -len("_observed")]
-            for dist_obj, datum in zip(
-                self._likelihood.distributions, self._likelihood.data, strict=True
-            ):
-                if isinstance(datum, str) or not isinstance(datum, BinnedData):
-                    continue
-                actual_dist_name = (
-                    dist_obj if isinstance(dist_obj, str) else dist_obj.name
-                )
-                if actual_dist_name == dist_name:
-                    return pt.constant(
-                        np.asarray(datum.contents, dtype=np.float64), name=node_name
-                    )
+        baked = self._try_bake_hfdc_observed(node_name)
+        if baked is not None:
+            return baked
 
         param_point = self.parameterset.get(node_name) if self.parameterset else None
         domain_bounds = (

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -22,7 +22,8 @@ from rich.progress import (
 
 from pyhs3.compile import function
 from pyhs3.context import Context
-from pyhs3.distributions import Distributions
+from pyhs3.data import BinnedData
+from pyhs3.distributions import Distributions, HistFactoryDistChannel
 from pyhs3.domains import Domain
 from pyhs3.functions import Functions
 from pyhs3.networks import build_dependency_graph
@@ -112,6 +113,16 @@ class Model:
         # leaf[None, :] for non-observable vector overrides.  Distributions see
         # these via Context; model.parameters[name] always holds the leaf.
         self._views: dict[str, TensorVar] = {}
+        # Pre-built HFDC constraint expressions, collected during graph construction.
+        # ParameterModifier constraints are deduped by parameter name across channels;
+        # ParametersModifier constraints (shapesys/staterror) are emitted per-channel.
+        self._hfdc_constraints: list[TensorVar] = []
+        self._hfdc_constraint_params_seen: set[str] = set()
+        # Poisson-only (no constraint product) expressions for HFDC channels.
+        # self.distributions[name] stores the full expression (Poisson x constraints)
+        # so that logpdf() continues to work; log_prob uses this dict to avoid
+        # double-counting constraint terms when multiple channels share a parameter.
+        self._hfdc_poisson: dict[str, TensorVar] = {}
 
         # Build dependency graph with proper entity identification
         self._build_dependency_graph(functions, distributions, progress)
@@ -216,10 +227,16 @@ class Model:
             if isinstance(datum, str):
                 continue
             entries = getattr(datum, "entries", None)
-            if entries is None:
-                continue
-
             dist_name = dist_obj if isinstance(dist_obj, str) else dist_obj.name
+
+            if entries is None:
+                # HFDC: log_prob uses the Poisson-only term here; deduplicated
+                # constraint terms are added after the loop.  Non-HFDC distributions
+                # paired with BinnedData (e.g. a Gaussian used as a template) are
+                # skipped because there is no sensible unbinned likelihood for them.
+                if dist_name in self._hfdc_poisson:
+                    terms.append(pt.log(self._hfdc_poisson[dist_name]))
+                continue
 
             # model.distributions[name] is the normalized PDF expression with
             # observables as symbolic pt.vector free inputs.
@@ -256,6 +273,11 @@ class Model:
                 if aux_name in self.distributions:
                     terms.append(pt.log(self.distributions[aux_name]))
 
+        # HFDC constraint terms: collected once per unique nuisance parameter
+        # across all channels during graph construction.
+        for constraint_expr in self._hfdc_constraints:
+            terms.append(pt.log(constraint_expr))
+
         if not terms:
             return pt.constant(np.float64(0.0))
         if len(terms) == 1:
@@ -282,6 +304,25 @@ class Model:
 
     def _build_parameter_node(self, node_name: str, context: Context) -> TensorVar:
         """Build a parameter node: baked constant (const=True) or bounded free variable."""
+        # Bake HFDC observed data as a 1-D constant when the model was built with a
+        # likelihood that pairs this channel's BinnedData with an HFDC distribution.
+        # This keeps the observed counts out of the free-input set so that
+        # explicit_graph_inputs and JAX transpilation only see the nuisance parameters.
+        if self._likelihood is not None and node_name.endswith("_observed"):
+            dist_name = node_name[: -len("_observed")]
+            for dist_obj, datum in zip(
+                self._likelihood.distributions, self._likelihood.data, strict=True
+            ):
+                if isinstance(datum, str) or not isinstance(datum, BinnedData):
+                    continue
+                actual_dist_name = (
+                    dist_obj if isinstance(dist_obj, str) else dist_obj.name
+                )
+                if actual_dist_name == dist_name:
+                    return pt.constant(
+                        np.asarray(datum.contents, dtype=np.float64), name=node_name
+                    )
+
         param_point = self.parameterset.get(node_name) if self.parameterset else None
         domain_bounds = (
             self.domain.get(node_name, (None, None)) if self.domain else (None, None)
@@ -357,8 +398,39 @@ class Model:
     def _build_distribution_node(
         self, node_name: str, distributions: Distributions, context: Context
     ) -> TensorVar:
-        """Build a distribution node by evaluating its symbolic expression."""
-        return distributions[node_name].expression(context)
+        """Build a distribution node by evaluating its symbolic expression.
+
+        For HistFactoryDistChannel the full expression (Poisson x constraints)
+        is returned and stored in ``self.distributions`` so that :meth:`logpdf`
+        continues to work as before.  In addition, the Poisson-only term is
+        stored in ``self._hfdc_poisson`` and the deduplicated constraint terms
+        are appended to ``self._hfdc_constraints`` so that :attr:`log_prob` can
+        combine them without double-counting when multiple channels share a
+        nuisance parameter.
+        """
+        dist = distributions[node_name]
+        if not isinstance(dist, HistFactoryDistChannel):
+            return dist.expression(context)
+
+        # Poisson-only term; the full expression is returned below for logpdf.
+        poisson = dist.likelihood(context)
+        self._hfdc_poisson[node_name] = poisson
+
+        # Collect constraint expressions, deduped across channels by parameter.
+        single, multi = dist.constraint_modifiers()
+        for param, (modifier, sample_data) in single.items():
+            if param not in self._hfdc_constraint_params_seen:
+                self._hfdc_constraint_params_seen.add(param)
+                self._hfdc_constraints.append(
+                    modifier.make_constraint(context, sample_data)
+                )
+        for modifier, sample_data in multi:
+            # Per-channel (shapesys/staterror) — validator forbids cross-channel sharing.
+            self._hfdc_constraints.append(
+                modifier.make_constraint(context, sample_data)
+            )
+
+        return dist.expression(context)
 
     def _build_dependency_graph(
         self,

--- a/src/pyhs3/typing/annotations.py
+++ b/src/pyhs3/typing/annotations.py
@@ -42,7 +42,7 @@ def _serialize_fk(v: Any) -> str | None:
 def _serialize_fk_list(v: Any) -> list[str]:
     """Serialize FK list to list of string names."""
     result: list[str] = []
-    for item in v:
+    for item in v or []:
         if isinstance(item, str):
             result.append(item)
         else:

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -227,6 +227,18 @@ class Workspace(BaseModel):
             likelihood.distributions = Distributions(
                 cast(list[DistributionType], resolved)
             )
+
+            if likelihood.aux_distributions is not None:
+                resolved_aux = self._resolve_fk_list(
+                    likelihood.aux_distributions,
+                    self.distributions,
+                    f"Likelihood '{likelihood.name}'",
+                    "aux_distribution",
+                    errors,
+                )
+                likelihood.aux_distributions = Distributions(
+                    cast(list[DistributionType], resolved_aux)
+                )
         else:
             errors.append(
                 f"Likelihood '{likelihood.name}' references unknown distributions"

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from pyhs3.analyses import Analyses, Analysis
 from pyhs3.data import Data, DataType
-from pyhs3.distributions import Distributions, DistributionType
+from pyhs3.distributions import Distributions, DistributionType, HistFactoryDistChannel
+from pyhs3.distributions.histfactory.modifiers import (
+    ParameterModifier,
+    ParametersModifier,
+)
 from pyhs3.domains import Domain, Domains, DomainType, ProductDomain
 from pyhs3.exceptions import WorkspaceValidationError
 from pyhs3.functions import Functions
@@ -93,6 +97,14 @@ class Workspace(BaseModel):
                 except ValueError as exc:
                     errors.append(str(exc))
 
+        # Validate HFDC constraint consistency across channels
+        if self.likelihoods is not None:
+            for likelihood in self.likelihoods:
+                try:
+                    self._validate_hfdc_constraints(likelihood)
+                except ValueError as exc:
+                    errors.append(str(exc))
+
         # Resolve Analysis fields
         if self.analyses is not None:
             for analysis in self.analyses:
@@ -126,6 +138,64 @@ class Workspace(BaseModel):
             else:
                 resolved.append(ref)
         return resolved
+
+    def _validate_hfdc_constraints(self, likelihood: Likelihood) -> None:
+        """Validate constraint consistency across HFDC channels in a likelihood.
+
+        Rules enforced:
+        - A nuisance parameter may not have conflicting constraint types (e.g.,
+          Gauss in one channel, LogNormal in another).
+        - shapesys parameters must not be shared across channels (per-channel by design).
+        - staterror parameters must not be shared across channels (same reason).
+
+        Called after FK resolution so likelihood.distributions contains objects.
+        """
+        # param -> (constraint_literal, "channel/sample/modifier" description)
+        param_constraint: dict[str, tuple[str, str]] = {}
+        shapesys_owners: dict[str, str] = {}
+        staterror_owners: dict[str, str] = {}
+
+        for dist_obj in likelihood.distributions:
+            if isinstance(dist_obj, str) or not isinstance(
+                dist_obj, HistFactoryDistChannel
+            ):
+                continue
+            for sample in dist_obj.samples:
+                for modifier in sample.modifiers:
+                    if (
+                        not hasattr(modifier, "constraint")
+                        or modifier.constraint is None
+                    ):
+                        continue
+                    where = f"{dist_obj.name}/{sample.name}/{modifier.name}"
+                    constraint = modifier.constraint
+                    if isinstance(modifier, ParameterModifier):
+                        param = modifier.parameter
+                        prev = param_constraint.get(param)
+                        if prev is not None and prev[0] != constraint:
+                            msg = (
+                                f"Parameter '{param}' has conflicting constraint types: "
+                                f"'{prev[1]}' declared '{prev[0]}', "
+                                f"'{where}' declares '{constraint}'"
+                            )
+                            raise ValueError(msg)
+                        param_constraint[param] = (constraint, where)
+                    elif isinstance(modifier, ParametersModifier):
+                        owners = (
+                            shapesys_owners
+                            if modifier.type == "shapesys"
+                            else staterror_owners
+                        )
+                        for param in modifier.parameters:
+                            if param in owners and owners[param] != dist_obj.name:
+                                kind = modifier.type
+                                msg = (
+                                    f"{kind} parameter '{param}' appears in both "
+                                    f"'{owners[param]}' and '{dist_obj.name}'; "
+                                    f"{kind} is per-channel and may not be shared."
+                                )
+                                raise ValueError(msg)
+                            owners[param] = dist_obj.name
 
     def _resolve_likelihood_fields(
         self, likelihood: Likelihood, errors: list[str]

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -139,6 +139,45 @@ class Workspace(BaseModel):
                 resolved.append(ref)
         return resolved
 
+    @staticmethod
+    def _check_hfdc_modifier(
+        modifier: object,
+        where: str,
+        channel_name: str,
+        param_constraint: dict[str, tuple[str, str]],
+        shapesys_owners: dict[str, str],
+        staterror_owners: dict[str, str],
+    ) -> None:
+        """Check one modifier's constraint for type consistency and ownership."""
+        if not hasattr(modifier, "constraint") or modifier.constraint is None:
+            return
+        constraint = modifier.constraint
+        if isinstance(modifier, ParameterModifier):
+            param = modifier.parameter
+            prev = param_constraint.get(param)
+            if prev is not None and prev[0] != constraint:
+                msg = (
+                    f"Parameter '{param}' has conflicting constraint types: "
+                    f"'{prev[1]}' declared '{prev[0]}', "
+                    f"'{where}' declares '{constraint}'"
+                )
+                raise ValueError(msg)
+            param_constraint[param] = (constraint, where)
+        elif isinstance(modifier, ParametersModifier):
+            owners = (
+                shapesys_owners if modifier.type == "shapesys" else staterror_owners
+            )
+            for param in modifier.parameters:
+                if param in owners and owners[param] != channel_name:
+                    kind = modifier.type
+                    msg = (
+                        f"{kind} parameter '{param}' appears in both "
+                        f"'{owners[param]}' and '{channel_name}'; "
+                        f"{kind} is per-channel and may not be shared."
+                    )
+                    raise ValueError(msg)
+                owners[param] = channel_name
+
     def _validate_hfdc_constraints(self, likelihood: Likelihood) -> None:
         """Validate constraint consistency across HFDC channels in a likelihood.
 
@@ -162,40 +201,15 @@ class Workspace(BaseModel):
                 continue
             for sample in dist_obj.samples:
                 for modifier in sample.modifiers:
-                    if (
-                        not hasattr(modifier, "constraint")
-                        or modifier.constraint is None
-                    ):
-                        continue
                     where = f"{dist_obj.name}/{sample.name}/{modifier.name}"
-                    constraint = modifier.constraint
-                    if isinstance(modifier, ParameterModifier):
-                        param = modifier.parameter
-                        prev = param_constraint.get(param)
-                        if prev is not None and prev[0] != constraint:
-                            msg = (
-                                f"Parameter '{param}' has conflicting constraint types: "
-                                f"'{prev[1]}' declared '{prev[0]}', "
-                                f"'{where}' declares '{constraint}'"
-                            )
-                            raise ValueError(msg)
-                        param_constraint[param] = (constraint, where)
-                    elif isinstance(modifier, ParametersModifier):
-                        owners = (
-                            shapesys_owners
-                            if modifier.type == "shapesys"
-                            else staterror_owners
-                        )
-                        for param in modifier.parameters:
-                            if param in owners and owners[param] != dist_obj.name:
-                                kind = modifier.type
-                                msg = (
-                                    f"{kind} parameter '{param}' appears in both "
-                                    f"'{owners[param]}' and '{dist_obj.name}'; "
-                                    f"{kind} is per-channel and may not be shared."
-                                )
-                                raise ValueError(msg)
-                            owners[param] = dist_obj.name
+                    self._check_hfdc_modifier(
+                        modifier,
+                        where,
+                        dist_obj.name,
+                        param_constraint,
+                        shapesys_owners,
+                        staterror_owners,
+                    )
 
     def _resolve_likelihood_fields(
         self, likelihood: Likelihood, errors: list[str]

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -163,13 +163,14 @@ class Workspace(BaseModel):
                 )
                 raise ValueError(msg)
             param_constraint[param] = (constraint, where)
-        elif isinstance(modifier, ParametersModifier):
+        else:
+            multi_mod = cast(ParametersModifier, modifier)
             owners = (
-                shapesys_owners if modifier.type == "shapesys" else staterror_owners
+                shapesys_owners if multi_mod.type == "shapesys" else staterror_owners
             )
-            for param in modifier.parameters:
+            for param in multi_mod.parameters:
                 if param in owners and owners[param] != channel_name:
-                    kind = modifier.type
+                    kind = multi_mod.type
                     msg = (
                         f"{kind} parameter '{param}' appears in both "
                         f"'{owners[param]}' and '{channel_name}'; "

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -15,7 +15,6 @@ import math
 
 import numpy as np
 import pytensor
-import pytensor.tensor as pt
 import pytest
 
 from pyhs3.data import BinnedData, Data
@@ -26,6 +25,7 @@ from pyhs3.distributions.histfactory.modifiers import (
     ParametersModifier,
 )
 from pyhs3.domains import Domains, ProductDomain
+from pyhs3.exceptions import WorkspaceValidationError
 from pyhs3.likelihoods import Likelihood, Likelihoods
 from pyhs3.metadata import Metadata
 from pyhs3.parameter_points import ParameterPoint, ParameterPoints, ParameterSet
@@ -78,11 +78,6 @@ def _simple_workspace(channels: list[dict], params: list[dict]) -> Workspace:
         data.append(binned)
         likelihood_data.append(binned)
 
-    # Observed data parameters — HFDC requires "{name}_observed" in the context.
-    obs_params = [
-        ParameterPoint(name=f"{ch['name']}_observed", value=0.0, kind=pt.vector)
-        for ch in channels
-    ]
     param_points = [ParameterPoint(name=p["name"], value=p["value"]) for p in params]
 
     return Workspace(
@@ -103,7 +98,7 @@ def _simple_workspace(channels: list[dict], params: list[dict]) -> Workspace:
             [
                 ParameterSet(
                     name="default",
-                    parameters=obs_params + param_points,
+                    parameters=param_points,
                 )
             ]
         ),
@@ -523,7 +518,7 @@ class TestConstraintValidator:
                 }
             ],
         )
-        with pytest.raises(ValueError, match="conflicting constraint"):
+        with pytest.raises(WorkspaceValidationError, match="conflicting constraint"):
             _simple_workspace(
                 channels=[sr_channel, cr_channel],
                 params=[{"name": "lumi", "value": 0.0}],
@@ -544,7 +539,7 @@ class TestConstraintValidator:
         }
         sr = _make_channel("SR", [10.0], [shared_shapesys])
         cr = _make_channel("CR", [50.0], [shared_shapesys])
-        with pytest.raises(ValueError, match="shapesys"):
+        with pytest.raises(WorkspaceValidationError, match="shapesys"):
             _simple_workspace(channels=[sr, cr], params=[])
 
     def test_staterror_shared_across_channels_raises(self):
@@ -557,7 +552,7 @@ class TestConstraintValidator:
         }
         sr = _make_channel("SR", [10.0], [shared_staterror])
         cr = _make_channel("CR", [50.0], [shared_staterror])
-        with pytest.raises(ValueError, match="staterror"):
+        with pytest.raises(WorkspaceValidationError, match="staterror"):
             _simple_workspace(channels=[sr, cr], params=[])
 
     def test_same_normsys_type_across_channels_is_valid(self):

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -106,15 +106,15 @@ def _simple_workspace(channels: list[dict], params: list[dict]) -> Workspace:
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: constraint_modifiers()
+# Unit tests: constraint_specs()
 # ---------------------------------------------------------------------------
 
 
 class TestConstraintModifiers:
-    """Unit tests for HistFactoryDistChannel.constraint_modifiers()."""
+    """Unit tests for HistFactoryDistChannel.constraint_specs()."""
 
     def test_empty_no_constraints(self):
-        """Channel with no HasConstraint modifiers returns empty collections."""
+        """Channel with no HasConstraint modifiers yields nothing."""
         ch = HistFactoryDistChannel(
             **_make_channel(
                 "ch",
@@ -122,12 +122,10 @@ class TestConstraintModifiers:
                 [{"name": "mu", "type": "normfactor", "parameter": "mu"}],
             )
         )
-        single, multi = ch.constraint_modifiers()
-        assert single == {}
-        assert multi == []
+        assert list(ch.constraint_specs()) == []
 
     def test_normsys_is_in_single(self):
-        """normsys modifier (ParameterModifier + HasConstraint) appears in single dict."""
+        """normsys (ParameterModifier + HasConstraint) yields a string dedup_key."""
         ch = HistFactoryDistChannel(
             **_make_channel(
                 "ch",
@@ -143,15 +141,15 @@ class TestConstraintModifiers:
                 ],
             )
         )
-        single, multi = ch.constraint_modifiers()
-        assert "lumi" in single
-        modifier, _sample_data = single["lumi"]
+        specs = list(ch.constraint_specs())
+        assert len(specs) == 1
+        dedup_key, modifier, _sample_data = specs[0]
+        assert dedup_key == "lumi"
         assert isinstance(modifier, HasConstraint)
         assert isinstance(modifier, ParameterModifier)
-        assert multi == []
 
     def test_shapesys_is_in_multi(self):
-        """shapesys modifier (ParametersModifier + HasConstraint) appears in multi list."""
+        """shapesys (ParametersModifier + HasConstraint) yields dedup_key=None."""
         ch = HistFactoryDistChannel(
             **_make_channel(
                 "ch",
@@ -167,15 +165,15 @@ class TestConstraintModifiers:
                 ],
             )
         )
-        single, multi = ch.constraint_modifiers()
-        assert single == {}
-        assert len(multi) == 1
-        modifier, _sample_data = multi[0]
+        specs = list(ch.constraint_specs())
+        assert len(specs) == 1
+        dedup_key, modifier, _sample_data = specs[0]
+        assert dedup_key is None
         assert isinstance(modifier, HasConstraint)
         assert isinstance(modifier, ParametersModifier)
 
     def test_mixed_returns_both(self):
-        """Channel with both normsys and shapesys populates both collections."""
+        """Channel with both normsys and shapesys yields both kinds of specs."""
         ch = HistFactoryDistChannel(
             **_make_channel(
                 "ch",
@@ -198,12 +196,18 @@ class TestConstraintModifiers:
                 ],
             )
         )
-        single, multi = ch.constraint_modifiers()
-        assert "lumi" in single
-        assert len(multi) == 1
+        specs = list(ch.constraint_specs())
+        assert len(specs) == 2
+        keys = [key for key, _, _ in specs]
+        assert "lumi" in keys
+        assert None in keys
 
-    def test_duplicate_normsys_parameter_in_same_channel_first_wins(self):
-        """Two samples with the same normsys parameter: first sample wins in single dict."""
+    def test_duplicate_normsys_parameter_in_same_channel_yields_both(self):
+        """Two samples with the same normsys parameter yield two specs with the same key.
+
+        The caller (extended_likelihood, _build_distribution_node) is responsible for
+        deduping using the key — constraint_specs() yields all modifiers without dedup.
+        """
         dist = HistFactoryDistChannel(
             name="ch",
             axes=[{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}],
@@ -236,8 +240,10 @@ class TestConstraintModifiers:
                 },
             ],
         )
-        single, _multi = dist.constraint_modifiers()
-        assert list(single.keys()) == ["lumi"]  # only one entry
+        specs = list(dist.constraint_specs())
+        keys = [key for key, _, _ in specs]
+        # Both specs have the same dedup_key; callers apply the seen-set dedup.
+        assert keys == ["lumi", "lumi"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -12,12 +12,13 @@ nuisance parameter across all HFDC channels.
 from __future__ import annotations
 
 import math
+import types
 
 import numpy as np
 import pytensor
 import pytest
 
-from pyhs3.data import BinnedData, Data
+from pyhs3.data import BinnedData, Data, UnbinnedData
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
 from pyhs3.distributions.histfactory.modifiers import (
     HasConstraint,
@@ -244,6 +245,49 @@ class TestConstraintModifiers:
         keys = [key for key, _, _ in specs]
         # Both specs have the same dedup_key; callers apply the seen-set dedup.
         assert keys == ["lumi", "lumi"]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Model._try_bake_hfdc_observed
+# ---------------------------------------------------------------------------
+
+
+class TestTryBakeHFDCObserved:
+    """Unit tests for Model._try_bake_hfdc_observed."""
+
+    def test_skips_non_binned_data_entries(self):
+        """Non-BinnedData likelihood entries are skipped; matching BinnedData is baked.
+
+        Exercises the ``continue`` branch where a datum is not a BinnedData —
+        the search must carry on to find the correct BinnedData for the channel.
+        """
+        ws = _simple_workspace(
+            channels=[_make_channel("SR", [10.0, 20.0], [])],
+            params=[],
+        )
+        model = ws.model(next(iter(ws.likelihoods)), progress=False)
+
+        sr_channel = next(iter(ws.distributions))
+        binned = BinnedData(
+            name="SR_data",
+            axes=[{"name": "x_SR", "min": 0.0, "max": 10.0, "nbins": 2}],
+            contents=[10.0, 20.0],
+        )
+        unbinned = UnbinnedData(
+            name="other_data",
+            entries=[[1.0]],
+            axes=[{"name": "y", "min": 0.0, "max": 5.0}],
+        )
+        # Unbinned datum comes first so the loop hits `continue` at least once
+        # before finding the matching BinnedData.
+        model._likelihood = types.SimpleNamespace(
+            distributions=["other_dist", sr_channel],
+            data=[unbinned, binned],
+        )
+
+        result = model._try_bake_hfdc_observed("SR_observed")
+        assert result is not None
+        np.testing.assert_array_equal(result.data, [10.0, 20.0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -502,6 +502,80 @@ class TestConstraintDeduplication:
         expected = poisson_sr + poisson_cr + 2 * gauss_lp  # two independent constraints
         assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
 
+    def test_inactive_channel_constraints_excluded_from_log_prob(self):
+        """Constraints from HFDC channels not in the active likelihood must not
+        appear in log_prob even though all workspace distributions are built.
+
+        Regression: _build_distribution_node previously collected constraints
+        from ALL workspace distributions regardless of the active likelihood.
+        """
+        normsys_sr = {
+            "name": "alpha_sr",
+            "type": "normsys",
+            "parameter": "alpha_sr",
+            "constraint": "Gauss",
+            "data": {"hi": 1.1, "lo": 0.9},
+        }
+        normsys_cr = {
+            "name": "alpha_cr",
+            "type": "normsys",
+            "parameter": "alpha_cr",
+            "constraint": "Gauss",
+            "data": {"hi": 1.2, "lo": 0.8},
+        }
+        sr_channel = HistFactoryDistChannel(**_make_channel("SR", [10.0], [normsys_sr]))
+        cr_channel = HistFactoryDistChannel(**_make_channel("CR", [50.0], [normsys_cr]))
+        sr_data = BinnedData(
+            name="SR_data",
+            axes=[{"name": "x_SR", "min": 0.0, "max": 10.0, "nbins": 1}],
+            contents=[10.0],
+        )
+        ws = Workspace(
+            metadata=Metadata(hs3_version="0.3.0"),
+            distributions=Distributions([sr_channel, cr_channel]),
+            data=Data([sr_data]),
+            likelihoods=Likelihoods(
+                [
+                    Likelihood(
+                        name="L",
+                        distributions=[sr_channel],
+                        data=[sr_data],
+                    )
+                ]
+            ),
+            domains=Domains([ProductDomain(name="default")]),
+            parameter_points=ParameterPoints(
+                [
+                    ParameterSet(
+                        name="default",
+                        parameters=[
+                            ParameterPoint(name="alpha_sr", value=0.0),
+                            ParameterPoint(name="alpha_cr", value=0.0),
+                        ],
+                    )
+                ]
+            ),
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        # Filter to only the free inputs (after fix, alpha_cr is not a free input).
+        param_vals = {k: v for k, v in model.nominal_params.items() if k in inputs}
+        val = float(fn(**{**model.data, **param_vals}).item())
+
+        # Expected: Poisson(SR only) + 1 Gaussian(alpha_sr=0)
+        # With the bug, Gaussian(alpha_cr) from inactive CR also appears.
+        poisson_sr = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        gauss_lp = -0.5 * math.log(2 * math.pi)
+        expected = poisson_sr + gauss_lp
+        assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
     def test_normfactor_has_no_constraint(self):
         """normfactor adds no constraint term; log_prob equals Poisson only."""
         ws = _simple_workspace(

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -1,0 +1,578 @@
+"""Tests for HFDC constraint deduplication and log_prob integration.
+
+PR #2: When multiple HistFactoryDistChannel (HFDC) instances share nuisance
+parameters, each channel's extended_likelihood previously emitted its own
+constraint term, causing double-counting in the joint NLL.
+
+Fix: _build_distribution_node stores only dist.likelihood(context) for HFDC
+(Poisson term only). Model.log_prob collects constraint terms once per unique
+nuisance parameter across all HFDC channels.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+from pyhs3.data import BinnedData, Data
+from pyhs3.distributions import Distributions, HistFactoryDistChannel
+from pyhs3.distributions.histfactory.modifiers import (
+    HasConstraint,
+    ParameterModifier,
+    ParametersModifier,
+)
+from pyhs3.domains import Domains, ProductDomain
+from pyhs3.likelihoods import Likelihood, Likelihoods
+from pyhs3.metadata import Metadata
+from pyhs3.parameter_points import ParameterPoint, ParameterPoints, ParameterSet
+from pyhs3.workspace import Workspace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_channel(name: str, contents: list[float], modifiers: list[dict]) -> dict:
+    """Return a JSON-like dict for HistFactoryDistChannel constructor.
+
+    The observable axis is named after the channel (e.g., "x_SR") so that
+    multi-channel workspaces pass the unique-axis-name validation.
+    """
+    obs_name = f"x_{name}"
+    return {
+        "name": name,
+        "axes": [{"name": obs_name, "min": 0.0, "max": 10.0, "nbins": len(contents)}],
+        "samples": [
+            {
+                "name": "signal",
+                "data": {"contents": contents, "errors": [1.0] * len(contents)},
+                "modifiers": modifiers,
+            }
+        ],
+    }
+
+
+def _simple_workspace(channels: list[dict], params: list[dict]) -> Workspace:
+    """Build a minimal Workspace with HFDC channel(s) and BinnedData."""
+    distributions = []
+    data = []
+    likelihood_dists = []
+    likelihood_data = []
+
+    for ch in channels:
+        dist = HistFactoryDistChannel(**ch)
+        distributions.append(dist)
+        likelihood_dists.append(dist)
+
+        nbins = len(ch["samples"][0]["data"]["contents"])
+        obs_name = ch["axes"][0]["name"]  # already set per-channel by _make_channel
+        binned = BinnedData(
+            name=f"{ch['name']}_data",
+            axes=[{"name": obs_name, "min": 0.0, "max": 10.0, "nbins": nbins}],
+            contents=ch["samples"][0]["data"]["contents"],
+        )
+        data.append(binned)
+        likelihood_data.append(binned)
+
+    # Observed data parameters — HFDC requires "{name}_observed" in the context.
+    obs_params = [
+        ParameterPoint(name=f"{ch['name']}_observed", value=0.0, kind=pt.vector)
+        for ch in channels
+    ]
+    param_points = [ParameterPoint(name=p["name"], value=p["value"]) for p in params]
+
+    return Workspace(
+        metadata=Metadata(hs3_version="0.3.0"),
+        distributions=Distributions(distributions),
+        data=Data(data),
+        likelihoods=Likelihoods(
+            [
+                Likelihood(
+                    name="L",
+                    distributions=likelihood_dists,
+                    data=likelihood_data,
+                )
+            ]
+        ),
+        domains=Domains([ProductDomain(name="default")]),
+        parameter_points=ParameterPoints(
+            [
+                ParameterSet(
+                    name="default",
+                    parameters=obs_params + param_points,
+                )
+            ]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: constraint_modifiers()
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintModifiers:
+    """Unit tests for HistFactoryDistChannel.constraint_modifiers()."""
+
+    def test_empty_no_constraints(self):
+        """Channel with no HasConstraint modifiers returns empty collections."""
+        ch = HistFactoryDistChannel(
+            **_make_channel(
+                "ch",
+                [10.0, 20.0],
+                [{"name": "mu", "type": "normfactor", "parameter": "mu"}],
+            )
+        )
+        single, multi = ch.constraint_modifiers()
+        assert single == {}
+        assert multi == []
+
+    def test_normsys_is_in_single(self):
+        """normsys modifier (ParameterModifier + HasConstraint) appears in single dict."""
+        ch = HistFactoryDistChannel(
+            **_make_channel(
+                "ch",
+                [10.0],
+                [
+                    {
+                        "name": "lumi",
+                        "type": "normsys",
+                        "parameter": "lumi",
+                        "constraint": "Gauss",
+                        "data": {"hi": 1.05, "lo": 0.95},
+                    }
+                ],
+            )
+        )
+        single, multi = ch.constraint_modifiers()
+        assert "lumi" in single
+        modifier, _sample_data = single["lumi"]
+        assert isinstance(modifier, HasConstraint)
+        assert isinstance(modifier, ParameterModifier)
+        assert multi == []
+
+    def test_shapesys_is_in_multi(self):
+        """shapesys modifier (ParametersModifier + HasConstraint) appears in multi list."""
+        ch = HistFactoryDistChannel(
+            **_make_channel(
+                "ch",
+                [10.0, 20.0],
+                [
+                    {
+                        "name": "stat",
+                        "type": "shapesys",
+                        "parameters": ["gamma_0", "gamma_1"],
+                        "constraint": "Poisson",
+                        "data": {"vals": [2.0, 4.0]},
+                    }
+                ],
+            )
+        )
+        single, multi = ch.constraint_modifiers()
+        assert single == {}
+        assert len(multi) == 1
+        modifier, _sample_data = multi[0]
+        assert isinstance(modifier, HasConstraint)
+        assert isinstance(modifier, ParametersModifier)
+
+    def test_mixed_returns_both(self):
+        """Channel with both normsys and shapesys populates both collections."""
+        ch = HistFactoryDistChannel(
+            **_make_channel(
+                "ch",
+                [10.0, 20.0],
+                [
+                    {
+                        "name": "lumi",
+                        "type": "normsys",
+                        "parameter": "lumi",
+                        "constraint": "Gauss",
+                        "data": {"hi": 1.05, "lo": 0.95},
+                    },
+                    {
+                        "name": "stat",
+                        "type": "shapesys",
+                        "parameters": ["gamma_0", "gamma_1"],
+                        "constraint": "Poisson",
+                        "data": {"vals": [2.0, 4.0]},
+                    },
+                ],
+            )
+        )
+        single, multi = ch.constraint_modifiers()
+        assert "lumi" in single
+        assert len(multi) == 1
+
+    def test_duplicate_normsys_parameter_in_same_channel_first_wins(self):
+        """Two samples with the same normsys parameter: first sample wins in single dict."""
+        dist = HistFactoryDistChannel(
+            name="ch",
+            axes=[{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}],
+            samples=[
+                {
+                    "name": "sig",
+                    "data": {"contents": [10.0], "errors": [1.0]},
+                    "modifiers": [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                },
+                {
+                    "name": "bkg",
+                    "data": {"contents": [5.0], "errors": [1.0]},
+                    "modifiers": [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                },
+            ],
+        )
+        single, _multi = dist.constraint_modifiers()
+        assert list(single.keys()) == ["lumi"]  # only one entry
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: log_prob includes HFDC Poisson term
+# ---------------------------------------------------------------------------
+
+
+class TestHFDCLogProb:
+    """log_prob for HFDC workspaces includes Poisson and constraint terms."""
+
+    def _eval_log_prob(self, ws: Workspace) -> float:
+        """Build a model from the first likelihood and evaluate log_prob at nominal params."""
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        return float(fn(**model.data, **model.nominal_params).item())
+
+    def test_log_prob_is_finite_for_hfdc(self):
+        """log_prob must be a finite number, not zero (which would mean HFDC was skipped)."""
+        ws = _simple_workspace(
+            channels=[_make_channel("SR", [10.0, 20.0], [])],
+            params=[],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        val = float(fn(**model.data, **model.nominal_params).item())
+        assert math.isfinite(val)
+        assert val != 0.0
+
+    def test_log_prob_no_constraint_matches_poisson(self):
+        """Single HFDC with no constraints: log_prob equals sum of Poisson log-probs.
+
+        When observed == expected, Poisson log-prob for bin k is
+          obs_k * log(exp_k) - exp_k - log(obs_k!)
+        """
+        contents = [10.0, 20.0]
+        ws = _simple_workspace(
+            channels=[_make_channel("SR", contents, [])],
+            params=[],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        # Nominal: obs == exp for each bin
+        obs = np.array(contents)
+        val = float(fn(**model.data, **model.nominal_params).item())
+        expected = float(
+            np.sum(
+                obs * np.log(obs) - obs - np.array([math.lgamma(o + 1) for o in obs])
+            )
+        )
+        assert abs(val - expected) < 1e-6
+
+    def test_log_prob_single_channel_with_normsys(self):
+        """Single HFDC with normsys: log_prob = Poisson + constraint.
+
+        At alpha=0, the Gaussian constraint log-prob is -0.5*log(2*pi) ≈ -0.9189.
+        """
+        contents = [10.0]
+        ws = _simple_workspace(
+            channels=[
+                _make_channel(
+                    "SR",
+                    contents,
+                    [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                )
+            ],
+            params=[{"name": "lumi", "value": 0.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        val = float(fn(**model.data, **model.nominal_params).item())
+
+        # Poisson part: obs=10 at exp=10
+        poisson_lp = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        # Gaussian constraint at alpha=0: log N(0|0,1) = -0.5*log(2*pi)
+        gauss_lp = -0.5 * math.log(2 * math.pi)
+        expected = poisson_lp + gauss_lp
+        assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: constraint deduplication across channels
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintDeduplication:
+    """Shared nuisance parameters must appear exactly once in the joint NLL."""
+
+    def test_two_channels_shared_normsys_same_as_single_constraint(self):
+        """Two channels sharing a normsys parameter produce the same NLL as
+        manually computing: Poisson_SR + Poisson_CR + 1 * constraint(lumi).
+
+        Before the fix, the NLL contained 2 * constraint(lumi).
+        """
+        normsys_mod = {
+            "name": "lumi",
+            "type": "normsys",
+            "parameter": "lumi",
+            "constraint": "Gauss",
+            "data": {"hi": 1.05, "lo": 0.95},
+        }
+        ws = _simple_workspace(
+            channels=[
+                _make_channel("SR", [10.0], [normsys_mod]),
+                _make_channel("CR", [50.0], [normsys_mod]),
+            ],
+            params=[{"name": "lumi", "value": 0.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        val = float(fn(**model.data, **model.nominal_params).item())
+
+        # Expected: sum of Poisson log-probs + 1 Gaussian constraint at alpha=0
+        poisson_sr = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        poisson_cr = 50.0 * math.log(50.0) - 50.0 - math.lgamma(51.0)
+        gauss_lp = -0.5 * math.log(2 * math.pi)
+        expected = poisson_sr + poisson_cr + gauss_lp
+        assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
+    def test_two_channels_independent_normsys_both_constraints_present(self):
+        """Two channels with different normsys parameters must each contribute a constraint."""
+        ws = _simple_workspace(
+            channels=[
+                _make_channel(
+                    "SR",
+                    [10.0],
+                    [
+                        {
+                            "name": "alpha_sr",
+                            "type": "normsys",
+                            "parameter": "alpha_sr",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.1, "lo": 0.9},
+                        }
+                    ],
+                ),
+                _make_channel(
+                    "CR",
+                    [50.0],
+                    [
+                        {
+                            "name": "alpha_cr",
+                            "type": "normsys",
+                            "parameter": "alpha_cr",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.2, "lo": 0.8},
+                        }
+                    ],
+                ),
+            ],
+            params=[
+                {"name": "alpha_sr", "value": 0.0},
+                {"name": "alpha_cr", "value": 0.0},
+            ],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        val = float(fn(**model.data, **model.nominal_params).item())
+
+        poisson_sr = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        poisson_cr = 50.0 * math.log(50.0) - 50.0 - math.lgamma(51.0)
+        gauss_lp = -0.5 * math.log(2 * math.pi)  # each at alpha=0
+        expected = poisson_sr + poisson_cr + 2 * gauss_lp  # two independent constraints
+        assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
+    def test_normfactor_has_no_constraint(self):
+        """normfactor adds no constraint term; log_prob equals Poisson only."""
+        ws = _simple_workspace(
+            channels=[
+                _make_channel(
+                    "SR",
+                    [10.0],
+                    [{"name": "mu", "type": "normfactor", "parameter": "mu"}],
+                )
+            ],
+            params=[{"name": "mu", "value": 1.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        val = float(fn(**model.data, **model.nominal_params).item())
+        # At mu=1: rates=10, obs=10
+        expected = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
+
+# ---------------------------------------------------------------------------
+# Validator tests: constraint type consistency and per-channel uniqueness
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintValidator:
+    """Workspace validation catches conflicting constraint configurations."""
+
+    def test_conflicting_constraint_types_raises(self):
+        """Same nuisance parameter with different constraint types must raise ValueError.
+
+        'lumi' as normsys(Gauss) in SR and normsys(LogNormal) in CR is invalid.
+        """
+        sr_channel = _make_channel(
+            "SR",
+            [10.0],
+            [
+                {
+                    "name": "lumi",
+                    "type": "normsys",
+                    "parameter": "lumi",
+                    "constraint": "Gauss",
+                    "data": {"hi": 1.05, "lo": 0.95},
+                }
+            ],
+        )
+        cr_channel = _make_channel(
+            "CR",
+            [50.0],
+            [
+                {
+                    "name": "lumi",
+                    "type": "normsys",
+                    "parameter": "lumi",
+                    "constraint": "LogNormal",
+                    "data": {"hi": 1.05, "lo": 0.95},
+                }
+            ],
+        )
+        with pytest.raises(ValueError, match="conflicting constraint"):
+            _simple_workspace(
+                channels=[sr_channel, cr_channel],
+                params=[{"name": "lumi", "value": 0.0}],
+            )
+
+    def test_shapesys_shared_across_channels_raises(self):
+        """ShapeSys parameter names shared across channels must raise ValueError.
+
+        shapesys parameters are per-channel (bin yields differ per region),
+        so correlation across channels is physically nonsensical.
+        """
+        shared_shapesys = {
+            "name": "stat",
+            "type": "shapesys",
+            "parameters": ["gamma_0"],
+            "constraint": "Poisson",
+            "data": {"vals": [2.0]},
+        }
+        sr = _make_channel("SR", [10.0], [shared_shapesys])
+        cr = _make_channel("CR", [50.0], [shared_shapesys])
+        with pytest.raises(ValueError, match="shapesys"):
+            _simple_workspace(channels=[sr, cr], params=[])
+
+    def test_staterror_shared_across_channels_raises(self):
+        """StatError parameter names shared across channels must raise ValueError."""
+        shared_staterror = {
+            "name": "stat",
+            "type": "staterror",
+            "parameters": ["gamma_0"],
+            "data": {"uncertainties": [1.0]},
+        }
+        sr = _make_channel("SR", [10.0], [shared_staterror])
+        cr = _make_channel("CR", [50.0], [shared_staterror])
+        with pytest.raises(ValueError, match="staterror"):
+            _simple_workspace(channels=[sr, cr], params=[])
+
+    def test_same_normsys_type_across_channels_is_valid(self):
+        """Same parameter with the same constraint type across channels is fine."""
+        normsys = {
+            "name": "lumi",
+            "type": "normsys",
+            "parameter": "lumi",
+            "constraint": "Gauss",
+            "data": {"hi": 1.05, "lo": 0.95},
+        }
+        sr = _make_channel("SR", [10.0], [normsys])
+        cr = _make_channel("CR", [50.0], [normsys])
+        # Should not raise
+        ws = _simple_workspace(
+            channels=[sr, cr], params=[{"name": "lumi", "value": 0.0}]
+        )
+        assert ws is not None

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -1196,6 +1196,65 @@ class TestModifierExpressions:
         assert result[1] == pytest.approx(1.05)
 
 
+class TestExtendedLikelihoodConstraintDedup:
+    """Test that extended_likelihood dedupes constraints by parameter name."""
+
+    def test_shared_normsys_parameter_emits_one_constraint(self):
+        """Two normsys modifiers on different samples sharing one parameter
+        must emit exactly ONE Gaussian factor, not one per modifier.
+
+        At alpha=1 the ratio extended_likelihood(alpha=1) / extended_likelihood(alpha=0)
+        equals exp(-0.5) for one Gaussian factor or exp(-1) for two.
+        """
+        axes = [{"name": "x", "min": 0.0, "max": 10.0, "nbins": 2}]
+        samples = [
+            {
+                "name": "signal",
+                "data": {"contents": [5.0, 3.0], "errors": [1.0, 1.0]},
+                "modifiers": [
+                    {
+                        "name": "lumi",
+                        "type": "normsys",
+                        "parameter": "alpha_lumi",
+                        "data": {"hi": 1.1, "lo": 0.9},
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+            {
+                "name": "background",
+                "data": {"contents": [10.0, 8.0], "errors": [1.0, 1.0]},
+                "modifiers": [
+                    {
+                        "name": "lumi",
+                        "type": "normsys",
+                        "parameter": "alpha_lumi",
+                        "data": {"hi": 1.1, "lo": 0.9},
+                        "constraint": "Gauss",
+                    }
+                ],
+            },
+        ]
+
+        channel = HistFactoryDistChannel(name="ch", axes=axes, samples=samples)
+
+        alpha = pt.dscalar("alpha_lumi")
+        obs = pt.dvector("ch_observed")
+        context = Context({"alpha_lumi": alpha, "ch_observed": obs})
+
+        el_expr = channel.extended_likelihood(context)
+        f = function([alpha], el_expr)
+
+        val_at_0 = f(0.0)
+        val_at_1 = f(1.0)
+
+        # Ratio for ONE Gaussian factor N(alpha | 0, 1) at x=0:
+        #   exp(-0.5 * 1^2) / exp(0) = exp(-0.5)
+        # Ratio for TWO factors (the bug): exp(-1.0)
+        ratio = val_at_1 / val_at_0
+        assert ratio == pytest.approx(np.exp(-0.5), rel=1e-6)
+
+
 class TestHistFactoryChannelHistConversion:
     """Tests for HistFactoryDistChannel.to_hist() method."""
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -738,6 +738,7 @@ class TestWorkspaceWithLikelihoodsAndAnalyses:
         assert len(combined_likelihood.data) == 2
         assert combined_likelihood.data[0].name == "observed_data"
         assert combined_likelihood.data[1].name == "observed_data"
+        assert len(combined_likelihood.aux_distributions) == 1
         assert combined_likelihood.aux_distributions[0].name == "background_dist"
 
     def test_workspace_loads_analyses_correctly(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -738,7 +738,7 @@ class TestWorkspaceWithLikelihoodsAndAnalyses:
         assert len(combined_likelihood.data) == 2
         assert combined_likelihood.data[0].name == "observed_data"
         assert combined_likelihood.data[1].name == "observed_data"
-        assert combined_likelihood.aux_distributions == ["background_dist"]
+        assert combined_likelihood.aux_distributions[0].name == "background_dist"
 
     def test_workspace_loads_analyses_correctly(
         self, workspace_with_likelihoods_analyses

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -690,25 +690,3 @@ def test_log_prob_aux_distributions_contributes_to_log_prob():
     # With the constraint, log_prob gains an extra log(N(0|0,1)) term.
     assert val_with != pytest.approx(val_without)
     assert val_with < val_without  # constraint N(0|0,1) < 1, so log < 0
-
-
-def test_log_prob_aux_unknown_distribution_is_silently_skipped():
-    """aux_distributions names not in model.distributions are skipped without error."""
-    ws = Workspace(
-        **{
-            **_WS_AUX,
-            "likelihoods": [
-                {
-                    "name": "L",
-                    "distributions": ["gauss1"],
-                    "data": ["data1"],
-                    # "nonexistent" is not a distribution in the workspace.
-                    "aux_distributions": ["constraint", "nonexistent"],
-                }
-            ],
-        }
-    )
-    model = ws.model(ws.analyses["A"], progress=False)
-    # Should not raise; "nonexistent" is simply skipped.
-    lp = model.log_prob
-    assert hasattr(lp, "type")

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -83,6 +83,77 @@ class TestWorkspaceFKResolutionWithNoneCollections:
                 data=None,
             )
 
+    def test_likelihood_references_aux_distribution_nonexistent(self):
+        """aux_distributions names not in model.distributions raise error."""
+        with pytest.raises(
+            WorkspaceValidationError, match="references unknown aux_distribution"
+        ):
+            Workspace.model_validate(
+                {
+                    "metadata": {"hs3_version": "0.2"},
+                    "distributions": [
+                        {
+                            "name": "gauss1",
+                            "type": "gaussian_dist",
+                            "x": "x_obs",
+                            "mean": "mean",
+                            "sigma": 1.0,
+                        },
+                        {
+                            "name": "constraint",
+                            "type": "gaussian_dist",
+                            "x": "alpha",
+                            "mean": 0.0,
+                            "sigma": 1.0,
+                        },
+                    ],
+                    "domains": [
+                        {
+                            "name": "main",
+                            "type": "product_domain",
+                            "axes": [
+                                {"name": "mean", "min": -10.0, "max": 10.0},
+                                {"name": "alpha", "min": -5.0, "max": 5.0},
+                            ],
+                        }
+                    ],
+                    "data": [
+                        {
+                            "name": "data1",
+                            "type": "unbinned",
+                            "axes": [{"name": "x_obs", "min": -10.0, "max": 10.0}],
+                            "entries": [[1.0], [2.0], [3.0]],
+                        }
+                    ],
+                    "likelihoods": [
+                        {
+                            "name": "L",
+                            "distributions": ["gauss1"],
+                            "data": ["data1"],
+                            # "nonexistent" is not a distribution in the workspace.
+                            "aux_distributions": ["constraint", "nonexistent"],
+                        }
+                    ],
+                    "analyses": [
+                        {
+                            "name": "A",
+                            "likelihood": "L",
+                            "domains": ["main"],
+                            "init": "params",
+                        }
+                    ],
+                    "parameter_points": [
+                        {
+                            "name": "params",
+                            "parameters": [
+                                {"name": "mean", "value": 0.0},
+                                {"name": "alpha", "value": 0.0},
+                            ],
+                        }
+                    ],
+                }
+            )
+
     def test_likelihood_references_data_when_none(self):
         """Test error when likelihood references data but data=None."""
         with pytest.raises(WorkspaceValidationError, match="references unknown data"):


### PR DESCRIPTION
## Summary

- **Bug fixed**: When multiple `HistFactoryDistChannel` (HFDC) instances share nuisance parameters (e.g. `lumi` correlated across channels), each channel's `extended_likelihood` previously emitted its own constraint term, causing double-counting in the joint NLL.
- `Model._build_distribution_node` now stores the Poisson-only term in `self._hfdc_poisson` and collects deduplicated constraint expressions in `self._hfdc_constraints`. The full expression (Poisson x constraints) is still stored in `self.distributions` so `model.logpdf()` is unchanged.
- `Model.log_prob` uses `self._hfdc_poisson[dist_name]` for binned channels and appends the deduplicated constraint log-terms in a single pass after the main loop.
- `Model._build_parameter_node` bakes `{name}_observed` as `pt.constant` when a paired `BinnedData` exists in the likelihood, removing it from the free-input set for JAX transpilation.
- `Workspace._validate_hfdc_constraints` validates constraint-type consistency across channels and forbids `shapesys`/`staterror` parameters from being shared (they are per-channel by design).

## Relationship to other PRs

Depends on #220 (histosys nominal-rate bug fix) — the real-world NLL comparisons in the slow test suite are only meaningful once the histosys bug is resolved.

## Test plan

- [ ] `pixi run --environment py312 test tests/test_hfdc_model_constraints.py` -- 15 tests, all green
- [ ] `pixi run --environment py312 test` -- 926 passed, no regressions
- [ ] `pixi run pre-commit` -- all hooks pass
- [ ] `pixi run --environment py312 test-slow tests/test_realworld.py -s` -- multi-channel workspaces (requires #220 merged first)

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added constraint deduplication for multi-channel analyses, ensuring shared constraints are applied once rather than multiple times across channels.
  * Introduced workspace validation to detect and prevent inconsistent constraint configurations across channels.

* **Bug Fixes**
  * Corrected constraint accumulation in likelihood calculations to avoid duplicate constraint terms.

* **Tests**
  * Added comprehensive test coverage for constraint deduplication and validation logic, including edge cases with shared and independent constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scipp-atlas/pyhs3/pull/222)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->