### PR TITLE
fix: evaluate logpdf in log space to avoid HistFactory underflow

### DIFF
--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -319,6 +319,7 @@ class MixtureDist(Distribution):
     def log_prob_terms(  # pylint: disable=redefined-outer-name
         self,
         expressions: Mapping[str, TensorVar],
+        log_expressions: Mapping[str, TensorVar],
         distributions: Distributions,
     ) -> LogProbTerms:
         """
@@ -346,7 +347,7 @@ class MixtureDist(Distribution):
         Non-extended mixtures contribute the default per-event log(PDF).
         """
         if not self.extended:
-            return super().log_prob_terms(expressions, distributions)
+            return super().log_prob_terms(expressions, log_expressions, distributions)
 
         if self._cached_unnorm_expr is None or self._cached_nu_expr is None:
             msg = (
@@ -406,6 +407,7 @@ class ProductDist(Distribution):
     def log_prob_terms(  # pylint: disable=redefined-outer-name
         self,
         expressions: Mapping[str, TensorVar],
+        log_expressions: Mapping[str, TensorVar],
         distributions: Distributions,
     ) -> LogProbTerms:
         """
@@ -440,13 +442,13 @@ class ProductDist(Distribution):
 
             if is_shape:
                 factor_terms = distributions[factor_name].log_prob_terms(
-                    expressions, distributions
+                    expressions, log_expressions, distributions
                 )
                 terms.per_event.extend(factor_terms.per_event)
                 terms.channel.extend(factor_terms.channel)
                 terms.constraints.update(factor_terms.constraints)
             else:
-                terms.constraints[factor_name] = cast(TensorVar, pt.log(factor_expr))
+                terms.constraints[factor_name] = log_expressions[factor_name]
         return terms
 
 

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -284,7 +284,7 @@ class Distribution(Evaluable, ABC):
 
     def log_prob_terms(
         self,
-        expressions: Mapping[str, TensorVar],
+        _expressions: Mapping[str, TensorVar],
         log_expressions: Mapping[str, TensorVar],
         _distributions: Distributions,
     ) -> LogProbTerms:
@@ -303,11 +303,12 @@ class Distribution(Evaluable, ABC):
         probability-space PDF underflows.
 
         Args:
-            expressions: Compiled symbolic expressions for all distributions,
-                keyed by name (``model.distributions``).
+            _expressions: Compiled symbolic expressions for all distributions,
+                keyed by name (``model.distributions``).  Unused in the base
+                implementation; subclasses may reference it.
             log_expressions: Compiled log-space symbolic expressions for all
                 distributions, keyed by name (``model.log_distributions``).
-            distributions: Distribution objects keyed by name, so composite
+            _distributions: Distribution objects keyed by name, so composite
                 distributions can delegate to their components' hooks.
 
         Returns:

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -285,6 +285,7 @@ class Distribution(Evaluable, ABC):
     def log_prob_terms(
         self,
         expressions: Mapping[str, TensorVar],
+        log_expressions: Mapping[str, TensorVar],
         _distributions: Distributions,
     ) -> LogProbTerms:
         """
@@ -297,15 +298,19 @@ class Distribution(Evaluable, ABC):
         or globally-deduplicated constraint factors
         (:class:`~pyhs3.distributions.ProductDist`).
 
-        Default: a single per-event ``log(PDF)`` term.
+        Default: a single per-event ``log(PDF)`` term sourced from the
+        pre-built log-space expression so it stays finite where the
+        probability-space PDF underflows.
 
         Args:
             expressions: Compiled symbolic expressions for all distributions,
                 keyed by name (``model.distributions``).
+            log_expressions: Compiled log-space symbolic expressions for all
+                distributions, keyed by name (``model.log_distributions``).
             distributions: Distribution objects keyed by name, so composite
                 distributions can delegate to their components' hooks.
 
         Returns:
             LogProbTerms: per-event, per-channel, and constraint contributions.
         """
-        return LogProbTerms(per_event=[pt.log(expressions[self.name])])
+        return LogProbTerms(per_event=[log_expressions[self.name]])

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -136,8 +136,15 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
     # calling both methods for the same context does not rebuild the
     # interpolation-spline/per-bin-modifier subgraph (_compute_expected_rates)
     # and the Poisson log-pmf subgraph (_bin_log_probs) a second time.  This is
-    # a per-instance cache scoped to a single context, matching the caching
-    # pattern used by MixtureDist; it is not safe across differing contexts.
+    # a per-instance cache, and the same HistFactoryDistChannel instance can be
+    # reused across multiple Model builds (e.g. Workspace.model() called more
+    # than once on the same workspace), each supplying its own Context with
+    # fresh parameter tensors.  _cached_context holds the exact Context object
+    # that populated the other two fields; callers must check
+    # `self._cached_context is context` (object identity, not equality) before
+    # trusting them, and refresh all three fields together whenever the cache
+    # is (re)populated.
+    _cached_context: Context | None = PrivateAttr(default=None)
     _cached_expected_rates: TensorVar | None = PrivateAttr(default=None)
     _cached_bin_log_probs: TensorVar | None = PrivateAttr(default=None)
 
@@ -221,6 +228,7 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         # instead of rebuilding it.
         expected_rates = self._compute_expected_rates(context, total_bins)
         self._cached_expected_rates = expected_rates
+        self._cached_context = context
 
         # Build main Poisson model for observed data
         return self._build_main_model(context, expected_rates)
@@ -507,6 +515,7 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         # context instead of rebuilding the Poisson log-pmf expression.
         log_probs = self._bin_log_probs(context, expected_rates)
         self._cached_bin_log_probs = log_probs
+        self._cached_context = context
         # Convert from log probabilities to probabilities
         probs = pt.exp(log_probs)
         main_prob = pt.prod(probs)  # type: ignore[no-untyped-call]
@@ -530,17 +539,26 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         """
         # Reuse the per-bin log-probabilities cached by likelihood() (via
         # _build_main_model) for the same context, if available, to avoid
-        # rebuilding the expected-rates and Poisson log-pmf subgraphs.
-        if self._cached_bin_log_probs is not None:
+        # rebuilding the expected-rates and Poisson log-pmf subgraphs.  Only
+        # trust the cache when it was populated by this exact context object
+        # (see _cached_context) -- otherwise rebuild and refresh the cache so
+        # a later call for this context can reuse it.
+        if self._cached_context is context and self._cached_bin_log_probs is not None:
             log_probs = self._cached_bin_log_probs
         else:
             total_bins = self._get_total_bins()
-            expected_rates = (
-                self._cached_expected_rates
-                if self._cached_expected_rates is not None
-                else self._compute_expected_rates(context, total_bins)
-            )
+            if (
+                self._cached_context is context
+                and self._cached_expected_rates is not None
+            ):
+                expected_rates = self._cached_expected_rates
+            else:
+                expected_rates = self._compute_expected_rates(context, total_bins)
+                self._cached_expected_rates = expected_rates
+                self._cached_context = context
             log_probs = self._bin_log_probs(context, expected_rates)
+            self._cached_bin_log_probs = log_probs
+            self._cached_context = context
         return cast(TensorVar, pt.sum(log_probs))  # type: ignore[no-untyped-call]
 
     def log_extended_likelihood(self, context: Context) -> TensorVar:

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -131,6 +131,16 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
     )
     _normalizable: bool = PrivateAttr(default=False)
 
+    # Per-bin Poisson log-probabilities built by likelihood() (via
+    # _build_main_model), reused by log_likelihood() so that a model build
+    # calling both methods for the same context does not rebuild the
+    # interpolation-spline/per-bin-modifier subgraph (_compute_expected_rates)
+    # and the Poisson log-pmf subgraph (_bin_log_probs) a second time.  This is
+    # a per-instance cache scoped to a single context, matching the caching
+    # pattern used by MixtureDist; it is not safe across differing contexts.
+    _cached_expected_rates: TensorVar | None = PrivateAttr(default=None)
+    _cached_bin_log_probs: TensorVar | None = PrivateAttr(default=None)
+
     @model_validator(mode="after")
     def _validate_staterror(self) -> HistFactoryDistChannel:
         total_bins = self.axes.get_total_bins()
@@ -206,8 +216,11 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         # Extract binning information
         total_bins = self._get_total_bins()
 
-        # Process all samples and compute expected rates
+        # Process all samples and compute expected rates.  Cached so
+        # log_likelihood() can reuse this subgraph for the same context
+        # instead of rebuilding it.
         expected_rates = self._compute_expected_rates(context, total_bins)
+        self._cached_expected_rates = expected_rates
 
         # Build main Poisson model for observed data
         return self._build_main_model(context, expected_rates)
@@ -490,7 +503,10 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         Returns:
             PyTensor expression for the Poisson probability (not log probability)
         """
+        # Cached so log_likelihood() can reuse this subgraph for the same
+        # context instead of rebuilding the Poisson log-pmf expression.
         log_probs = self._bin_log_probs(context, expected_rates)
+        self._cached_bin_log_probs = log_probs
         # Convert from log probabilities to probabilities
         probs = pt.exp(log_probs)
         main_prob = pt.prod(probs)  # type: ignore[no-untyped-call]
@@ -512,9 +528,20 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         Returns:
             PyTensor expression for the summed Poisson log-probability.
         """
-        total_bins = self._get_total_bins()
-        expected_rates = self._compute_expected_rates(context, total_bins)
-        return cast(TensorVar, pt.sum(self._bin_log_probs(context, expected_rates)))  # type: ignore[no-untyped-call]
+        # Reuse the per-bin log-probabilities cached by likelihood() (via
+        # _build_main_model) for the same context, if available, to avoid
+        # rebuilding the expected-rates and Poisson log-pmf subgraphs.
+        if self._cached_bin_log_probs is not None:
+            log_probs = self._cached_bin_log_probs
+        else:
+            total_bins = self._get_total_bins()
+            expected_rates = (
+                self._cached_expected_rates
+                if self._cached_expected_rates is not None
+                else self._compute_expected_rates(context, total_bins)
+            )
+            log_probs = self._bin_log_probs(context, expected_rates)
+        return cast(TensorVar, pt.sum(log_probs))  # type: ignore[no-untyped-call]
 
     def log_extended_likelihood(self, context: Context) -> TensorVar:
         """Log-space constraint sum for this channel.

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -453,11 +453,20 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
 
         # Per-bin Poisson log-probability:
         # log P(observed_i | expected_i) = observed_i * log(expected_i) - expected_i - log(observed_i!)
-        return cast(
-            TensorVar,
+        #
+        # Guard against 0 * log(0) = NaN when observed_i == 0 and expected_i == 0.
+        # The Poisson log-pmf for k=0 is just -lambda (since log(0!) = 0), so when
+        # observed == 0 we only need -expected_rates; the full expression is only
+        # needed (and safe) when observed > 0.  When observed > 0 and expected == 0
+        # the result is correctly -inf (P(k>0 | lambda=0) = 0).
+        full = (
             observed_data * pt.log(expected_rates)
             - expected_rates
-            - pt.gammaln(observed_data + 1),
+            - pt.gammaln(observed_data + 1)
+        )
+        return cast(
+            TensorVar,
+            pt.switch(pt.eq(observed_data, 0), -expected_rates, full),
         )
 
     def _build_main_model(

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -431,6 +431,35 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
 
         return cast(TensorVar, rates)
 
+    def _bin_log_probs(self, context: Context, expected_rates: TensorVar) -> TensorVar:
+        r"""Per-bin Poisson log-probabilities for the observed bin counts.
+
+        Observed data must be provided in the context as '{name}_observed' where
+        name is the HistFactory distribution name. This is a required parameter
+        for likelihood evaluation.
+
+        Returns:
+            PyTensor expression for the per-bin Poisson log-probabilities,
+            :math:`\log P(observed_i \mid expected_i)`.
+        """
+        # Observed data is required - no defensive programming needed
+        observed_data_param = f"{self.name}_observed"
+        observed_data = context[observed_data_param]
+
+        # Observables are reshaped to (N, 1) by the model builder for broadcasting.
+        # Flatten to 1-D here so element-wise Poisson matches the (N,) expected_rates.
+        if observed_data.ndim == 2:
+            observed_data = observed_data[:, 0]
+
+        # Per-bin Poisson log-probability:
+        # log P(observed_i | expected_i) = observed_i * log(expected_i) - expected_i - log(observed_i!)
+        return cast(
+            TensorVar,
+            observed_data * pt.log(expected_rates)
+            - expected_rates
+            - pt.gammaln(observed_data + 1),
+        )
+
     def _build_main_model(
         self, context: Context, expected_rates: TensorVar
     ) -> TensorVar:
@@ -444,28 +473,92 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         Returns:
             PyTensor expression for the Poisson probability (not log probability)
         """
-        # Create a Poisson likelihood for the observed bin counts
-        # Observed data is required - no defensive programming needed
-        observed_data_param = f"{self.name}_observed"
-        observed_data = context[observed_data_param]
-
-        # Observables are reshaped to (N, 1) by the model builder for broadcasting.
-        # Flatten to 1-D here so element-wise Poisson matches the (N,) expected_rates.
-        if observed_data.ndim == 2:
-            observed_data = observed_data[:, 0]
-
-        # Build product of individual Poisson probabilities for each bin
-        # P(observed_i | expected_i) = exp(observed_i * log(expected_i) - expected_i - log(observed_i!))
-        log_probs = (
-            observed_data * pt.log(expected_rates)
-            - expected_rates
-            - pt.gammaln(observed_data + 1)
-        )
+        log_probs = self._bin_log_probs(context, expected_rates)
         # Convert from log probabilities to probabilities
         probs = pt.exp(log_probs)
         main_prob = pt.prod(probs)  # type: ignore[no-untyped-call]
 
         return cast(TensorVar, main_prob)
+
+    def log_likelihood(self, context: Context) -> TensorVar:
+        """Log-space main Poisson likelihood: sum of per-bin Poisson log-pmfs.
+
+        This is the log-space counterpart of :meth:`likelihood`.  Returning the
+        sum of per-bin log-probabilities directly avoids the
+        ``log(prod(exp(log_probs)))`` round-trip, whose intermediate product
+        underflows float64 to ``0.0`` for channels with many bins or large
+        expected counts (turning ``log_prob`` into ``-inf``).
+
+        Args:
+            context: Mapping of parameter names to PyTensor variables
+
+        Returns:
+            PyTensor expression for the summed Poisson log-probability.
+        """
+        total_bins = self._get_total_bins()
+        expected_rates = self._compute_expected_rates(context, total_bins)
+        return cast(TensorVar, pt.sum(self._bin_log_probs(context, expected_rates)))  # type: ignore[no-untyped-call]
+
+    def log_extended_likelihood(self, context: Context) -> TensorVar:
+        """Log-space constraint sum for this channel.
+
+        Log-space counterpart of :meth:`extended_likelihood`: returns the sum of
+        ``log(constraint)`` terms (deduped by parameter exactly as in
+        :meth:`extended_likelihood`) instead of their product, avoiding the
+        ``log(prod(...))`` round-trip.
+
+        Args:
+            context: Mapping of parameter names to PyTensor variables
+
+        Returns:
+            PyTensor expression for the summed log-constraint contribution.
+        """
+        seen: set[str] = set()
+        log_constraints: list[TensorVar] = []
+        for dedup_key, modifier, sample_data in self.constraint_specs():
+            # Skip StatErrorModifier in lite mode - constraint built at channel level
+            if self.barlow_beeston_method == "lite" and isinstance(
+                modifier, StatErrorModifier
+            ):
+                continue
+            if dedup_key is not None:
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+            log_constraints.append(
+                pt.log(modifier.make_constraint(context, sample_data))
+            )
+
+        # Add channel-level BB-lite constraint if in lite mode
+        if self.barlow_beeston_method == "lite":
+            lite_constraint = self._make_barlow_beeston_lite_constraint(context)
+            if lite_constraint is not None:
+                log_constraints.append(cast(TensorVar, pt.log(lite_constraint)))
+
+        if not log_constraints:
+            return cast(TensorVar, pt.constant(0.0))
+        return cast(TensorVar, pt.sum(pt.stack(log_constraints)))  # type: ignore[no-untyped-call]
+
+    def log_expression(self, context: Context) -> TensorVar:
+        """Log-probability for the channel: summed Poisson log-pmf + log-constraints.
+
+        Overrides :meth:`Distribution.log_expression` to assemble the channel
+        log-probability directly in log space (sum of per-bin Poisson log-pmfs
+        plus summed log-constraint terms), rather than taking ``log`` of the
+        probability-space :meth:`likelihood`/:meth:`extended_likelihood` product.
+        This keeps the result finite where the probability-space product would
+        underflow to ``0.0``.
+
+        Args:
+            context: Mapping of parameter names to PyTensor variables
+
+        Returns:
+            PyTensor expression for the channel log-probability.
+        """
+        return cast(
+            TensorVar,
+            self.log_likelihood(context) + self.log_extended_likelihood(context),
+        )
 
     def to_hist(self) -> Any:
         """

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -459,8 +459,16 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         # observed == 0 we only need -expected_rates; the full expression is only
         # needed (and safe) when observed > 0.  When observed > 0 and expected == 0
         # the result is correctly -inf (P(k>0 | lambda=0) = 0).
+        #
+        # The log's argument is guarded separately from the switch's output: PyTensor
+        # differentiates both branches of a switch, so the untaken `full` branch still
+        # contributes a gradient of observed/expected_rates = 0/0 = NaN at this point,
+        # and multiplying that NaN by the switch's zero mask does not clear it. Substituting
+        # a nonzero placeholder for expected_rates inside the log (only where observed == 0,
+        # where `full`'s value and gradient are discarded anyway) keeps both finite.
+        safe_rates = pt.switch(pt.eq(observed_data, 0), 1.0, expected_rates)
         full = (
-            observed_data * pt.log(expected_rates)
+            observed_data * pt.log(safe_rates)
             - expected_rates
             - pt.gammaln(observed_data + 1)
         )

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 from __future__ import annotations
 
 import logging

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -127,6 +127,16 @@ class Model:
         # Ordered input names cached alongside _compiled_inputs so that pars()
         # and _reorder_params() avoid rebuilding the list on every pdf/logpdf call.
         self._compiled_input_names: dict[str, list[str]] = {}
+        # Log-space distribution expressions (dist.log_expression(context)), built
+        # alongside self.distributions during graph construction.  logpdf and
+        # log_prob use these to evaluate in log space so that log(prod(exp(...)))
+        # stays collapsed and does not underflow to -inf.  Compiled log functions
+        # are cached separately from the probability-space ones.
+        self.log_distributions: dict[str, TensorVar] = {}
+        self._compiled_log_functions: dict[
+            str, Callable[..., npt.NDArray[np.float64]]
+        ] = {}
+        self._compiled_log_inputs: dict[str, list[TensorVar]] = {}
         self._likelihood = likelihood
         # Views used internally for broadcasting: leaf[:, None] for observables,
         # leaf[None, :] for non-observable vector overrides.  Distributions see
@@ -142,6 +152,11 @@ class Model:
         # so that logpdf() continues to work; log_prob uses this dict to avoid
         # double-counting constraint terms when multiple channels share a parameter.
         self._hfdc_poisson: dict[str, TensorVar] = {}
+        # Log-space counterpart of self._hfdc_poisson: the summed per-bin Poisson
+        # log-pmf for each HFDC channel.  log_prob uses this instead of
+        # log(self._hfdc_poisson[name]) so the joint NLL stays finite where the
+        # probability-space product would underflow.
+        self._hfdc_log_poisson: dict[str, TensorVar] = {}
         # Build dependency graph with proper entity identification
         self._build_dependency_graph(functions, distributions, progress)
 
@@ -267,8 +282,10 @@ class Model:
                 # tracked in https://github.com/scipp-atlas/pyhs3/issues/242
                 # (spec: hep-statistics-serialization-standard issue #93,
                 # export: root-project/root issue #22598).
-                if dist_name in self._hfdc_poisson:
-                    terms.append(pt.log(self._hfdc_poisson[dist_name]))
+                if dist_name in self._hfdc_log_poisson:
+                    # Log-space Poisson term: sum of per-bin log-pmfs, finite even
+                    # where the probability-space product underflows to 0.0.
+                    terms.append(self._hfdc_log_poisson[dist_name])
                 continue
 
             # Resolve weight tensor once for this datum.
@@ -298,7 +315,9 @@ class Model:
             # the channel-dataset pairing and applies event weights, sums
             # over events, and deduplicates constraints globally.
             contrib = self._distribution_objects[dist_name].log_prob_terms(
-                self.distributions, self._distribution_objects
+                self.distributions,
+                self.log_distributions,
+                self._distribution_objects,
             )
 
             # Sum the per-event log-density over events.  Weighted:
@@ -333,11 +352,9 @@ class Model:
         # onto the parameter-scan axis when non-scalar params are present.
         if self._likelihood.aux_distributions:
             terms.extend(
-                pt.log(
-                    self.distributions[
-                        aux_name if isinstance(aux_name, str) else aux_name.name
-                    ]
-                )
+                self.log_distributions[
+                    aux_name if isinstance(aux_name, str) else aux_name.name
+                ]
                 for aux_name in self._likelihood.aux_distributions
             )
 
@@ -470,6 +487,9 @@ class Model:
         """
         dist = distributions[node_name]
         if not isinstance(dist, HistFactoryDistChannel):
+            # Build the log-space expression once for logpdf/log_prob (collapses
+            # log(prod(exp(...))) so it does not underflow to -inf).
+            self.log_distributions[node_name] = dist.log_expression(context)
             return dist.expression(context)
 
         # Build the Poisson term and each constraint factor exactly once, then
@@ -480,6 +500,10 @@ class Model:
         # Poisson subgraph or re-running make_constraint a second time.
         poisson = dist.likelihood(context)
         self._hfdc_poisson[node_name] = poisson
+        # Log-space Poisson-only term (sum of per-bin Poisson log-pmfs).
+        self._hfdc_log_poisson[node_name] = dist.log_likelihood(context)
+        # Full per-channel log expression (Poisson + constraints) for logpdf().
+        self.log_distributions[node_name] = dist.log_expression(context)
 
         # Whether this channel participates in the active likelihood; only then
         # do its constraints feed the joint log_prob.  All channels still build
@@ -665,6 +689,49 @@ class Model:
             )
         return self._compiled_functions[name]
 
+    def _get_compiled_log_function(
+        self, name: str
+    ) -> Callable[..., npt.NDArray[np.float64]]:
+        """
+        Get or create a compiled PyTensor function for a distribution's log-PDF.
+
+        Mirrors :meth:`_get_compiled_function` but compiles the log-space
+        expression (``self.log_distributions[name]``) instead of the
+        probability-space one.  Evaluating in log space keeps
+        ``log(prod(exp(...)))`` collapsed so it does not underflow to ``-inf``
+        for HistFactory channels with many bins or large expected counts.
+
+        Args:
+            name (str): Name of the distribution.
+
+        Returns:
+            Callable: Compiled PyTensor function returning the log-PDF.
+        """
+        if name not in self._compiled_log_functions:
+            log_expression = self.log_distributions[name]
+
+            inputs = [
+                var
+                for var in explicit_graph_inputs([log_expression])
+                if var.name is not None
+            ]
+
+            # Cache the inputs list for consistent ordering.
+            self._compiled_log_inputs[name] = cast(list[TensorVar], inputs)
+
+            self._compiled_log_functions[name] = cast(
+                Callable[..., npt.NDArray[np.float64]],
+                function(
+                    inputs=inputs,
+                    outputs=log_expression,
+                    mode=self.mode,
+                    on_unused_input="ignore",
+                    name=f"log_{name}",
+                    trust_input=True,
+                ),
+            )
+        return self._compiled_log_functions[name]
+
     def pdf_unsafe(
         self,
         name: str,
@@ -758,7 +825,11 @@ class Model:
         Example:
             >>> model.logpdf_unsafe("gauss", x=1.5, mu=0.0, sigma=1.0)  # floats ok  # doctest: +SKIP
         """
-        return np.log(self.pdf_unsafe(name, **parametervalues))
+        # Convert all parameter values to numpy arrays
+        converted_params = {
+            key: ensure_array(value) for key, value in parametervalues.items()
+        }
+        return self.logpdf(name, **converted_params)
 
     def logpdf(
         self, name: str, **parametervalues: npt.NDArray[np.float64]
@@ -768,6 +839,11 @@ class Model:
 
         This method requires all parameter values to be numpy arrays with dtype float64.
         For automatic type conversion, use :meth:`logpdf_unsafe` instead.
+
+        The logarithm is evaluated in log space via a compiled log-PDF function
+        (``log(prod(exp(...)))`` stays collapsed), so the result remains finite
+        for HistFactory channels where the probability-space ``pdf`` underflows
+        to ``0.0``.
 
         Args:
             name (str): Name of the distribution to evaluate.
@@ -787,7 +863,9 @@ class Model:
             >>> import numpy as np
             >>> model.logpdf("gauss", x=np.array(1.5), mu=np.array(0.0), sigma=np.array(1.0))  # doctest: +SKIP
         """
-        return np.log(self.pdf(name, **parametervalues))
+        func = self._get_compiled_log_function(name)
+        positional_values = self._reorder_log_params(name, parametervalues)
+        return func(*positional_values)
 
     def pars(self, name: str) -> list[str]:
         """
@@ -846,6 +924,45 @@ class Model:
             List of values in the correct order for the compiled function
         """
         input_order = self.pars(name)
+        return [params[param_name] for param_name in input_order]
+
+    def log_pars(self, name: str) -> list[str]:
+        """
+        Get the ordered input parameter names for a distribution's log-PDF.
+
+        Like :meth:`pars`, but for the compiled log-PDF function (:meth:`logpdf`).
+        The log-space expression can have a different set or ordering of inputs
+        than the probability-space one, so it has its own cached ordering.
+
+        Args:
+            name: Distribution name
+
+        Returns:
+            List of parameter names in the order expected by logpdf()
+        """
+        if name not in self._compiled_log_inputs:
+            # Trigger compilation to populate cache
+            self._get_compiled_log_function(name)
+        return [
+            var.name for var in self._compiled_log_inputs[name] if var.name is not None
+        ]
+
+    def _reorder_log_params(
+        self,
+        name: str,
+        params: Mapping[str, npt.NDArray[np.float64]],
+    ) -> list[npt.NDArray[np.float64]]:
+        """
+        Reorder parameters to match the input order of a distribution's log-PDF.
+
+        Args:
+            name: Distribution name
+            params: Dictionary of parameter values (numpy arrays)
+
+        Returns:
+            List of values in the correct order for the compiled log function
+        """
+        input_order = self.log_pars(name)
         return [params[param_name] for param_name in input_order]
 
     def visualize_graph(

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -659,6 +659,65 @@ class Model:
 
                 progress_bar.advance(task)
 
+    def _compile_expression(
+        self,
+        name: str,
+        expressions: dict[str, TensorVar],
+        compiled_functions: dict[str, Callable[..., npt.NDArray[np.float64]]],
+        compiled_inputs: dict[str, list[TensorVar]],
+        compiled_input_names: dict[str, list[str]],
+        fn_name: str,
+    ) -> Callable[..., npt.NDArray[np.float64]]:
+        """
+        Get or create a compiled PyTensor function for an expression dict entry.
+
+        Shared by :meth:`_get_compiled_function` and
+        :meth:`_get_compiled_log_function`, which differ only in which
+        expression dict (probability-space or log-space) they compile from
+        and which cache dicts they read and populate.
+
+        Args:
+            name (str): Key into ``expressions`` and the cache dicts.
+            expressions: Distribution expressions to compile from
+                (``self.distributions`` or ``self.log_distributions``).
+            compiled_functions: Cache of compiled functions to read and populate.
+            compiled_inputs: Cache of ordered input variables to populate.
+            compiled_input_names: Cache of ordered input names to populate.
+            fn_name (str): Name to give the compiled PyTensor function.
+
+        Returns:
+            Callable: Compiled PyTensor function.
+        """
+        if name not in compiled_functions:
+            expression = expressions[name]
+
+            inputs = [
+                var
+                for var in explicit_graph_inputs([expression])
+                if var.name is not None
+            ]
+
+            # Cache the inputs list (and their names) for consistent ordering so
+            # pars()/log_pars() and _reorder_params()/_reorder_log_params() don't
+            # rebuild the name list per evaluation.
+            compiled_inputs[name] = cast(list[TensorVar], inputs)
+            compiled_input_names[name] = [
+                var.name for var in inputs if var.name is not None
+            ]
+
+            compiled_functions[name] = cast(
+                Callable[..., npt.NDArray[np.float64]],
+                function(
+                    inputs=inputs,
+                    outputs=expression,
+                    mode=self.mode,
+                    on_unused_input="ignore",
+                    name=fn_name,
+                    trust_input=True,
+                ),
+            )
+        return compiled_functions[name]
+
     def _get_compiled_function(
         self, name: str
     ) -> Callable[..., npt.NDArray[np.float64]]:
@@ -674,38 +733,14 @@ class Model:
         Returns:
             Callable: Compiled PyTensor function.
         """
-        if name not in self._compiled_functions:
-            # Get the distribution expression (already includes extended_likelihood)
-            dist_expression = self.distributions[name]
-
-            inputs = [
-                var
-                for var in explicit_graph_inputs([dist_expression])
-                if var.name is not None
-            ]
-
-            # Cache the inputs list (and their names) for consistent ordering so
-            # pars()/_reorder_params don't rebuild the name list per evaluation.
-            self._compiled_inputs[name] = cast(list[TensorVar], inputs)
-            self._compiled_input_names[name] = [
-                var.name for var in inputs if var.name is not None
-            ]
-
-            # Use the specified PyTensor mode
-            compilation_mode = self.mode
-
-            self._compiled_functions[name] = cast(
-                Callable[..., npt.NDArray[np.float64]],
-                function(
-                    inputs=inputs,
-                    outputs=dist_expression,
-                    mode=compilation_mode,
-                    on_unused_input="ignore",
-                    name=name,
-                    trust_input=True,
-                ),
-            )
-        return self._compiled_functions[name]
+        return self._compile_expression(
+            name,
+            self.distributions,
+            self._compiled_functions,
+            self._compiled_inputs,
+            self._compiled_input_names,
+            name,
+        )
 
     def _get_compiled_log_function(
         self, name: str
@@ -725,34 +760,14 @@ class Model:
         Returns:
             Callable: Compiled PyTensor function returning the log-PDF.
         """
-        if name not in self._compiled_log_functions:
-            log_expression = self.log_distributions[name]
-
-            inputs = [
-                var
-                for var in explicit_graph_inputs([log_expression])
-                if var.name is not None
-            ]
-
-            # Cache the inputs list and their names for consistent ordering so
-            # log_pars()/_reorder_log_params() don't rebuild the name list per call.
-            self._compiled_log_inputs[name] = cast(list[TensorVar], inputs)
-            self._compiled_log_input_names[name] = [
-                var.name for var in inputs if var.name is not None
-            ]
-
-            self._compiled_log_functions[name] = cast(
-                Callable[..., npt.NDArray[np.float64]],
-                function(
-                    inputs=inputs,
-                    outputs=log_expression,
-                    mode=self.mode,
-                    on_unused_input="ignore",
-                    name=f"log_{name}",
-                    trust_input=True,
-                ),
-            )
-        return self._compiled_log_functions[name]
+        return self._compile_expression(
+            name,
+            self.log_distributions,
+            self._compiled_log_functions,
+            self._compiled_log_inputs,
+            self._compiled_log_input_names,
+            f"log_{name}",
+        )
 
     def pdf_unsafe(
         self,
@@ -889,6 +904,34 @@ class Model:
         positional_values = self._reorder_log_params(name, parametervalues)
         return func(*positional_values)
 
+    def _get_pars(
+        self,
+        name: str,
+        compiled_input_names: dict[str, list[str]],
+        compile_fn: Callable[[str], Callable[..., npt.NDArray[np.float64]]],
+    ) -> list[str]:
+        """
+        Get the ordered input parameter names, compiling to populate the cache
+        if needed.
+
+        Shared by :meth:`pars` and :meth:`log_pars`, which differ only in
+        which cache dict and which compilation method populate it.
+
+        Args:
+            name: Distribution name
+            compiled_input_names: Cache of ordered input names to read/populate
+                (``self._compiled_input_names`` or ``self._compiled_log_input_names``).
+            compile_fn: Compilation method to call to populate the cache
+                (:meth:`_get_compiled_function` or :meth:`_get_compiled_log_function`).
+
+        Returns:
+            List of parameter names in the cached order
+        """
+        if name not in compiled_input_names:
+            # Trigger compilation to populate cache
+            compile_fn(name)
+        return compiled_input_names[name]
+
     def pars(self, name: str) -> list[str]:
         """
         Get the ordered list of input parameter names for a distribution.
@@ -907,10 +950,9 @@ class Model:
             >>> model.pars("model_singlechannel") # doctest: +SKIP
             ['uncorr_bkguncrt_1', 'uncorr_bkguncrt_0', 'model_singlechannel_observed', 'mu', 'Lumi']
         """
-        if name not in self._compiled_input_names:
-            # Trigger compilation to populate cache
-            self._get_compiled_function(name)
-        return self._compiled_input_names[name]
+        return self._get_pars(
+            name, self._compiled_input_names, self._get_compiled_function
+        )
 
     def parsort(self, name: str, names: list[str]) -> list[int]:
         """
@@ -930,6 +972,30 @@ class Model:
         """
         return [names.index(par) for par in self.pars(name)]
 
+    def _reorder_by_pars(
+        self,
+        name: str,
+        params: Mapping[str, npt.NDArray[np.float64]],
+        pars_fn: Callable[[str], list[str]],
+    ) -> list[npt.NDArray[np.float64]]:
+        """
+        Reorder parameters to match an input order.
+
+        Shared by :meth:`_reorder_params` and :meth:`_reorder_log_params`,
+        which differ only in which method supplies the input order.
+
+        Args:
+            name: Distribution name
+            params: Dictionary of parameter values (numpy arrays)
+            pars_fn: Method supplying the ordered input names (:meth:`pars`
+                or :meth:`log_pars`).
+
+        Returns:
+            List of values in the order given by ``pars_fn``
+        """
+        input_order = pars_fn(name)
+        return [params[param_name] for param_name in input_order]
+
     def _reorder_params(
         self,
         name: str,
@@ -945,8 +1011,7 @@ class Model:
         Returns:
             List of values in the correct order for the compiled function
         """
-        input_order = self.pars(name)
-        return [params[param_name] for param_name in input_order]
+        return self._reorder_by_pars(name, params, self.pars)
 
     def log_pars(self, name: str) -> list[str]:
         """
@@ -962,10 +1027,9 @@ class Model:
         Returns:
             List of parameter names in the order expected by logpdf()
         """
-        if name not in self._compiled_log_input_names:
-            # Trigger compilation to populate cache
-            self._get_compiled_log_function(name)
-        return self._compiled_log_input_names[name]
+        return self._get_pars(
+            name, self._compiled_log_input_names, self._get_compiled_log_function
+        )
 
     def _reorder_log_params(
         self,
@@ -982,8 +1046,7 @@ class Model:
         Returns:
             List of values in the correct order for the compiled log function
         """
-        input_order = self.log_pars(name)
-        return [params[param_name] for param_name in input_order]
+        return self._reorder_by_pars(name, params, self.log_pars)
 
     def visualize_graph(
         self,

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -498,17 +498,18 @@ class Model:
             return dist.expression(context)
 
         # Build the Poisson term and each constraint factor exactly once, then
-        # assemble both the model-level deduped constraint list and the full
-        # per-channel expression from those shared pieces.  This mirrors
-        # Distribution._expression (likelihood -> normalization -> x constraints)
-        # and HistFactoryDistChannel.extended_likelihood without rebuilding the
-        # Poisson subgraph or re-running make_constraint a second time.
+        # assemble the model-level deduped constraint list and both the
+        # probability-space and log-space per-channel expressions from those
+        # shared pieces.  This mirrors Distribution._expression/log_expression
+        # (likelihood -> normalization -> x/+ constraints) and
+        # HistFactoryDistChannel.extended_likelihood/log_extended_likelihood
+        # without rebuilding the Poisson subgraph or re-running make_constraint
+        # a second time.
         poisson = dist.likelihood(context)
         self._hfdc_poisson[node_name] = poisson
         # Log-space Poisson-only term (sum of per-bin Poisson log-pmfs).
-        self._hfdc_log_poisson[node_name] = dist.log_likelihood(context)
-        # Full per-channel log expression (Poisson + constraints) for logpdf().
-        self.log_distributions[node_name] = dist.log_expression(context)
+        log_poisson = dist.log_likelihood(context)
+        self._hfdc_log_poisson[node_name] = log_poisson
 
         # Whether this channel participates in the active likelihood; only then
         # do its constraints feed the joint log_prob.  All channels still build
@@ -546,13 +547,25 @@ class Model:
         raw = dist._apply_normalization(poisson, context)  # pylint: disable=protected-access
         if not channel_constraints:
             extended: TensorVar = cast(TensorVar, pt.constant(1.0))
+            log_extended: TensorVar = cast(TensorVar, pt.constant(0.0))
         else:
             extended = cast(
                 TensorVar,
                 pt.prod(pt.stack(channel_constraints)),  # type: ignore[no-untyped-call]
             )
+            log_extended = cast(
+                TensorVar,
+                pt.sum(pt.stack([pt.log(c) for c in channel_constraints])),  # type: ignore[no-untyped-call]
+            )
         full = cast(TensorVar, raw * extended)
         full.name = dist.name  # Evaluable.expression sets the name
+
+        # Full per-channel log expression (Poisson + constraints) for logpdf(),
+        # assembled from the pieces built above (mirrors
+        # HistFactoryDistChannel.log_expression) instead of calling
+        # dist.log_expression(context), which would rebuild log_poisson and
+        # re-run make_constraint for every spec.
+        self.log_distributions[node_name] = cast(TensorVar, log_poisson + log_extended)
         return full
 
     def _build_dependency_graph(

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -138,6 +138,10 @@ class Model:
             str, Callable[..., npt.NDArray[np.float64]]
         ] = {}
         self._compiled_log_inputs: dict[str, list[TensorVar]] = {}
+        # Ordered log-input names cached alongside _compiled_log_inputs, mirroring
+        # _compiled_input_names for the prob-space path so log_pars() avoids
+        # rebuilding the list via a comprehension on every logpdf call.
+        self._compiled_log_input_names: dict[str, list[str]] = {}
         self._likelihood = likelihood
         # Views used internally for broadcasting: leaf[:, None] for observables,
         # leaf[None, :] for non-observable vector overrides.  Distributions see
@@ -717,8 +721,12 @@ class Model:
                 if var.name is not None
             ]
 
-            # Cache the inputs list for consistent ordering.
+            # Cache the inputs list and their names for consistent ordering so
+            # log_pars()/_reorder_log_params() don't rebuild the name list per call.
             self._compiled_log_inputs[name] = cast(list[TensorVar], inputs)
+            self._compiled_log_input_names[name] = [
+                var.name for var in inputs if var.name is not None
+            ]
 
             self._compiled_log_functions[name] = cast(
                 Callable[..., npt.NDArray[np.float64]],
@@ -941,12 +949,10 @@ class Model:
         Returns:
             List of parameter names in the order expected by logpdf()
         """
-        if name not in self._compiled_log_inputs:
+        if name not in self._compiled_log_input_names:
             # Trigger compilation to populate cache
             self._get_compiled_log_function(name)
-        return [
-            var.name for var in self._compiled_log_inputs[name] if var.name is not None
-        ]
+        return self._compiled_log_input_names[name]
 
     def _reorder_log_params(
         self,

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -88,7 +88,11 @@ class TestDistribution:
                 return pt.constant(0.5)
 
         dist = TestDist(name="test", type="test")
-        terms = dist.log_prob_terms({"test": pt.constant(0.5)}, Distributions([]))
+        terms = dist.log_prob_terms(
+            {"test": pt.constant(0.5)},
+            {"test": pt.constant(np.log(0.5))},
+            Distributions([]),
+        )
 
         assert len(terms.per_event) == 1
         assert terms.channel == []
@@ -124,6 +128,10 @@ class TestProductDist:
             "shape": pt.exp(-x),
             "constr": pt.exp(-(alpha**2)),
         }
+        log_expressions = {
+            "shape": -x,
+            "constr": -(alpha**2),
+        }
         distributions = Distributions(
             [
                 GaussianDist(name="shape", x="x", mean=0.0, sigma=1.0),
@@ -131,7 +139,7 @@ class TestProductDist:
             ]
         )
 
-        terms = dist.log_prob_terms(expressions, distributions)
+        terms = dist.log_prob_terms(expressions, log_expressions, distributions)
 
         assert len(terms.per_event) == 1
         assert terms.channel == []
@@ -165,11 +173,15 @@ class TestProductDist:
             "mix": mix_expr,
             "constr": pt.exp(-(alpha**2)),
         }
+        log_expressions = {
+            "mix": pt.log(mix_expr),
+            "constr": -(alpha**2),
+        }
         distributions = Distributions(
             [mix, GaussianDist(name="constr", x="alpha", mean=0.0, sigma=1.0)]
         )
 
-        terms = dist.log_prob_terms(expressions, distributions)
+        terms = dist.log_prob_terms(expressions, log_expressions, distributions)
 
         assert len(terms.per_event) == 1
         assert len(terms.channel) == 1
@@ -2972,7 +2984,7 @@ class TestMixtureDist:
         }
         dist.likelihood(context)
 
-        terms = dist.log_prob_terms({}, Distributions([]))
+        terms = dist.log_prob_terms({}, {}, Distributions([]))
 
         assert len(terms.per_event) == 1
         assert len(terms.channel) == 1
@@ -2992,7 +3004,7 @@ class TestMixtureDist:
             extended=True,
         )
         with pytest.raises(RuntimeError, match="likelihood"):
-            dist.log_prob_terms({}, Distributions([]))
+            dist.log_prob_terms({}, {}, Distributions([]))
 
     def test_mixture_dist_log_prob_terms_non_extended_uses_default(self):
         """Non-extended mixture falls back to the base log(PDF) contribution."""
@@ -3002,7 +3014,11 @@ class TestMixtureDist:
             coefficients=["coeff1"],
             extended=False,
         )
-        terms = dist.log_prob_terms({"mix": pt.constant(0.7)}, Distributions([]))
+        terms = dist.log_prob_terms(
+            {"mix": pt.constant(0.7)},
+            {"mix": pt.constant(np.log(0.7))},
+            Distributions([]),
+        )
 
         assert len(terms.per_event) == 1
         assert terms.channel == []

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -295,6 +295,37 @@ class TestConstraintModifiers:
         val = float(fn(0.0))
         assert abs(val - (-0.5 * math.log(2 * math.pi))) < 1e-9
 
+    def test_log_extended_likelihood_empty_constraints_is_zero(self):
+        """A channel with no constrained modifiers returns exactly 0.0.
+
+        Covers the early-return branch in log_extended_likelihood taken when
+        constraint_specs() yields nothing and BB-lite is not active — e.g. a
+        channel whose only modifier is an unconstrained normfactor. Also checks
+        that log_expression reduces to log_likelihood alone in this case.
+        """
+        dist = HistFactoryDistChannel(
+            **_make_channel(
+                "ch",
+                [10.0, 20.0],
+                [{"name": "mu", "type": "normfactor", "parameter": "mu"}],
+            )
+        )
+        mu = pt.dscalar("mu")
+        observed = pt.constant(np.array([10.0, 20.0]))
+        context = Context({"mu": mu, "ch_observed": observed})
+
+        expr = dist.log_extended_likelihood(context)
+        # expr does not depend on mu (there are no constrained modifiers to
+        # tie mu's value to the graph).
+        fn = pytensor.function([mu], expr, on_unused_input="ignore")
+        assert fn(1.0) == 0.0
+
+        log_lik = dist.log_likelihood(context)
+        log_expr = dist.log_expression(context)
+        fn_expr = pytensor.function([mu], [log_lik, log_expr])
+        lik_val, expr_val = fn_expr(1.0)
+        assert expr_val == pytest.approx(lik_val)
+
 
 # ---------------------------------------------------------------------------
 # Unit tests: Model._try_bake_hfdc_observed

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -540,24 +540,7 @@ class TestHFDCSubgraphBuildCounts:
 
         monkeypatch.setattr(HistFactoryDistChannel, "_compute_expected_rates", counted)
 
-        ws = _simple_workspace(
-            channels=[
-                _make_channel(
-                    "SR",
-                    [10.0],
-                    [
-                        {
-                            "name": "lumi",
-                            "type": "normsys",
-                            "parameter": "lumi",
-                            "constraint": "Gauss",
-                            "data": {"hi": 1.05, "lo": 0.95},
-                        }
-                    ],
-                )
-            ],
-            params=[{"name": "lumi", "value": 0.0}],
-        )
+        ws = _single_channel_normsys_workspace()
         likelihood = next(iter(ws.likelihoods))
         ws.model(likelihood, progress=False)
 
@@ -580,24 +563,7 @@ class TestHFDCSubgraphBuildCounts:
 
         monkeypatch.setattr(SingleParamConstraint, "make_constraint", counted)
 
-        ws = _simple_workspace(
-            channels=[
-                _make_channel(
-                    "SR",
-                    [10.0],
-                    [
-                        {
-                            "name": "lumi",
-                            "type": "normsys",
-                            "parameter": "lumi",
-                            "constraint": "Gauss",
-                            "data": {"hi": 1.05, "lo": 0.95},
-                        }
-                    ],
-                )
-            ],
-            params=[{"name": "lumi", "value": 0.0}],
-        )
+        ws = _single_channel_normsys_workspace()
         likelihood = next(iter(ws.likelihoods))
         ws.model(likelihood, progress=False)
 
@@ -609,24 +575,7 @@ class TestHFDCSubgraphBuildCounts:
         """logpdf(channel) must equal log(pdf(channel)) for an HFDC channel with
         a constraint modifier, confirming log_distributions is assembled from
         the same pieces as the probability-space expression."""
-        ws = _simple_workspace(
-            channels=[
-                _make_channel(
-                    "SR",
-                    [10.0],
-                    [
-                        {
-                            "name": "lumi",
-                            "type": "normsys",
-                            "parameter": "lumi",
-                            "constraint": "Gauss",
-                            "data": {"hi": 1.05, "lo": 0.95},
-                        }
-                    ],
-                )
-            ],
-            params=[{"name": "lumi", "value": 0.0}],
-        )
+        ws = _single_channel_normsys_workspace()
         likelihood = next(iter(ws.likelihoods))
         model = ws.model(likelihood, progress=False)
 

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -16,8 +16,10 @@ import types
 
 import numpy as np
 import pytensor
+import pytensor.tensor as pt
 import pytest
 
+from pyhs3.context import Context
 from pyhs3.data import BinnedData, Data, UnbinnedData
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
 from pyhs3.distributions.histfactory.modifiers import (
@@ -245,6 +247,52 @@ class TestConstraintModifiers:
         keys = [key for key, _, _ in specs]
         # Both specs have the same dedup_key; callers apply the seen-set dedup.
         assert keys == ["lumi", "lumi"]
+
+    def test_log_extended_likelihood_dedups_shared_parameter(self):
+        """Two samples sharing a normsys parameter contribute one log-constraint.
+
+        Mirrors the spec-level test above: log_extended_likelihood must apply
+        the seen-set dedup, so the shared Gaussian constraint appears once
+        (log N(0|0,1) = -0.5*log(2*pi)), not twice.
+        """
+        dist = HistFactoryDistChannel(
+            name="ch",
+            axes=[{"name": "x", "min": 0.0, "max": 10.0, "nbins": 1}],
+            samples=[
+                {
+                    "name": "sig",
+                    "data": {"contents": [10.0], "errors": [1.0]},
+                    "modifiers": [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                },
+                {
+                    "name": "bkg",
+                    "data": {"contents": [5.0], "errors": [1.0]},
+                    "modifiers": [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                },
+            ],
+        )
+        lumi = pt.dscalar("lumi")
+        context = Context({"lumi": lumi})
+        expr = dist.log_extended_likelihood(context)
+        fn = pytensor.function([lumi], expr)
+        val = float(fn(0.0))
+        assert abs(val - (-0.5 * math.log(2 * math.pi))) < 1e-9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -686,6 +686,58 @@ class TestHFDCContextGuardedCache:
         assert fresh_lumi in inputs
         assert fresh_observed in inputs
 
+    def test_log_likelihood_reuses_cached_expected_rates_after_bin_log_probs_failure(
+        self, monkeypatch
+    ):
+        """A fresh instance's first ``log_likelihood`` call can populate
+        ``_cached_expected_rates``/``_cached_context`` and then still fail:
+        ``_compute_expected_rates`` only needs ``lumi``, so it succeeds and
+        populates the cache, but ``_bin_log_probs`` then raises because
+        ``SR_observed`` is missing from the context, so ``_cached_bin_log_probs``
+        is never set. A second call for the *same* context object -- once the
+        missing observed data is added in place via ``Context.add_parameter``
+        -- fails the outer cache check (``_cached_bin_log_probs`` is still
+        ``None``) but passes the inner one (``_cached_context is context`` and
+        ``_cached_expected_rates is not None``), so the cached expected rates
+        are reused instead of recomputed.
+        """
+        calls: list[str] = []
+        original = HistFactoryDistChannel._compute_expected_rates
+
+        def counted(
+            self: HistFactoryDistChannel, context: Context, total_bins: int
+        ) -> object:
+            calls.append(self.name)
+            return original(self, context, total_bins)
+
+        monkeypatch.setattr(HistFactoryDistChannel, "_compute_expected_rates", counted)
+
+        ws = _single_channel_normsys_workspace()
+        dist = next(iter(ws.distributions))
+
+        lumi = pt.dscalar("lumi")
+        context = Context({"lumi": lumi})
+
+        # First call: _compute_expected_rates succeeds and populates the cache,
+        # but _bin_log_probs raises because "SR_observed" is missing.
+        with pytest.raises(KeyError, match="SR_observed"):
+            dist.log_likelihood(context)
+        assert calls == ["SR"]
+
+        # Add the missing observed data to the SAME context object in place.
+        observed = pt.dvector("SR_observed")
+        context.add_parameter("SR_observed", observed)
+
+        expr = dist.log_likelihood(context)
+        # _compute_expected_rates was not called again -- the cached expected
+        # rates from the first call were reused.
+        assert calls == ["SR"]
+
+        fn = pytensor.function([lumi, observed], expr)
+        val = float(fn(0.0, np.array([10.0])))
+        expected = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        assert val == pytest.approx(expected, rel=1e-10)
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: constraint deduplication across channels

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -26,6 +26,7 @@ from pyhs3.distributions.histfactory.modifiers import (
     HasConstraint,
     ParameterModifier,
     ParametersModifier,
+    SingleParamConstraint,
 )
 from pyhs3.domains import Domains, ProductDomain
 from pyhs3.exceptions import WorkspaceValidationError
@@ -449,6 +450,137 @@ class TestHFDCLogProb:
         gauss_lp = -0.5 * math.log(2 * math.pi)
         expected = poisson_lp + gauss_lp
         assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: HFDC subgraphs are each built exactly once
+# ---------------------------------------------------------------------------
+
+
+class TestHFDCSubgraphBuildCounts:
+    """Model construction must build each HFDC subgraph exactly once.
+
+    ``_build_distribution_node`` previously called ``dist.likelihood(context)``,
+    ``dist.log_likelihood(context)``, and ``dist.log_expression(context)`` for
+    the same context; the last call internally re-ran ``log_likelihood`` (which
+    recomputes expected_rates) and ``log_extended_likelihood`` (which reruns
+    ``make_constraint`` for every constraint spec), duplicating work already
+    done for the probability-space expression and the constraint loop below it.
+    """
+
+    def test_compute_expected_rates_called_once_per_channel(self, monkeypatch):
+        """``_compute_expected_rates`` must build the expected-rates subgraph
+        exactly once per channel during model construction."""
+        calls: list[str] = []
+        original = HistFactoryDistChannel._compute_expected_rates
+
+        def counted(
+            self: HistFactoryDistChannel, context: Context, total_bins: int
+        ) -> object:
+            calls.append(self.name)
+            return original(self, context, total_bins)
+
+        monkeypatch.setattr(HistFactoryDistChannel, "_compute_expected_rates", counted)
+
+        ws = _simple_workspace(
+            channels=[
+                _make_channel(
+                    "SR",
+                    [10.0],
+                    [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                )
+            ],
+            params=[{"name": "lumi", "value": 0.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        ws.model(likelihood, progress=False)
+
+        assert calls == ["SR"], (
+            f"expected exactly one _compute_expected_rates call per channel, got {calls}"
+        )
+
+    def test_make_constraint_called_once_per_spec(self, monkeypatch):
+        """``make_constraint`` must build each constraint factor exactly once
+        during model construction, regardless of how many places (probability-space
+        expression, log-space expression, joint log_prob) reuse the result."""
+        calls: list[str] = []
+        original = SingleParamConstraint.make_constraint
+
+        def counted(
+            self: SingleParamConstraint, context: Context, sample_data: object
+        ) -> object:
+            calls.append(self.name)
+            return original(self, context, sample_data)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(SingleParamConstraint, "make_constraint", counted)
+
+        ws = _simple_workspace(
+            channels=[
+                _make_channel(
+                    "SR",
+                    [10.0],
+                    [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                )
+            ],
+            params=[{"name": "lumi", "value": 0.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        ws.model(likelihood, progress=False)
+
+        assert calls == ["lumi"], (
+            f"expected exactly one make_constraint call per constraint spec, got {calls}"
+        )
+
+    def test_logpdf_matches_log_pdf_for_hfdc_with_constraint(self):
+        """logpdf(channel) must equal log(pdf(channel)) for an HFDC channel with
+        a constraint modifier, confirming log_distributions is assembled from
+        the same pieces as the probability-space expression."""
+        ws = _simple_workspace(
+            channels=[
+                _make_channel(
+                    "SR",
+                    [10.0],
+                    [
+                        {
+                            "name": "lumi",
+                            "type": "normsys",
+                            "parameter": "lumi",
+                            "constraint": "Gauss",
+                            "data": {"hi": 1.05, "lo": 0.95},
+                        }
+                    ],
+                )
+            ],
+            params=[{"name": "lumi", "value": 0.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+
+        pdf_val = float(
+            np.asarray(model.pdf_unsafe("SR", lumi=0.1, SR_observed=np.array([10.0])))
+        )
+        logpdf_val = float(
+            np.asarray(
+                model.logpdf_unsafe("SR", lumi=0.1, SR_observed=np.array([10.0]))
+            )
+        )
+        assert logpdf_val == pytest.approx(math.log(pdf_val), rel=1e-10)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -488,6 +488,33 @@ class TestHFDCLogProb:
 # ---------------------------------------------------------------------------
 
 
+def _single_channel_normsys_workspace() -> Workspace:
+    """Single-channel HFDC workspace with one normsys constraint on ``lumi``.
+
+    Shared setup for the HFDC subgraph-build-count regression tests and the
+    per-instance cache context-guard test below, all of which only need this
+    minimal single-parameter-constraint channel.
+    """
+    return _simple_workspace(
+        channels=[
+            _make_channel(
+                "SR",
+                [10.0],
+                [
+                    {
+                        "name": "lumi",
+                        "type": "normsys",
+                        "parameter": "lumi",
+                        "constraint": "Gauss",
+                        "data": {"hi": 1.05, "lo": 0.95},
+                    }
+                ],
+            )
+        ],
+        params=[{"name": "lumi", "value": 0.0}],
+    )
+
+
 class TestHFDCSubgraphBuildCounts:
     """Model construction must build each HFDC subgraph exactly once.
 
@@ -612,6 +639,103 @@ class TestHFDCSubgraphBuildCounts:
             )
         )
         assert logpdf_val == pytest.approx(math.log(pdf_val), rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: per-instance HFDC caches must be tied to their context
+# ---------------------------------------------------------------------------
+
+
+class TestHFDCContextGuardedCache:
+    """``_cached_expected_rates``/``_cached_bin_log_probs`` must only be reused
+    for the exact :class:`Context` object that populated them.
+
+    ``Workspace.model()`` passes the same ``HistFactoryDistChannel`` instances
+    into every ``Model`` built from that workspace (distributions are not
+    copied), and each ``Model`` build supplies its own fresh ``Context`` with
+    new parameter tensors.  ``likelihood()``/``log_likelihood()`` happen to be
+    called back-to-back for the same context during a single ``Model`` build,
+    which masks the problem when driven only through ``Workspace.model()`` +
+    ``Model.logpdf()`` -- both builds still evaluate correctly because each
+    build unconditionally repopulates the cache with its own context right
+    before reading it back.  But ``log_likelihood()`` (and ``log_expression()``,
+    which calls it) are public methods that can be invoked directly for any
+    context, and a shared instance's cache does not know which context it was
+    last built for -- so a direct call for a context that never populated the
+    cache must not silently reuse a previous build's stale graph.
+    """
+
+    def test_two_model_builds_still_evaluate_correctly(self):
+        """Sanity check: both Model builds, and re-evaluating the first after
+        the second is built, must all match the analytic Poisson+Gaussian
+        expectation (the cache-overwrite direction already works)."""
+        ws = _single_channel_normsys_workspace()
+        likelihood = next(iter(ws.likelihoods))
+
+        poisson_lp = 10.0 * math.log(10.0) - 10.0 - math.lgamma(11.0)
+        gauss_lp = -0.5 * math.log(2 * math.pi)
+        expected = poisson_lp + gauss_lp
+
+        model1 = ws.model(likelihood, progress=False)
+        val1 = float(
+            np.asarray(
+                model1.logpdf_unsafe("SR", lumi=0.0, SR_observed=np.array([10.0]))
+            )
+        )
+        assert val1 == pytest.approx(expected, rel=1e-10)
+
+        model2 = ws.model(likelihood, progress=False)
+        val2 = float(
+            np.asarray(
+                model2.logpdf_unsafe("SR", lumi=0.0, SR_observed=np.array([10.0]))
+            )
+        )
+        assert val2 == pytest.approx(expected, rel=1e-10)
+
+        # model1 must still work correctly after model2's build has mutated
+        # the shared distribution instance's cache.
+        val1_again = float(
+            np.asarray(
+                model1.logpdf_unsafe("SR", lumi=0.0, SR_observed=np.array([10.0]))
+            )
+        )
+        assert val1_again == pytest.approx(expected, rel=1e-10)
+
+    def test_log_likelihood_rebuilds_for_a_context_that_never_populated_the_cache(self):
+        """Calling ``log_likelihood`` directly for a fresh, unpaired context must
+        build a graph over *that* context's tensors, not silently reuse a
+        previous build's cached graph.
+
+        Before the context-identity guard, ``log_likelihood`` reused
+        ``_cached_bin_log_probs`` whenever it was non-``None``, regardless of
+        which context built it. Two prior ``Model`` builds leave the shared
+        ``HistFactoryDistChannel`` instance's cache populated with the second
+        build's tensors; calling ``log_likelihood`` for a brand new context
+        that was never passed to ``likelihood()`` must not return a graph
+        wired to those old tensors.
+        """
+        ws = _single_channel_normsys_workspace()
+        likelihood = next(iter(ws.likelihoods))
+        # Two builds share the same HistFactoryDistChannel instance (Workspace.model
+        # does not copy distributions), leaving its per-instance cache primed by
+        # whichever build ran last.
+        ws.model(likelihood, progress=False)
+        ws.model(likelihood, progress=False)
+
+        dist = next(iter(ws.distributions))
+
+        fresh_lumi = pt.dscalar("lumi")
+        fresh_observed = pt.dvector("SR_observed")
+        fresh_context = Context({"lumi": fresh_lumi, "SR_observed": fresh_observed})
+
+        expr = dist.log_likelihood(fresh_context)
+        inputs = set(pytensor.graph.traversal.explicit_graph_inputs([expr]))
+
+        # Before the fix, the returned graph references stale leaves left over
+        # from the second Model build, so neither fresh tensor is even present
+        # as an input.
+        assert fresh_lumi in inputs
+        assert fresh_observed in inputs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -21,9 +21,11 @@ import math
 
 import numpy as np
 import pytensor
+import pytensor.tensor as pt
 import pytest
 
 import pyhs3 as hs3
+from pyhs3.context import Context
 from pyhs3.data import BinnedData, Data
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
 from pyhs3.domains import Domains, ProductDomain
@@ -227,3 +229,42 @@ def test_zero_bin_logprob_is_not_nan():
         f"logpdf should be finite (not NaN), got {logpdf_val}"
     )
     assert logpdf_val == pytest.approx(0.0, abs=1e-12)
+
+
+def test_zero_bin_logprob_gradient_is_not_nan():
+    """The gradient of the Poisson log-pmf wrt expected_rates must stay finite
+    at observed==0, expected==0, independent of graph rewrites.
+
+    ``_bin_log_probs`` guards the *value* of ``0 * log(0)`` with a ``pt.switch``
+    on its output, but PyTensor differentiates every branch of a switch,
+    including the one not selected at runtime. The untaken branch still
+    contains ``observed * log(expected_rates)``, whose gradient wrt
+    ``expected_rates`` is ``observed / expected_rates = 0 / 0 = NaN`` at this
+    point; multiplying that NaN by the switch's zero mask does not clear it
+    (``0 * NaN = NaN``). Compiling with ``optimizer=None`` disables the graph
+    rewrites that otherwise happen to simplify this away, so the test exposes
+    the NaN structurally rather than relying on optimizer behavior.
+    """
+    channel = HistFactoryDistChannel(
+        name="grad_probe",
+        axes=[{"name": "x_probe", "min": 0.0, "max": 2.0, "nbins": 2}],
+        samples=[
+            {
+                "name": "signal",
+                "data": {"contents": [1.0, 3.0], "errors": [1.0, 1.0]},
+                "modifiers": [],
+            }
+        ],
+    )
+    observed = pt.constant(np.array([0.0, 2.0]))
+    context = Context(parameters={"grad_probe_observed": observed})
+    expected_rates = pt.vector("expected_rates")
+
+    log_probs = channel._bin_log_probs(context, expected_rates)
+    grad = pt.grad(pt.sum(log_probs), expected_rates)
+
+    mode = pytensor.compile.mode.Mode(linker="py", optimizer=None)
+    fn = pytensor.function([expected_rates], grad, mode=mode)
+
+    grad_val = fn(np.array([0.0, 3.0]))
+    assert np.all(np.isfinite(grad_val)), f"gradient has NaN/Inf: {grad_val}"

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -43,9 +43,9 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - scipy is in the dev deps
 
     def _poisson_logpmf(counts: np.ndarray, rates: np.ndarray) -> np.ndarray:
-        from scipy.special import gammaln  # noqa: PLC0415
-
-        return counts * np.log(rates) - rates - gammaln(counts + 1)
+        # math.lgamma is a stdlib built-in (Python ≥ 3.5); no external deps needed.
+        lgamma = np.vectorize(math.lgamma)
+        return counts * np.log(rates) - rates - lgamma(counts + 1)
 
 
 def _underflow_workspace() -> tuple[Workspace, np.ndarray]:
@@ -172,3 +172,58 @@ def test_logpdf_matches_log_pdf_for_gaussian():
             np.asarray(model.logpdf_unsafe("gauss", x=x, mu=0.0, sigma=1.0))
         )
         assert logpdf_val == pytest.approx(math.log(pdf_val), rel=1e-12)
+
+
+def test_zero_bin_logprob_is_not_nan():
+    """When observed==0 and expected==0, the bin's Poisson log-pmf must be 0 (not NaN).
+
+    When the HFDC observed data is a symbolic pt.vector (built without a likelihood
+    context so it is not baked as a constant), PyTensor evaluates
+    ``0 * pt.log(0) = 0 * -inf = NaN``.  The correct Poisson log-pmf for k=0 is
+    just ``-expected`` (i.e. 0 when expected==0 too).  A ``pt.switch`` guard fixes
+    this: when observed==0, return only ``-expected_rates``.
+    """
+    channel = HistFactoryDistChannel(
+        name="zero",
+        axes=[{"name": "x_zero", "min": 0.0, "max": 1.0, "nbins": 1}],
+        samples=[
+            {
+                "name": "signal",
+                "data": {"contents": [5.0], "errors": [1.0]},
+                "modifiers": [
+                    # normfactor lets us drive expected_rates → 0 at mu=0
+                    {"name": "mu", "type": "normfactor", "parameter": "mu"},
+                ],
+            }
+        ],
+    )
+    ws = Workspace(
+        metadata=Metadata(hs3_version="0.3.0"),
+        distributions=Distributions([channel]),
+        data=Data([]),
+        likelihoods=Likelihoods([]),
+        domains=Domains([ProductDomain(name="default")]),
+        parameter_points=ParameterPoints(
+            [
+                ParameterSet(
+                    name="default",
+                    parameters=[{"name": "mu", "value": 0.0}],
+                )
+            ]
+        ),
+    )
+    # Build without a likelihood so zero_observed stays symbolic (not baked).
+    model = ws.model(0, progress=False)
+    observed = np.zeros(1, dtype=np.float64)
+
+    # logpdf at mu=0 → expected_rates=0.  With obs=0 this is Poisson(0|0)=1 → log=0.
+    # Without the pt.switch guard, PyTensor computes 0*log(0) = NaN.
+    logpdf_val = float(
+        np.asarray(
+            model.logpdf_unsafe("zero", zero_observed=observed, mu=np.float64(0.0))
+        )
+    )
+    assert math.isfinite(logpdf_val), (
+        f"logpdf should be finite (not NaN), got {logpdf_val}"
+    )
+    assert logpdf_val == pytest.approx(0.0, abs=1e-12)

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -1,0 +1,174 @@
+"""Regression tests for log-space likelihood evaluation.
+
+The probability-space HistFactory likelihood multiplies per-bin Poisson
+probabilities (``pt.prod(pt.exp(log_probs))``).  For channels with many bins
+and/or large expected counts this product underflows float64 to ``0.0``, so the
+old ``logpdf = np.log(pdf(...))`` returned ``-inf`` even though every per-bin
+log-probability is perfectly finite.
+
+These tests assert that:
+
+* ``model.pdf(...)`` underflows to ``0.0`` for such a channel,
+* ``model.logpdf(...)`` / ``logpdf_unsafe(...)`` stay finite and match the
+  analytic sum of per-bin Poisson log-pmfs,
+* the likelihood ``log_prob`` path is finite too, and
+* ``logpdf == log(pdf)`` for a simple (representable) Gaussian model.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytensor
+import pytest
+
+import pyhs3 as hs3
+from pyhs3.data import BinnedData, Data
+from pyhs3.distributions import Distributions, HistFactoryDistChannel
+from pyhs3.domains import Domains, ProductDomain
+from pyhs3.likelihoods import Likelihood, Likelihoods
+from pyhs3.metadata import Metadata
+from pyhs3.parameter_points import ParameterPoints, ParameterSet
+from pyhs3.workspace import Workspace
+
+# scipy.stats.poisson.logpmf is preferred for the analytic reference; fall back
+# to gammaln if scipy is unavailable in the test environment.
+try:
+    from scipy.stats import poisson as _scipy_poisson
+
+    def _poisson_logpmf(counts: np.ndarray, rates: np.ndarray) -> np.ndarray:
+        return np.asarray(_scipy_poisson.logpmf(counts, rates), dtype=np.float64)
+
+except ModuleNotFoundError:  # pragma: no cover - scipy is in the dev deps
+
+    def _poisson_logpmf(counts: np.ndarray, rates: np.ndarray) -> np.ndarray:
+        from scipy.special import gammaln  # noqa: PLC0415
+
+        return counts * np.log(rates) - rates - gammaln(counts + 1)
+
+
+def _underflow_workspace() -> tuple[Workspace, np.ndarray]:
+    """Build a single-channel HFDC workspace whose probability underflows.
+
+    Returns the workspace and the observed/expected bin counts (observed equals
+    expected so the analytic Poisson log-pmf is straightforward).
+    """
+    nbins = 200
+    rng = np.random.default_rng(0)
+    # Thousands of counts per bin: each bin's Poisson pmf at its mode is ~1/sqrt(2*pi*rate)
+    # (~5e-3 here); the product across this many bins underflows float64 to 0.0
+    # (the smallest positive double is ~2.2e-308).
+    contents = (5000.0 + rng.integers(0, 1000, size=nbins)).astype(float).tolist()
+
+    obs_name = "x_SR"
+    channel = HistFactoryDistChannel(
+        name="SR",
+        axes=[{"name": obs_name, "min": 0.0, "max": 10.0, "nbins": nbins}],
+        samples=[
+            {
+                "name": "signal",
+                "data": {"contents": contents, "errors": [1.0] * nbins},
+                "modifiers": [],
+            }
+        ],
+    )
+    binned = BinnedData(
+        name="SR_data",
+        axes=[{"name": obs_name, "min": 0.0, "max": 10.0, "nbins": nbins}],
+        contents=contents,
+    )
+    ws = Workspace(
+        metadata=Metadata(hs3_version="0.3.0"),
+        distributions=Distributions([channel]),
+        data=Data([binned]),
+        likelihoods=Likelihoods(
+            [Likelihood(name="L", distributions=[channel], data=[binned])]
+        ),
+        domains=Domains([ProductDomain(name="default")]),
+        parameter_points=ParameterPoints([ParameterSet(name="default", parameters=[])]),
+    )
+    return ws, np.asarray(contents, dtype=np.float64)
+
+
+def test_pdf_underflows_but_logpdf_is_finite():
+    """pdf underflows to 0.0; logpdf stays finite and matches Poisson log-pmf sum."""
+    ws, contents = _underflow_workspace()
+    model = ws.model(next(iter(ws.likelihoods)), progress=False)
+
+    observed = np.asarray(contents)
+    # observed == expected for every bin
+    pdf_val = model.pdf_unsafe("SR", SR_observed=observed)
+    logpdf_val = model.logpdf_unsafe("SR", SR_observed=observed)
+
+    # Probability-space product underflows to (essentially) zero ...
+    assert float(np.asarray(pdf_val)) == 0.0
+
+    # ... but the log-space value is finite (the old np.log(pdf) gave -inf).
+    logpdf_scalar = float(np.asarray(logpdf_val))
+    assert math.isfinite(logpdf_scalar)
+
+    # And it matches the analytic sum of per-bin Poisson log-pmfs.
+    expected = float(np.sum(_poisson_logpmf(observed, observed)))
+    assert logpdf_scalar == pytest.approx(expected, rel=1e-10)
+
+
+def test_log_prob_is_finite_under_underflow():
+    """The likelihood log_prob path is finite where the probability product underflows."""
+    ws, contents = _underflow_workspace()
+    model = ws.model(next(iter(ws.likelihoods)), progress=False)
+
+    lp = model.log_prob
+    inputs = {
+        v.name: v
+        for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+        if v.name
+    }
+    fn = pytensor.function(list(inputs.values()), lp)
+    val = float(np.asarray(fn(**model.data, **model.nominal_params)).item())
+
+    assert math.isfinite(val)
+    observed = np.asarray(contents)
+    expected = float(np.sum(_poisson_logpmf(observed, observed)))
+    assert val == pytest.approx(expected, rel=1e-10)
+
+
+def test_logpdf_matches_log_pdf_for_gaussian():
+    """For a representable Gaussian model, logpdf equals log(pdf)."""
+    ws = hs3.Workspace(
+        metadata={"hs3_version": "0.2"},
+        distributions=[
+            {
+                "name": "gauss",
+                "type": "gaussian_dist",
+                "x": "x",
+                "mean": "mu",
+                "sigma": "sigma",
+            }
+        ],
+        domains=[
+            {
+                "name": "default",
+                "type": "product_domain",
+                "axes": [{"name": "x", "min": -10.0, "max": 10.0}],
+            }
+        ],
+        parameter_points=[
+            {
+                "name": "default_values",
+                "parameters": [
+                    {"name": "x", "value": 0.0},
+                    {"name": "mu", "value": 0.0},
+                    {"name": "sigma", "value": 1.0},
+                ],
+            }
+        ],
+    )
+    model = ws.model(0, progress=False)
+
+    for x in (-2.0, 0.0, 1.5, 3.0):
+        pdf_val = float(np.asarray(model.pdf_unsafe("gauss", x=x, mu=0.0, sigma=1.0)))
+        logpdf_val = float(
+            np.asarray(model.logpdf_unsafe("gauss", x=x, mu=0.0, sigma=1.0))
+        )
+        assert logpdf_val == pytest.approx(math.log(pdf_val), rel=1e-12)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -960,6 +960,25 @@ class TestModelParameterOrdering:
         assert isinstance(param_list, list)
         assert len(param_list) > 0
 
+    def test_log_pars_triggers_compilation(self, simple_workspace):
+        """Test that log_pars() triggers log compilation if not already compiled."""
+        model = simple_workspace.model(0, mode="FAST_RUN")
+
+        # Before calling log_pars, the log function should not be compiled
+        assert "gauss" not in model._compiled_log_inputs
+
+        # Call log_pars - should trigger compilation of the log function
+        param_list = model.log_pars("gauss")
+
+        # After calling log_pars, the log inputs cache should be populated
+        assert "gauss" in model._compiled_log_inputs
+
+        # Should return valid parameter list
+        assert isinstance(param_list, list)
+        assert "x" in param_list
+        assert "mu" in param_list
+        assert "sigma" in param_list
+
     def test_pars_order_matches_pdf_inputs(self, simple_workspace):
         """Test that pars() order matches what pdf() expects."""
         model = simple_workspace.model(0)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -964,14 +964,19 @@ class TestModelParameterOrdering:
         """Test that log_pars() triggers log compilation if not already compiled."""
         model = simple_workspace.model(0, mode="FAST_RUN")
 
-        # Before calling log_pars, the log function should not be compiled
+        # Before calling log_pars, neither cache should be populated
         assert "gauss" not in model._compiled_log_inputs
+        assert "gauss" not in model._compiled_log_input_names
 
         # Call log_pars - should trigger compilation of the log function
         param_list = model.log_pars("gauss")
 
-        # After calling log_pars, the log inputs cache should be populated
+        # After calling log_pars, both caches should be populated
         assert "gauss" in model._compiled_log_inputs
+        assert "gauss" in model._compiled_log_input_names
+
+        # log_pars returns the pre-built cached list (mirrors pars())
+        assert param_list is model._compiled_log_input_names["gauss"]
 
         # Should return valid parameter list
         assert isinstance(param_list, list)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #230.

## Problem

`Model.logpdf` was `np.log(pdf(...))` — the log was applied in NumPy *after* evaluating the compiled probability-space function. For HistFactory channels the main model multiplies per-bin Poisson probabilities (`pt.prod(pt.exp(log_probs))`), which **underflows float64 to `0.0`** for channels with many bins or large expected counts. `np.log(0.0)` is `-inf`, so `logpdf` (and the `log_prob`-based likelihood) returned `-inf` even though every per-bin log-probability is finite.

### Underflow repro

A single channel, 200 bins, ~5000–6000 expected counts per bin (observed == expected):

```
pdf        = 0.0
np.log(pdf)= -inf          # old logpdf
logpdf     = -1045.4748759709182   # new log-space path
analytic   = -1045.4748759709182   # sum of scipy.stats.poisson.logpmf
```

## Change

- **`Model`**: caches `log_distributions` (built from each distribution's `log_expression()`) and `_compiled_log_functions`, mirroring `_get_compiled_function`/`_compiled_inputs`. `logpdf`/`logpdf_unsafe` now compile and evaluate the log-space expression instead of taking `np.log` of `pdf`. The probability-space `pdf` path is unchanged.
- **`log_prob`**: uses each distribution's log-space expression directly. HFDC channels contribute a per-channel summed Poisson log-pmf term (`_hfdc_log_poisson`), reusing the existing constraint-dedup structure (constraint terms still collected once per unique nuisance parameter).
- **`HistFactoryDistChannel`**: implements `log_likelihood` / `log_extended_likelihood` / `log_expression` returning `sum(per-bin Poisson log-pmf) + sum(log constraints)` directly, instead of `log(prod(exp(log_probs)) * prod(constraints))`.

## Tests

New `tests/test_log_space_likelihood.py`:
- HFDC underflow channel: `pdf == 0.0` while `logpdf` and `log_prob` are finite and match the analytic Poisson log-pmf sum (`scipy.stats.poisson.logpmf`, gammaln fallback).
- `logpdf == log(pdf)` for a representable Gaussian model.

Full quick suite (`pixi run -e py312 pytest`) passes (939 passed); pre-commit (`prek -a`: ruff, ruff-format, mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added log-space likelihood APIs for HistFactory channels, including cached per-bin Poisson log terms and improved constraint contribution handling.
  * Introduced model-wide log-expression evaluation with compiled log-PDF functions and enhanced log-parameter handling.

* **Bug Fixes**
  * Improved numerical stability for binned Poisson likelihoods to avoid underflow and keep log-likelihoods finite.
  * Fixed `0 * log(0)` NaN issues and improved gradient stability near zero expected rates.

* **Tests**
  * Added regression coverage for underflow, zero-bin behavior (including gradients), constraint de-duplication, and log-parameter compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->