### PR TITLE
refactor: multiplicative modifier apply() delegates to expression()

### DIFF
--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -173,9 +173,7 @@ class NormFactorModifier(ParameterModifier):
 
     def apply(self, context: Context, rates: TensorVar) -> TensorVar:
         """Apply normfactor modifier (simple scaling by parameter)."""
-
-        mu = context[self.parameter]
-        return cast("TensorVar", rates * mu)
+        return cast("TensorVar", rates * self.expression(context))
 
 
 class NormSysModifier(HasConstraint, ParameterModifier):
@@ -206,25 +204,7 @@ class NormSysModifier(HasConstraint, ParameterModifier):
     def expression(self, context: Context) -> TensorVar:
         """Return multiplicative factor for normsys."""
         alpha = context[self.parameter]
-
-        hi_factor = self.data.hi
-        lo_factor = self.data.lo
-
-        # Apply interpolation method
-        interpolation = self.data.interpolation
-        nominal_factor = pt.constant(1.0)
-        hi_factor_tensor = pt.constant(hi_factor)
-        lo_factor_tensor = pt.constant(lo_factor)
-
         return interpolations.apply_interpolation(
-            interpolation, alpha, nominal_factor, hi_factor_tensor, lo_factor_tensor
-        )
-
-    def apply(self, context: Context, rates: TensorVar) -> TensorVar:
-        """Apply normsys modifier (systematic with hi/lo interpolation)."""
-        alpha = context[self.parameter]
-
-        factor = interpolations.apply_interpolation(
             self.data.interpolation,
             alpha,
             self._nominal_factor,
@@ -232,7 +212,9 @@ class NormSysModifier(HasConstraint, ParameterModifier):
             self._lo_factor_tensor,
         )
 
-        return cast("TensorVar", rates * factor)
+    def apply(self, context: Context, rates: TensorVar) -> TensorVar:
+        """Apply normsys modifier (systematic with hi/lo interpolation)."""
+        return cast("TensorVar", rates * self.expression(context))
 
     def make_constraint(self, context: Context, _: SampleData) -> TensorVar:
         """Create constraint term using PyTensor operations."""
@@ -348,9 +330,7 @@ class ShapeFactorModifier(ParametersModifier):
 
     def apply(self, context: Context, rates: TensorVar) -> TensorVar:
         """Apply shapefactor modifier (uncorrelated bin-by-bin scaling)."""
-        param_names = self.parameters
-        factors = pt.stack([context[name] for name in param_names])
-        return cast("TensorVar", rates * factors)
+        return cast("TensorVar", rates * self.expression(context))
 
 
 class ShapeSysModifier(HasConstraint, ParametersModifier):
@@ -375,10 +355,7 @@ class ShapeSysModifier(HasConstraint, ParametersModifier):
 
     def apply(self, context: Context, rates: TensorVar) -> TensorVar:
         """Apply shapesys modifier (shape systematic with constraints)."""
-        # ShapeSys uses multiple parameters (one per bin)
-        param_names = self.parameters
-        factors = pt.stack([context[name] for name in param_names])
-        return cast("TensorVar", rates * factors)
+        return cast("TensorVar", rates * self.expression(context))
 
     def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
         """Create constraint term using PyTensor operations."""

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -28,8 +28,10 @@ from pyhs3.context import Context
 from pyhs3.distributions import HistFactoryDistChannel
 from pyhs3.distributions.histfactory.modifiers import (
     HistoSysModifier,
+    NormFactorModifier,
     NormSysModifier,
     ShapeFactorModifier,
+    ShapeSysModifier,
     StatErrorModifier,
 )
 
@@ -1194,6 +1196,95 @@ class TestModifierExpressions:
         result = f(0.95, 1.05)
         assert result[0] == pytest.approx(0.95)
         assert result[1] == pytest.approx(1.05)
+
+    def test_normfactor_apply_equals_rates_times_expression(self):
+        """apply(ctx, rates) must equal rates * expression(ctx) for NormFactorModifier."""
+        modifier = NormFactorModifier(name="mu", parameter="mu")
+
+        mu_var = pt.dscalar("mu")
+        rates_var = pt.dvector("rates")
+        context = Context({"mu": mu_var})
+
+        expr_apply = modifier.apply(context, rates_var)
+        expr_product = rates_var * modifier.expression(context)
+
+        f_apply = function([mu_var, rates_var], expr_apply)
+        f_product = function([mu_var, rates_var], expr_product)
+
+        np.testing.assert_allclose(
+            f_apply(2.0, [10.0, 20.0]), f_product(2.0, [10.0, 20.0])
+        )
+        np.testing.assert_allclose(
+            f_apply(0.5, [10.0, 20.0]), f_product(0.5, [10.0, 20.0])
+        )
+
+    def test_normsys_apply_equals_rates_times_expression(self):
+        """apply(ctx, rates) must equal rates * expression(ctx) for NormSysModifier."""
+        modifier = NormSysModifier(
+            name="alpha", parameter="alpha", data={"hi": 1.2, "lo": 0.8}
+        )
+
+        alpha_var = pt.dscalar("alpha")
+        rates_var = pt.dvector("rates")
+        context = Context({"alpha": alpha_var})
+
+        expr_apply = modifier.apply(context, rates_var)
+        expr_product = rates_var * modifier.expression(context)
+
+        f_apply = function([alpha_var, rates_var], expr_apply)
+        f_product = function([alpha_var, rates_var], expr_product)
+
+        np.testing.assert_allclose(
+            f_apply(0.5, [10.0, 20.0]), f_product(0.5, [10.0, 20.0])
+        )
+        np.testing.assert_allclose(
+            f_apply(-0.5, [10.0, 20.0]), f_product(-0.5, [10.0, 20.0])
+        )
+        np.testing.assert_allclose(
+            f_apply(0.0, [10.0, 20.0]), f_product(0.0, [10.0, 20.0])
+        )
+
+    def test_shapefactor_apply_equals_rates_times_expression(self):
+        """apply(ctx, rates) must equal rates * expression(ctx) for ShapeFactorModifier."""
+        modifier = ShapeFactorModifier(name="gamma", parameters=["gamma_0", "gamma_1"])
+
+        g0 = pt.dscalar("gamma_0")
+        g1 = pt.dscalar("gamma_1")
+        rates_var = pt.dvector("rates")
+        context = Context({"gamma_0": g0, "gamma_1": g1})
+
+        expr_apply = modifier.apply(context, rates_var)
+        expr_product = rates_var * modifier.expression(context)
+
+        f_apply = function([g0, g1, rates_var], expr_apply)
+        f_product = function([g0, g1, rates_var], expr_product)
+
+        np.testing.assert_allclose(
+            f_apply(1.2, 0.8, [10.0, 20.0]), f_product(1.2, 0.8, [10.0, 20.0])
+        )
+
+    def test_shapesys_apply_equals_rates_times_expression(self):
+        """apply(ctx, rates) must equal rates * expression(ctx) for ShapeSysModifier."""
+        modifier = ShapeSysModifier(
+            name="staterr",
+            parameters=["gamma_0", "gamma_1"],
+            data={"vals": [0.1, 0.15]},
+        )
+
+        g0 = pt.dscalar("gamma_0")
+        g1 = pt.dscalar("gamma_1")
+        rates_var = pt.dvector("rates")
+        context = Context({"gamma_0": g0, "gamma_1": g1})
+
+        expr_apply = modifier.apply(context, rates_var)
+        expr_product = rates_var * modifier.expression(context)
+
+        f_apply = function([g0, g1, rates_var], expr_apply)
+        f_product = function([g0, g1, rates_var], expr_product)
+
+        np.testing.assert_allclose(
+            f_apply(1.1, 0.9, [10.0, 20.0]), f_product(1.1, 0.9, [10.0, 20.0])
+        )
 
 
 class TestExtendedLikelihoodConstraintDedup:


### PR DESCRIPTION
## Summary

- `NormFactor`, `NormSys`, `ShapeFactor`, and `ShapeSys` modifiers each had `apply()` re-implementing the factor computation already present in `expression()` — now `apply()` simply calls `self.expression()` and multiplies by rates
- Fixes `NormSysModifier.expression()` to use the cached PyTensor constants (`_nominal_factor`, `_hi_factor_tensor`, `_lo_factor_tensor`) built in `model_post_init()` instead of constructing fresh constant nodes on every call
- Adds four characterisation tests that pin the `apply(ctx, rates) == rates * expression(ctx)` contract for all four multiplicative modifier types

## Test plan

- [ ] `pytest tests/test_histfactory.py::TestModifierExpressions` — all 8 tests pass (4 pre-existing + 4 new contract tests)
- [ ] `pytest tests/test_histfactory.py` — full suite passes (49 tests)
- [ ] `pre-commit run --files src/pyhs3/distributions/histfactory/modifiers.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)