### PR TITLE
perf: remove quadratic context rebuilds and redundant graph construction

### DIFF
--- a/src/pyhs3/base.py
+++ b/src/pyhs3/base.py
@@ -130,6 +130,7 @@ class Evaluable(NamedModel, ABC):
     type: str = Field(..., json_schema_extra={"preprocess": False}, repr=False)
     _parameters: dict[str, str] = PrivateAttr(default_factory=dict)
     _constants_values: dict[str, float | int] = PrivateAttr(default_factory=dict)
+    _constants_cache: dict[str, TensorVar] | None = PrivateAttr(default=None)
 
     @property
     def parameters(self) -> set[str]:
@@ -149,10 +150,12 @@ class Evaluable(NamedModel, ABC):
             Mapping from generated constant names to PyTensor constant tensors.
             Empty if all fields are string references.
         """
-        return {
-            name: cast(TensorVar, pt.constant(value))
-            for name, value in self._constants_values.items()
-        }
+        if self._constants_cache is None:
+            self._constants_cache = {
+                name: cast(TensorVar, pt.constant(value))
+                for name, value in self._constants_values.items()
+            }
+        return self._constants_cache
 
     def process_parameter(self, param_key: str) -> tuple[str, float | int | None]:
         """Process a single parameter that can be either a string reference or numeric value.

--- a/src/pyhs3/context.py
+++ b/src/pyhs3/context.py
@@ -88,6 +88,44 @@ class Context:
         """Check if parameter name exists in context."""
         return key in self._parameters or key in self._auxiliaries
 
+    def add_parameter(self, key: str, value: TensorVar) -> None:
+        """Insert a single resolved parameter tensor into the context in place.
+
+        Used by the model builder to grow one long-lived context incrementally
+        as nodes are built in topological order, rather than reconstructing a
+        fresh context per node.  Preserves the parameter/auxiliary overlap
+        invariant enforced in :meth:`__init__`.
+
+        Args:
+            key: Parameter name to insert.
+            value: Resolved PyTensor variable for the parameter.
+
+        Raises:
+            ValueError: If ``key`` already exists among the auxiliaries.
+        """
+        if key in self._auxiliaries:
+            msg = (
+                "Parameter names cannot overlap between parameters and "
+                f"auxiliaries. Overlapping names: ['{key}']"
+            )
+            raise ValueError(msg)
+        self._parameters[key] = value
+
+    def add_view(self, key: str, view: TensorVar) -> None:
+        """Register a broadcasting view for ``key`` on this context in place.
+
+        Mirrors the ``views`` argument of :meth:`__init__` but lets the model
+        builder add the ExpandDims view of a vector parameter at the moment that
+        parameter node is built, so subsequent nodes see the correct broadcast
+        shape via ``context[key]``.
+
+        Args:
+            key: Parameter name the view belongs to.
+            view: ExpandDims view tensor (observable leaves are (N, 1),
+                non-observable vector overrides are (1, N)).
+        """
+        self._views[key] = view
+
     @property
     def parameters(self) -> dict[str, TensorVar]:
         """Get read-only view of parameters."""

--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -31,6 +31,30 @@ from pyhs3.networks import HasDependencies, HasInternalNodes
 from pyhs3.typing.aliases import TensorVar
 
 
+class ModifierNode(HasDependencies):
+    """Wrapper giving a modifier a globally unique name for the dependency graph.
+
+    Modifiers can share the same name across samples/types (e.g., a ``Lumi``
+    modifier appearing in several places), but the dependency graph requires
+    unique node identifiers.  This lightweight wrapper provides the unique name
+    while delegating all functionality to the wrapped modifier.
+    """
+
+    def __init__(self, name: str, modifier: Modifier):
+        """Store the unique node name and the wrapped modifier."""
+        self.name = name
+        self._modifier = modifier
+
+    @property
+    def dependencies(self) -> set[str]:
+        """Parameter names the wrapped modifier depends on."""
+        return self._modifier.dependencies
+
+    def expression(self, context: Context) -> TensorVar:
+        """Delegate expression building to the wrapped modifier."""
+        return self._modifier.expression(context)
+
+
 class HistFactoryDistChannel(Distribution, HasInternalNodes):
     r"""
     HistFactory probability distribution for a single channel/region.
@@ -117,24 +141,6 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
                 # Create unique node name: {dist_name}/{sample_name}/{modifier_type}/{modifier_name}
                 # This ensures uniqueness even when modifier names are reused across samples
                 node_name = f"{self.name}/{sample.name}/{modifier.type}/{modifier.name}"
-
-                # Create a lightweight wrapper that provides the unique name for the dependency graph
-                # while delegating all functionality to the original modifier
-                class ModifierNode(HasDependencies):
-                    """
-                    Wrapper Modifier to provide a globally unique internal name for the dependency graph.
-                    """
-
-                    def __init__(self, name: str, modifier: Modifier):
-                        self.name = name
-                        self._modifier = modifier
-
-                    @property
-                    def dependencies(self) -> set[str]:
-                        return self._modifier.dependencies
-
-                    def expression(self, context: Context) -> TensorVar:
-                        return self._modifier.expression(context)
 
                 nodes.append(ModifierNode(node_name, modifier))
 

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import Annotated, Any, Literal, cast
 
+import numpy as np
 import pytensor.tensor as pt
 from pydantic import (
     BaseModel,
@@ -13,7 +14,6 @@ from pydantic import (
     model_validator,
 )
 
-from pyhs3.compile import function
 from pyhs3.context import Context
 from pyhs3.distributions.basic import GaussianDist, LogNormalDist, PoissonDist
 from pyhs3.distributions.core import Distribution
@@ -362,13 +362,11 @@ class ShapeSysModifier(HasConstraint, ParametersModifier):
 
         name = f"constraint_{self.name}"
 
-        nominal_yield = pt.vector("nominal_yield")
-        uncertainty = pt.vector("uncertainty")
-        # (sigma_b)^{-2} = (nominal / vals)^2
-        rate_fn = function(
-            [nominal_yield, uncertainty], (nominal_yield / uncertainty) ** 2
-        )
-        rates = rate_fn(sample_data.contents, self.data.vals)
+        # (sigma_b)^{-2} = (nominal / vals)^2, evaluated on concrete floats.
+        rates = (
+            np.asarray(sample_data.contents, dtype=np.float64)
+            / np.asarray(self.data.vals, dtype=np.float64)
+        ) ** 2
 
         # Use augmented context pattern for parameter * rate scaling
         augmented_context = dict(context)

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from collections.abc import Callable, Mapping
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -122,6 +123,9 @@ class Model:
         self.mode = mode
         self._compiled_functions: dict[str, Callable[..., npt.NDArray[np.float64]]] = {}
         self._compiled_inputs: dict[str, list[TensorVar]] = {}
+        # Ordered input names cached alongside _compiled_inputs so that pars()
+        # and _reorder_params() avoid rebuilding the list on every pdf/logpdf call.
+        self._compiled_input_names: dict[str, list[str]] = {}
         self._likelihood = likelihood
         # Views used internally for broadcasting: leaf[:, None] for observables,
         # leaf[None, :] for non-observable vector overrides.  Distributions see
@@ -193,7 +197,7 @@ class Model:
                 result[pp.name] = float(pp.value)
         return result
 
-    @property
+    @cached_property
     def log_prob(self) -> TensorVar:
         """Symbolic joint log-probability expression for the full likelihood.
 
@@ -439,29 +443,59 @@ class Model:
         if not isinstance(dist, HistFactoryDistChannel):
             return dist.expression(context)
 
-        # Poisson-only term; the full expression is returned below for logpdf.
-        self._hfdc_poisson[node_name] = dist.likelihood(context)
+        # Build the Poisson term and each constraint factor exactly once, then
+        # assemble both the model-level deduped constraint list and the full
+        # per-channel expression from those shared pieces.  This mirrors
+        # Distribution._expression (likelihood -> normalization -> x constraints)
+        # and HistFactoryDistChannel.extended_likelihood without rebuilding the
+        # Poisson subgraph or re-running make_constraint a second time.
+        poisson = dist.likelihood(context)
+        self._hfdc_poisson[node_name] = poisson
 
-        # Collect constraint expressions, deduped across channels by parameter name.
-        # Only channels referenced by the active likelihood contribute constraints —
-        # all HFDC distributions are still evaluated so logpdf() works for any channel.
-        # Single-parameter modifiers carry a dedup_key; multi-parameter modifiers
-        # (shapesys/staterror) have dedup_key=None and are emitted per-channel because
-        # the workspace validator forbids cross-channel sharing of those parameters.
-        if self._likelihood is None or any(
+        # Whether this channel participates in the active likelihood; only then
+        # do its constraints feed the joint log_prob.  All channels still build
+        # their full expression so logpdf() works for any channel.
+        in_likelihood = self._likelihood is None or any(
             (d if isinstance(d, str) else d.name) == node_name
             for d in self._likelihood.distributions
-        ):
-            for dedup_key, modifier, sample_data in dist.constraint_specs():
+        )
+
+        # Single pass over constraint specs builds each constraint factor once.
+        # - channel_seen dedups by parameter for the per-channel product
+        #   (matches extended_likelihood's local dedup),
+        # - self._hfdc_constraint_params_seen dedups across channels for log_prob.
+        channel_seen: set[str] = set()
+        channel_constraints: list[TensorVar] = []
+        for dedup_key, modifier, sample_data in dist.constraint_specs():
+            constraint = modifier.make_constraint(context, sample_data)
+
+            if dedup_key is None or dedup_key not in channel_seen:
+                if dedup_key is not None:
+                    channel_seen.add(dedup_key)
+                channel_constraints.append(constraint)
+
+            if in_likelihood:
                 if dedup_key is not None:
                     if dedup_key in self._hfdc_constraint_params_seen:
                         continue
                     self._hfdc_constraint_params_seen.add(dedup_key)
-                self._hfdc_constraints.append(
-                    modifier.make_constraint(context, sample_data)
-                )
+                self._hfdc_constraints.append(constraint)
 
-        return dist.expression(context)
+        # Assemble the full per-channel expression: normalized Poisson term times
+        # the constraint product (extended likelihood).  HFDC is not normalizable
+        # (_normalizable defaults False here), so _apply_normalization is a no-op,
+        # but call it to stay faithful to Distribution._expression.
+        raw = dist._apply_normalization(poisson, context)  # pylint: disable=protected-access
+        if not channel_constraints:
+            extended: TensorVar = cast(TensorVar, pt.constant(1.0))
+        else:
+            extended = cast(
+                TensorVar,
+                pt.prod(pt.stack(channel_constraints)),  # type: ignore[no-untyped-call]
+            )
+        full = cast(TensorVar, raw * extended)
+        full.name = dist.name  # Evaluable.expression sets the name
+        return full
 
     def _build_dependency_graph(
         self,
@@ -497,6 +531,16 @@ class Model:
                 "Building expressions...", total=len(sorted_nodes)
             )
 
+            # A single long-lived context is grown incrementally as nodes are
+            # built.  Topological order guarantees every dependency is already
+            # present before a node that uses it is built, so there is no need
+            # to reconstruct (and re-validate) a fresh merged context per node.
+            context = Context(
+                parameters={},
+                observables=self._observables,
+                views=self._views,
+            )
+
             for node_idx in sorted_nodes:
                 node_data = graph[node_idx]
                 node_type: Literal[
@@ -515,37 +559,32 @@ class Model:
                     description=f"Building {node_type:<12}: {display_name:<{max_name_length}}",
                 )
 
-                context = Context(
-                    parameters={
-                        **self.parameters,
-                        **self.functions,
-                        **self.distributions,
-                        **self.modifiers,
-                    },
-                    observables=self._observables,
-                    views=self._views,
-                )
-
                 if node_type == "parameter":
-                    self.parameters[node_name] = self._build_parameter_node(
-                        node_name, context
-                    )
+                    built = self._build_parameter_node(node_name, context)
+                    self.parameters[node_name] = built
+                    # Vector parameters register a broadcasting view in
+                    # self._views during the build; propagate it so later
+                    # nodes resolve context[node_name] to the view.
+                    if node_name in self._views:
+                        context.add_view(node_name, self._views[node_name])
                 elif node_type == "constant":
-                    self.parameters[node_name] = self._build_constant_node(
-                        node_name, constants_map
-                    )
+                    built = self._build_constant_node(node_name, constants_map)
+                    self.parameters[node_name] = built
                 elif node_type == "function":
-                    self.functions[node_name] = self._build_function_node(
-                        node_name, functions, context
-                    )
+                    built = self._build_function_node(node_name, functions, context)
+                    self.functions[node_name] = built
                 elif node_type == "modifier":
-                    self.modifiers[node_name] = self._build_modifier_node(
-                        node_name, modifiers_map, context
-                    )
+                    built = self._build_modifier_node(node_name, modifiers_map, context)
+                    self.modifiers[node_name] = built
                 else:  # node_type == "distribution"
-                    self.distributions[node_name] = self._build_distribution_node(
+                    built = self._build_distribution_node(
                         node_name, distributions, context
                     )
+                    self.distributions[node_name] = built
+
+                # Make the freshly built node available to later nodes (any
+                # broadcasting view was propagated above for parameter nodes).
+                context.add_parameter(node_name, built)
 
                 progress_bar.advance(task)
 
@@ -574,8 +613,12 @@ class Model:
                 if var.name is not None
             ]
 
-            # Cache the inputs list for consistent ordering
+            # Cache the inputs list (and their names) for consistent ordering so
+            # pars()/_reorder_params don't rebuild the name list per evaluation.
             self._compiled_inputs[name] = cast(list[TensorVar], inputs)
+            self._compiled_input_names[name] = [
+                var.name for var in inputs if var.name is not None
+            ]
 
             # Use the specified PyTensor mode
             compilation_mode = self.mode
@@ -735,10 +778,10 @@ class Model:
             >>> model.pars("model_singlechannel") # doctest: +SKIP
             ['uncorr_bkguncrt_1', 'uncorr_bkguncrt_0', 'model_singlechannel_observed', 'mu', 'Lumi']
         """
-        if name not in self._compiled_inputs:
+        if name not in self._compiled_input_names:
             # Trigger compilation to populate cache
             self._get_compiled_function(name)
-        return [var.name for var in self._compiled_inputs[name] if var.name is not None]
+        return self._compiled_input_names[name]
 
     def parsort(self, name: str, names: list[str]) -> list[int]:
         """

--- a/src/pyhs3/parameter_points.py
+++ b/src/pyhs3/parameter_points.py
@@ -8,8 +8,9 @@ individual parameters and parameter sets for defining model parameter values.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator
+from typing import Any
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, PrivateAttr
 
 from pyhs3.collections import NamedCollection, NamedModel
 from pyhs3.typing.aliases import TensorVar
@@ -57,11 +58,16 @@ class ParameterSet(NamedModel):
     model_config = ConfigDict()
 
     parameters: list[ParameterPoint] = Field(default_factory=list, repr=False)
+    _points: dict[str, ParameterPoint] = PrivateAttr(default_factory=dict)
+
+    def model_post_init(self, __context: Any, /) -> None:
+        """Build the name-to-parameter mapping once after validation."""
+        self._points = {param.name: param for param in self.parameters}
 
     @property
     def points(self) -> dict[str, ParameterPoint]:
         """Compatibility property for core.py access."""
-        return {param.name: param for param in self.parameters}
+        return self._points
 
     def __len__(self) -> int:
         """Number of parameters in this set."""

--- a/tests/test_evaluable.py
+++ b/tests/test_evaluable.py
@@ -628,6 +628,34 @@ class TestContext:
         copied._parameters["param1"] = pt.constant(2.0)
         assert context["param1"].value != copied["param1"].value
 
+    def test_add_parameter_inserts_value(self):
+        """Test add_parameter inserts a new tensor into an existing context."""
+        context = Context({"param1": pt.constant(1.0)})
+        new_tensor = pt.constant(99.0)
+        context.add_parameter("param2", new_tensor)
+        assert context["param2"] is new_tensor
+
+    def test_add_parameter_overlap_with_auxiliary_raises(self):
+        """Test add_parameter raises ValueError when key is already an auxiliary."""
+        aux_tensor = pt.constant(5.0)
+        context = Context({}, {"existing_aux": aux_tensor})
+        with pytest.raises(
+            ValueError,
+            match=r"Parameter names cannot overlap between parameters and auxiliaries",
+        ):
+            context.add_parameter("existing_aux", pt.constant(1.0))
+
+    def test_add_view_registers_view(self):
+        """Test add_view registers a broadcasting view accessible via __getitem__."""
+        raw = pt.constant(1.0)
+        context = Context({"param1": raw})
+        view_tensor = pt.constant(2.0)
+        context.add_view("param1", view_tensor)
+        # __getitem__ should now return the view, not the raw parameter
+        assert context["param1"] is view_tensor
+        # But context.parameters still returns the raw value
+        assert context.parameters["param1"] is raw
+
 
 class TestEvaluableAdvanced:
     """Test advanced Evaluable functionality and edge cases."""

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -449,6 +449,57 @@ class TestConstraintDeduplication:
         expected = poisson_sr + poisson_cr + gauss_lp
         assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
 
+    def test_shared_normsys_within_one_channel_single_constraint(self):
+        """Two samples in one channel sharing a normsys parameter yield one constraint.
+
+        Exercises the per-channel seen-set dedup in _build_distribution_node:
+        the second sample's spec carries an already-seen dedup_key, so the
+        channel product must contain the Gaussian constraint exactly once.
+        """
+        normsys_mod = {
+            "name": "lumi",
+            "type": "normsys",
+            "parameter": "lumi",
+            "constraint": "Gauss",
+            "data": {"hi": 1.05, "lo": 0.95},
+        }
+        channel = {
+            "name": "SR",
+            "axes": [{"name": "x_SR", "min": 0.0, "max": 10.0, "nbins": 1}],
+            "samples": [
+                {
+                    "name": "signal",
+                    "data": {"contents": [10.0], "errors": [1.0]},
+                    "modifiers": [normsys_mod],
+                },
+                {
+                    "name": "background",
+                    "data": {"contents": [5.0], "errors": [1.0]},
+                    "modifiers": [normsys_mod],
+                },
+            ],
+        }
+        ws = _simple_workspace(
+            channels=[channel],
+            params=[{"name": "lumi", "value": 0.0}],
+        )
+        likelihood = next(iter(ws.likelihoods))
+        model = ws.model(likelihood, progress=False)
+        lp = model.log_prob
+        inputs = {
+            v.name: v
+            for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+            if v.name
+        }
+        fn = pytensor.function(list(inputs.values()), lp)
+        val = float(fn(**model.data, **model.nominal_params).item())
+
+        # Observed is sample 0's contents (10); expected at lumi=0 is 10 + 5.
+        poisson = 10.0 * math.log(15.0) - 15.0 - math.lgamma(11.0)
+        gauss_lp = -0.5 * math.log(2 * math.pi)
+        expected = poisson + gauss_lp
+        assert abs(val - expected) < 1e-6, f"got {val}, expected {expected}"
+
     def test_two_channels_independent_normsys_both_constraints_present(self):
         """Two channels with different normsys parameters must each contribute a constraint."""
         ws = _simple_workspace(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #230.

## Summary

Removes verified build-time and per-call overhead in `Model` construction and
evaluation. These are pure refactors — all existing tests pass unchanged
(936 quick, 937 with `--runslow`), and a single HFDC `logpdf`/`log_prob`
value is bit-identical before and after.

## Changes

1. **O(n²) Context construction → incremental** (`model.py`, `context.py`).
   The topological build loop previously constructed a fresh `Context` for
   every node by merging `{**parameters, **functions, **distributions,
   **modifiers}`, and `Context.__init__` copied + re-validated overlap each
   time. Now a single long-lived `Context` is grown in place as nodes are
   built (topological order guarantees deps exist first). `Context` gains
   `add_parameter`/`add_view` helpers that preserve the parameter/auxiliary
   overlap invariant and the broadcasting-view semantics.

2. **HFDC subgraphs no longer built twice** (`model.py`). For
   `HistFactoryDistChannel`, `_build_distribution_node` called
   `likelihood()` (stored as `_hfdc_poisson`) and then `expression()`, which
   internally re-ran `likelihood()` *and* re-ran every `make_constraint`
   already executed via `constraint_specs()`. Now the Poisson term and each
   constraint factor are built exactly once and the full per-channel
   expression is assembled from those pieces, faithfully mirroring
   `Distribution._expression` (likelihood → normalization → × constraints)
   and `HistFactoryDistChannel.extended_likelihood` (incl. the channel-local
   parameter dedup and the name set by `Evaluable.expression`).

3. **Throwaway PyTensor compile removed in shapesys** (`modifiers.py`).
   `make_constraint` compiled a full PyTensor function per shapesys modifier
   just to evaluate `(nominal/uncertainty)**2` on concrete floats; replaced
   with plain NumPy.

4. **`ParameterSet.points` cached** (`parameter_points.py`). `get` /
   `__getitem__` / `__contains__` rebuilt `{p.name: p}` on every call (O(P²)
   across parameter nodes); the mapping is now built once in
   `model_post_init` (matching `NamedCollection`). No post-init mutation of
   `parameters` exists in the codebase.

5. **`pars()` name list cached** (`model.py`). The ordered input-name list is
   cached alongside `_compiled_inputs` at compile time instead of being
   rebuilt on every `pdf`/`logpdf` call via `_reorder_params`.

6. **`Evaluable.constants` cached** (`base.py`). Previously materialized new
   `pt.constant` objects on every access (called from `networks.py` and
   several modifier sites); now cached in a `PrivateAttr`.

7. Extras: `Model.log_prob` is now a `functools.cached_property` (the
   weighted-data `UserWarning` is therefore emitted once per model instance
   instead of once per access — acceptable; no test relies on repeated
   emission), and the `ModifierNode` wrapper is hoisted to module level in
   `histfactory/__init__.py` instead of being redefined inside
   `get_internal_nodes` for every modifier.

## Benchmarks

Synthetic workspace, best of 3 runs (macOS, CPython 3.13, `FAST_RUN`):

| workspace size            | `ws.model()` before | after  |
| ------------------------- | ------------------- | ------ |
| 200 params / 50 dists     | 37.8 ms             | 36.6 ms |
| 1600 params / 400 dists   | 410.3 ms            | 313.7 ms (~23% faster) |

The gain scales with workspace size because the eliminated context-rebuild
cost was quadratic in the number of graph nodes. 10k `model.logpdf` calls:
15.9 ms → 15.2 ms (wall-clock here is dominated by PyTensor C-call overhead;
the `pars()` caching mainly removes per-call list allocation/GC).

The HFDC `logpdf`/`log_prob` value is identical before and after, and the
full `tests/test_hfdc_model_constraints.py` suite passes identically with and
without the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
