### PR TITLE
refactor: Use gauss from pytensor_dist

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -29,6 +29,7 @@ numpy = "*"
 sympy = "*"
 pydantic = "*"
 hist = "*"
+pytensor-distributions = "*"
 
 # pytensor >=2.33 does not exist for win-64 for py310
 [feature.py310]

--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -12,11 +12,12 @@ import math
 from typing import Literal, cast
 
 import pytensor.tensor as pt
+import pytensor_distributions.normal as Normal
 
 from pyhs3.context import Context
 from pyhs3.distributions.core import Distribution
 from pyhs3.typing.aliases import TensorVar
-import pytensor_distributions.normal as Normal
+
 
 class GaussianDist(Distribution):
     r"""
@@ -64,7 +65,11 @@ class GaussianDist(Distribution):
         # )
         # return cast(TensorVar, norm_const * exponent)
 
-        return Normal.pdf(context[self._parameters["x"]],context[self._parameters["mean"]],context[self._parameters["sigma"]])
+        return Normal.pdf(
+            context[self._parameters["x"]],
+            context[self._parameters["mean"]],
+            context[self._parameters["sigma"]],
+        )
 
 
 class UniformDist(Distribution):

--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -16,7 +16,7 @@ import pytensor.tensor as pt
 from pyhs3.context import Context
 from pyhs3.distributions.core import Distribution
 from pyhs3.typing.aliases import TensorVar
-
+import pytensor_distributions.normal as Normal
 
 class GaussianDist(Distribution):
     r"""
@@ -53,16 +53,18 @@ class GaussianDist(Distribution):
             pytensor.tensor.variable.TensorVariable: Symbolic representation of the Gaussian PDF.
         """
         # log.info("parameters: ", parameters)
-        norm_const = 1.0 / (pt.sqrt(2 * math.pi) * context[self._parameters["sigma"]])
-        exponent = pt.exp(
-            -0.5
-            * (
-                (context[self._parameters["x"]] - context[self._parameters["mean"]])
-                / context[self._parameters["sigma"]]
-            )
-            ** 2
-        )
-        return cast(TensorVar, norm_const * exponent)
+        # norm_const = 1.0 / (pt.sqrt(2 * math.pi) * context[self._parameters["sigma"]])
+        # exponent = pt.exp(
+        #     -0.5
+        #     * (
+        #         (context[self._parameters["x"]] - context[self._parameters["mean"]])
+        #         / context[self._parameters["sigma"]]
+        #     )
+        #     ** 2
+        # )
+        # return cast(TensorVar, norm_const * exponent)
+
+        return Normal.pdf(context[self._parameters["x"]],context[self._parameters["mean"]],context[self._parameters["sigma"]])
 
 
 class UniformDist(Distribution):


### PR DESCRIPTION
Ported Gauss distribution from pytensor-distributions to pyhs3. Is this how we want things to be?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal implementation of Gaussian distribution likelihood calculations to utilize optimized library functions. No changes to user-facing functionality or API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scipp-atlas/pyhs3/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->