### PR TITLE
fix: correct unbinned NLL for constraints, weighted data, and extended mixtures

### DIFF
--- a/docs/defining_components.rst
+++ b/docs/defining_components.rst
@@ -348,7 +348,17 @@ Override ``extended_likelihood()`` only when your distribution needs additional 
 - **HistFactory distributions**: Constraint terms for nuisance parameters (Gaussian/Poisson constraints)
 - **Most distributions**: Do not override (use default ``1.0``)
 
-Dataset-level terms cannot use this hook, for two reasons. First, ``expression()`` multiplies ``extended_likelihood()`` into the per-event density, so a term meant to enter the likelihood once per channel — like the extended Poisson yield term, which involves the observed event count — would be counted once per event when ``Model.log_prob`` sums over the data. Second, while the observable tensors are present in the ``Context``, a ``MixtureDist`` cannot identify them: its declared dependencies are its coefficients and summand distributions, not the random variable. ``Model.log_prob``, which owns the channel-dataset pairing, therefore assembles the extended term once per channel from ``MixtureDist.unnormalized_expression()`` and ``MixtureDist.expected_yield()``.
+Dataset-level terms cannot use this hook, for two reasons. First, ``expression()`` multiplies ``extended_likelihood()`` into the per-event density, so a term meant to enter the likelihood once per channel — like the extended Poisson yield term, which involves the observed event count — would be counted once per event when ``Model.log_prob`` sums over the data. Second, while the observable tensors are present in the ``Context``, a ``MixtureDist`` cannot identify them: its declared dependencies are its coefficients and summand distributions, not the random variable. Such terms are instead declared via ``log_prob_terms()`` (below) and assembled by ``Model.log_prob``, which owns the channel-dataset pairing.
+
+**Structured log-likelihood contributions: log_prob_terms()**
+
+Not every term a distribution contributes to the joint log-likelihood is a per-event log-density. ``Distribution.log_prob_terms(expressions, distributions)`` lets a distribution describe its contributions structurally, returning a ``LogProbTerms`` with three kinds of terms:
+
+- ``per_event``: log-density terms summed over events (with per-event weights applied when present)
+- ``channel``: scalar terms added once per channel (e.g. the ``-nu`` yield term of an extended ``MixtureDist``)
+- ``constraints``: log-terms keyed by factor name, added exactly once globally so constraints shared across channels are not double-counted
+
+The default implementation returns a single per-event ``log(PDF)`` term, which is correct for most distributions. ``ProductDist`` overrides it to split its factors into observable-dependent shape factors (delegating to each factor's own ``log_prob_terms``, so composition nests) and scalar-only constraint factors. ``MixtureDist`` overrides it to contribute the extended yield term. ``Model.log_prob`` calls this hook for each channel and owns the assembly — event weighting, summing, and global constraint deduplication — so new distribution types with channel-level terms only need to override ``log_prob_terms()``, never ``Model.log_prob`` itself.
 
 **Example with Extended Likelihood:**
 

--- a/docs/defining_components.rst
+++ b/docs/defining_components.rst
@@ -343,11 +343,12 @@ Distributions in pyhs3 separate the main probability model from extended likelih
 
 **When to Override extended_likelihood():**
 
-Override ``extended_likelihood()`` only when your distribution needs additional terms beyond the main PDF:
+Override ``extended_likelihood()`` only when your distribution needs additional terms beyond the main PDF that are computable from the context alone:
 
 - **HistFactory distributions**: Constraint terms for nuisance parameters (Gaussian/Poisson constraints)
-- **Mixture distributions**: Poisson yield terms for extended ML fits
 - **Most distributions**: Do not override (use default ``1.0``)
+
+Data-dependent terms cannot use this hook: ``expression()`` calls ``extended_likelihood()`` without data. The Poisson yield term of an extended ``MixtureDist``, which depends on the observed event count, is instead assembled by ``Model.log_prob`` from ``MixtureDist.unnormalized_expression()`` and ``MixtureDist.expected_yield()``.
 
 **Example with Extended Likelihood:**
 

--- a/docs/defining_components.rst
+++ b/docs/defining_components.rst
@@ -348,7 +348,7 @@ Override ``extended_likelihood()`` only when your distribution needs additional 
 - **HistFactory distributions**: Constraint terms for nuisance parameters (Gaussian/Poisson constraints)
 - **Most distributions**: Do not override (use default ``1.0``)
 
-Data-dependent terms cannot use this hook: ``expression()`` calls ``extended_likelihood()`` without data. The Poisson yield term of an extended ``MixtureDist``, which depends on the observed event count, is instead assembled by ``Model.log_prob`` from ``MixtureDist.unnormalized_expression()`` and ``MixtureDist.expected_yield()``.
+Dataset-level terms cannot use this hook, for two reasons. First, ``expression()`` multiplies ``extended_likelihood()`` into the per-event density, so a term meant to enter the likelihood once per channel — like the extended Poisson yield term, which involves the observed event count — would be counted once per event when ``Model.log_prob`` sums over the data. Second, while the observable tensors are present in the ``Context``, a ``MixtureDist`` cannot identify them: its declared dependencies are its coefficients and summand distributions, not the random variable. ``Model.log_prob``, which owns the channel-dataset pairing, therefore assembles the extended term once per channel from ``MixtureDist.unnormalized_expression()`` and ``MixtureDist.expected_yield()``.
 
 **Example with Extended Likelihood:**
 

--- a/src/pyhs3/distributions/__init__.py
+++ b/src/pyhs3/distributions/__init__.py
@@ -23,7 +23,7 @@ from pyhs3.distributions import (
     mathematical,
     physics,
 )
-from pyhs3.distributions.core import Distribution
+from pyhs3.distributions.core import Distribution, LogProbTerms
 from pyhs3.exceptions import custom_error_msg
 
 # Export distribution classes for backwards compatibility
@@ -79,6 +79,7 @@ __all__ = [
     "HistogramDist",
     "LandauDist",
     "LogNormalDist",
+    "LogProbTerms",
     "MixtureDist",
     "PoissonDist",
     "PolynomialDist",

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -337,6 +337,12 @@ class MixtureDist(Distribution):
         RooFit's sum-of-weights convention: weighting the log(Σcᵢfᵢ) term
         gives Σⱼwⱼ·log(PDF) + (Σwⱼ)·log(nu) - nu.
 
+        The data-only -log(N!) constant is omitted and N_eff = Σwⱼ is used
+        for weighted data; both are RooFit conventions adopted because HS3
+        does not specify the extended term exactly.  See
+        https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/91
+        and https://github.com/scipp-atlas/pyhs3/issues/241.
+
         Non-extended mixtures contribute the default per-event log(PDF).
         """
         if not self.extended:
@@ -415,6 +421,13 @@ class ProductDist(Distribution):
         globally.  This prevents the N-fold overcounting that occurs when
         naively summing log(shape x Π_j constr_j) over N events, which
         multiplies each constr_j term by N rather than counting it once.
+
+        The shape-vs-constraint classification is structural inference
+        (matching RooProdPdf), not HS3 spec semantics — nothing in an HS3
+        file marks a factor as a constraint.  If the spec adopts explicit
+        constraint encoding, this inference can be removed; see
+        https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/90
+        and https://github.com/scipp-atlas/pyhs3/issues/240.
         """
         terms = LogProbTerms()
         for factor_name in self.factors:

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -194,9 +194,9 @@ class MixtureDist(Distribution):
                 mixturesum += context[coeff] * context[self.summands[i]]
 
             # Cache the unnormalized Σcᵢfᵢ so that model.log_prob can build
-            # the extended log-likelihood as Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν without
-            # introducing a separate pt.log(ν) node that triggers costly
-            # optimizer rewrites when combined with log(Σcᵢfᵢ/ν).
+            # the extended log-likelihood as Σⱼ log(Σcᵢfᵢ(xⱼ)) - nu without
+            # introducing a separate pt.log(nu) node that triggers costly
+            # optimizer rewrites when combined with log(Σcᵢfᵢ/nu).
             self._cached_unnorm_expr = mixturesum
 
             # Handle normalization
@@ -282,13 +282,13 @@ class MixtureDist(Distribution):
         intermediate result; it is used by :meth:`pyhs3.model.Model.log_prob`
         to build the extended log-likelihood as
 
-            Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν
+            Σⱼ log(Σcᵢfᵢ(xⱼ)) - nu
 
         which is algebraically equivalent to
 
-            Σⱼ log(Σcᵢfᵢ(xⱼ)/ν)  +  N·log(ν)  −  ν
+            Σⱼ log(Σcᵢfᵢ(xⱼ)/nu)  +  N·log(nu)  -  nu
 
-        but avoids introducing a separate ``pt.log(ν)`` node that can trigger
+        but avoids introducing a separate ``pt.log(nu)`` node that can trigger
         expensive rewrite cascades in the PyTensor graph optimiser.
         """
         if hasattr(self, "_cached_unnorm_expr"):

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, cast
 import pytensor.tensor as pt
 from pydantic import (
     Field,
+    PrivateAttr,
     ValidationInfo,
     field_serializer,
     field_validator,
@@ -20,9 +21,6 @@ from pydantic import (
 )
 
 from pyhs3.context import Context
-
-# Import for Poisson extended likelihood calculation
-from pyhs3.distributions.basic import PoissonDist
 from pyhs3.distributions.core import Distribution
 from pyhs3.typing.aliases import TensorVar
 
@@ -71,6 +69,13 @@ class MixtureDist(Distribution):
     ref_coef_norm: list[str] | None = Field(
         default=None, json_schema_extra={"preprocess": False}
     )
+
+    # PyTensor nodes built by the most recent likelihood() call, reused by
+    # unnormalized_expression() and expected_yield() so that model.log_prob
+    # shares the same subgraphs instead of building duplicates the compiler
+    # then has to merge (a measurable compile-time cost on large workspaces).
+    _cached_unnorm_expr: TensorVar | None = PrivateAttr(default=None)
+    _cached_nu_expr: TensorVar | None = PrivateAttr(default=None)
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler: Callable[[Any], Any]) -> Any:
@@ -258,8 +263,8 @@ class MixtureDist(Distribution):
 
         # Reuse the normalisation sum cached by likelihood() to avoid building
         # a duplicate PyTensor summation subgraph (which would slow compilation).
-        if hasattr(self, "_cached_nu_expr"):
-            return cast(TensorVar, self._cached_nu_expr)
+        if self._cached_nu_expr is not None:
+            return self._cached_nu_expr
 
         # Fallback: likelihood() hasn't been called yet, compute fresh.
         nu = pt.constant(0.0)
@@ -290,46 +295,19 @@ class MixtureDist(Distribution):
 
         but avoids introducing a separate ``pt.log(nu)`` node that can trigger
         expensive rewrite cascades in the PyTensor graph optimiser.
+
+        The Poisson yield term itself depends on the observed event count and
+        is therefore assembled by :meth:`pyhs3.model.Model.log_prob` (which has
+        the dataset), not by :meth:`extended_likelihood` (which does not).
         """
-        if hasattr(self, "_cached_unnorm_expr"):
-            return cast(TensorVar, self._cached_unnorm_expr)
+        if self._cached_unnorm_expr is not None:
+            return self._cached_unnorm_expr
 
         # Fallback: recompute (likelihood() hasn't been called yet).
         unnorm = pt.constant(0.0)
         for i, coeff in enumerate(self.coefficients):
             unnorm += context[coeff] * context[self.summands[i]]
         return cast(TensorVar, unnorm)
-
-    def extended_likelihood(
-        self, context: Context, data: TensorVar | None = None
-    ) -> TensorVar:
-        """
-        Poisson term for the extended likelihood.
-
-        Args:
-            context: Mapping of names to pytensor variables
-            data: Tensor containing observed event count (if None, returns 1.0)
-
-        Returns:
-            pytensor.tensor.variable.TensorVariable: :func:`PoissonDist.expression` object
-
-        Raises:
-            RuntimeError: If called on non-extended PDF
-        """
-        if not self.extended:
-            return pt.constant(1.0)
-
-        if data is None:
-            # No data provided, return no contribution
-            return pt.constant(1.0)
-
-        nu = self.expected_yield(context)
-        n_obs = data  # data should contain the observed count
-
-        # Use the existing PoissonDist implementation for correctness
-        poisson_dist = PoissonDist(name="temp_poisson", mean="nu", x="n_obs")
-        poisson_context = Context(parameters={"nu": nu, "n_obs": n_obs})
-        return poisson_dist.expression(poisson_context)
 
 
 class ProductDist(Distribution):

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -296,9 +296,12 @@ class MixtureDist(Distribution):
         but avoids introducing a separate ``pt.log(nu)`` node that can trigger
         expensive rewrite cascades in the PyTensor graph optimiser.
 
-        The Poisson yield term itself depends on the observed event count and
-        is therefore assembled by :meth:`pyhs3.model.Model.log_prob` (which has
-        the dataset), not by :meth:`extended_likelihood` (which does not).
+        The Poisson yield term enters the likelihood once per channel and
+        involves the observed event count, so it is assembled by
+        :meth:`pyhs3.model.Model.log_prob` (which owns the channel-dataset
+        pairing) rather than via :meth:`extended_likelihood` (whose result is
+        multiplied into the per-event density and would be overcounted when
+        summing over events).
         """
         if self._cached_unnorm_expr is not None:
             return self._cached_unnorm_expr

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -7,8 +7,8 @@ multiple other distributions, including mixtures and products of distributions.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, Literal, cast
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import pytensor.tensor as pt
 from pydantic import (
@@ -19,10 +19,14 @@ from pydantic import (
     field_validator,
     model_serializer,
 )
+from pytensor.graph.traversal import explicit_graph_inputs
 
 from pyhs3.context import Context
-from pyhs3.distributions.core import Distribution
+from pyhs3.distributions.core import Distribution, LogProbTerms
 from pyhs3.typing.aliases import TensorVar
+
+if TYPE_CHECKING:
+    from pyhs3.distributions import Distributions
 
 
 class MixtureDist(Distribution):
@@ -312,6 +316,45 @@ class MixtureDist(Distribution):
             unnorm += context[coeff] * context[self.summands[i]]
         return cast(TensorVar, unnorm)
 
+    def log_prob_terms(
+        self,
+        expressions: Mapping[str, TensorVar],
+        distributions: Distributions,
+    ) -> LogProbTerms:
+        """
+        Extended-likelihood contributions for the mixture.
+
+        For an extended mixture the per-channel log-likelihood is built from
+        the unnormalized mixture and the expected yield:
+
+            Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
+
+        which simplifies from Σⱼ log(Σcᵢfᵢ(xⱼ)/nu) + N·log(nu) - nu (the
+        log(nu) terms cancel).  This is algebraically identical to the full
+        extended likelihood but avoids introducing pt.log(nu) into the graph,
+        preventing costly optimizer rewrite cascades triggered by
+        log(a/b) + N·log(b).  For weighted data this form also reproduces
+        RooFit's sum-of-weights convention: weighting the log(Σcᵢfᵢ) term
+        gives Σⱼwⱼ·log(PDF) + (Σwⱼ)·log(nu) - nu.
+
+        Non-extended mixtures contribute the default per-event log(PDF).
+        """
+        if not self.extended:
+            return super().log_prob_terms(expressions, distributions)
+
+        if self._cached_unnorm_expr is None or self._cached_nu_expr is None:
+            msg = (
+                f"log_prob_terms for extended mixture '{self.name}' requires "
+                f"likelihood() to have been called (the model graph build does "
+                f"this) so the unnormalized mixture and yield nodes exist."
+            )
+            raise RuntimeError(msg)
+
+        return LogProbTerms(
+            per_event=[pt.log(self._cached_unnorm_expr)],
+            channel=[-self._cached_nu_expr],
+        )
+
 
 class ProductDist(Distribution):
     r"""
@@ -353,6 +396,45 @@ class ProductDist(Distribution):
 
         vals = [context[factor] for factor in self.factors]
         return cast(TensorVar, pt.mul(*vals))
+
+    def log_prob_terms(
+        self,
+        expressions: Mapping[str, TensorVar],
+        distributions: Distributions,
+    ) -> LogProbTerms:
+        """
+        Split factors into per-event shape terms and per-channel constraints.
+
+        Factors that depend on an observable (detected by a pt.vector free
+        input — observable arrays are built as pt.vector, NP scalars as
+        pt.scalar) delegate to their own log_prob_terms, so e.g. an extended
+        mixture inside a product contributes its yield term correctly.
+
+        Factors that depend only on scalar nuisance parameters are constraint
+        PDFs and are returned as named constraints for the model to add once
+        globally.  This prevents the N-fold overcounting that occurs when
+        naively summing log(shape x Π_j constr_j) over N events, which
+        multiplies each constr_j term by N rather than counting it once.
+        """
+        terms = LogProbTerms()
+        for factor_name in self.factors:
+            factor_expr = expressions[factor_name]
+            free_inputs = [
+                v for v in explicit_graph_inputs([factor_expr]) if v.name is not None
+            ]
+            # Observable-dependent factors have at least one vector (rank-1) input.
+            is_shape = any(v.type.ndim >= 1 for v in free_inputs)
+
+            if is_shape:
+                factor_terms = distributions[factor_name].log_prob_terms(
+                    expressions, distributions
+                )
+                terms.per_event.extend(factor_terms.per_event)
+                terms.channel.extend(factor_terms.channel)
+                terms.constraints.update(factor_terms.constraints)
+            else:
+                terms.constraints[factor_name] = cast(TensorVar, pt.log(factor_expr))
+        return terms
 
 
 # Registry of composite distributions

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -316,7 +316,7 @@ class MixtureDist(Distribution):
             unnorm += context[coeff] * context[self.summands[i]]
         return cast(TensorVar, unnorm)
 
-    def log_prob_terms(
+    def log_prob_terms(  # pylint: disable=redefined-outer-name
         self,
         expressions: Mapping[str, TensorVar],
         distributions: Distributions,
@@ -403,7 +403,7 @@ class ProductDist(Distribution):
         vals = [context[factor] for factor in self.factors]
         return cast(TensorVar, pt.mul(*vals))
 
-    def log_prob_terms(
+    def log_prob_terms(  # pylint: disable=redefined-outer-name
         self,
         expressions: Mapping[str, TensorVar],
         distributions: Distributions,

--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -189,9 +189,15 @@ class MixtureDist(Distribution):
             # N coefficients case: direct summation with normalization
             mixturesum = pt.constant(0.0)
 
-            # Calculate the mixture sum
+            # Calculate the mixture sum (unnormalized: Σ cᵢ fᵢ)
             for i, coeff in enumerate(self.coefficients):
                 mixturesum += context[coeff] * context[self.summands[i]]
+
+            # Cache the unnormalized Σcᵢfᵢ so that model.log_prob can build
+            # the extended log-likelihood as Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν without
+            # introducing a separate pt.log(ν) node that triggers costly
+            # optimizer rewrites when combined with log(Σcᵢfᵢ/ν).
+            self._cached_unnorm_expr = mixturesum
 
             # Handle normalization
             if self.ref_coef_norm is not None:
@@ -199,12 +205,18 @@ class MixtureDist(Distribution):
                 norm_sum = pt.constant(0.0)
                 for norm_coeff in self.ref_coef_norm:
                     norm_sum += context[norm_coeff]
+                # Cache the normalisation sum so expected_yield() can reuse
+                # the same PyTensor node rather than building a duplicate
+                # summation subgraph that the compiler then has to merge.
+                self._cached_nu_expr = norm_sum
                 mixturesum = mixturesum / norm_sum
             else:
                 # Standard normalization: divide by sum of all coefficients
                 coeffsum = pt.constant(0.0)
                 for coeff in self.coefficients:
                     coeffsum += context[coeff]
+                # Cache so expected_yield() reuses this node.
+                self._cached_nu_expr = coeffsum
                 mixturesum = mixturesum / coeffsum
 
         else:
@@ -244,6 +256,12 @@ class MixtureDist(Distribution):
             msg = "expected_yield only valid for extended PDFs"
             raise RuntimeError(msg)
 
+        # Reuse the normalisation sum cached by likelihood() to avoid building
+        # a duplicate PyTensor summation subgraph (which would slow compilation).
+        if hasattr(self, "_cached_nu_expr"):
+            return cast(TensorVar, self._cached_nu_expr)
+
+        # Fallback: likelihood() hasn't been called yet, compute fresh.
         nu = pt.constant(0.0)
 
         if self.ref_coef_norm is not None:
@@ -256,6 +274,31 @@ class MixtureDist(Distribution):
                 nu += context[coeff]
 
         return cast(TensorVar, nu)
+
+    def unnormalized_expression(self, context: Context) -> TensorVar:
+        """Return the unnormalized mixture Σcᵢfᵢ (before dividing by Σcᵢ).
+
+        After :meth:`likelihood` has been called this just returns the cached
+        intermediate result; it is used by :meth:`pyhs3.model.Model.log_prob`
+        to build the extended log-likelihood as
+
+            Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν
+
+        which is algebraically equivalent to
+
+            Σⱼ log(Σcᵢfᵢ(xⱼ)/ν)  +  N·log(ν)  −  ν
+
+        but avoids introducing a separate ``pt.log(ν)`` node that can trigger
+        expensive rewrite cascades in the PyTensor graph optimiser.
+        """
+        if hasattr(self, "_cached_unnorm_expr"):
+            return cast(TensorVar, self._cached_unnorm_expr)
+
+        # Fallback: recompute (likelihood() hasn't been called yet).
+        unnorm = pt.constant(0.0)
+        for i, coeff in enumerate(self.coefficients):
+            unnorm += context[coeff] * context[self.summands[i]]
+        return cast(TensorVar, unnorm)
 
     def extended_likelihood(
         self, context: Context, data: TensorVar | None = None

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -8,7 +8,9 @@ standard and CMS-specific distribution implementations.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import cast
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
 
 import pytensor.tensor as pt
 from pydantic import PrivateAttr
@@ -18,6 +20,38 @@ from pyhs3.base import Evaluable
 from pyhs3.context import Context
 from pyhs3.normalization import gauss_legendre_integral
 from pyhs3.typing.aliases import TensorVar
+
+if TYPE_CHECKING:
+    from pyhs3.distributions import Distributions
+
+
+@dataclass
+class LogProbTerms:
+    """
+    Structured per-channel contributions to :attr:`pyhs3.model.Model.log_prob`.
+
+    Distributions describe *what* they contribute via
+    :meth:`Distribution.log_prob_terms`; the model owns the channel-dataset
+    pairing and decides *how* the pieces enter the joint log-likelihood
+    (event weighting, summing over events, global constraint deduplication).
+
+    Attributes:
+        per_event: Log-density terms with the observable as a free pt.vector
+            input, broadcasting to shape (N, M) for N events and parameter
+            batch size M.  The model sums these over the event axis (applying
+            per-event weights when present).
+        channel: Scalar terms added once per channel, broadcasting onto the
+            (M,) parameter batch axis (e.g. the -nu yield term of an extended
+            mixture).
+        constraints: Log-terms keyed by factor name, depending only on scalar
+            nuisance parameters.  The model adds each name exactly once
+            globally, so constraints shared across channels are not
+            double-counted.
+    """
+
+    per_event: list[TensorVar] = field(default_factory=list)
+    channel: list[TensorVar] = field(default_factory=list)
+    constraints: dict[str, TensorVar] = field(default_factory=dict)
 
 
 class Distribution(Evaluable, ABC):
@@ -247,3 +281,31 @@ class Distribution(Evaluable, ABC):
             TensorVar: Likelihood contribution (default: 1.0 = no contribution)
         """
         return pt.constant(1.0)
+
+    def log_prob_terms(
+        self,
+        expressions: Mapping[str, TensorVar],
+        _distributions: Distributions,
+    ) -> LogProbTerms:
+        """
+        Structured contributions of this distribution to the joint log-likelihood.
+
+        Called by :attr:`pyhs3.model.Model.log_prob` for each channel after the
+        model graph is built.  Override when the distribution's terms do not
+        all enter the likelihood as a per-event log-density — e.g. once-per-
+        channel yield terms (extended :class:`~pyhs3.distributions.MixtureDist`)
+        or globally-deduplicated constraint factors
+        (:class:`~pyhs3.distributions.ProductDist`).
+
+        Default: a single per-event ``log(PDF)`` term.
+
+        Args:
+            expressions: Compiled symbolic expressions for all distributions,
+                keyed by name (``model.distributions``).
+            distributions: Distribution objects keyed by name, so composite
+                distributions can delegate to their components' hooks.
+
+        Returns:
+            LogProbTerms: per-event, per-channel, and constraint contributions.
+        """
+        return LogProbTerms(per_event=[pt.log(expressions[self.name])])

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -228,11 +228,14 @@ class Distribution(Evaluable, ABC):
         Extended likelihood contribution in normal space.
 
         Returns additional likelihood terms for extended ML fitting.
-        Override only when the distribution contributes extended terms that
-        are computable from the context alone, like constraint terms
-        (HistFactory).  Data-dependent terms (e.g. the Poisson yield term of
-        an extended MixtureDist) are assembled by ``Model.log_prob``, which
-        has the dataset; ``_expression()`` calls this method without data.
+        Override only when the extended terms belong in the distribution's
+        per-event density, like constraint terms (HistFactory).  Terms that
+        enter the likelihood once per channel (e.g. the Poisson yield term
+        of an extended MixtureDist, which involves the observed event count)
+        must not use this hook: ``_expression()`` multiplies the result into
+        the density, so ``Model.log_prob`` would count it once per event when
+        summing over data.  Such terms are assembled once per channel by
+        ``Model.log_prob``, which owns the channel-dataset pairing.
 
         Default: no contribution (returns 1.0 in normal space).
 

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -228,8 +228,11 @@ class Distribution(Evaluable, ABC):
         Extended likelihood contribution in normal space.
 
         Returns additional likelihood terms for extended ML fitting.
-        Override only when the distribution contributes extended terms like
-        constraint terms (HistFactory) or Poisson yield terms (MixtureDist).
+        Override only when the distribution contributes extended terms that
+        are computable from the context alone, like constraint terms
+        (HistFactory).  Data-dependent terms (e.g. the Poisson yield term of
+        an extended MixtureDist) are assembled by ``Model.log_prob``, which
+        has the dataset; ``_expression()`` calls this method without data.
 
         Default: no contribution (returns 1.0 in normal space).
 

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -24,7 +24,7 @@ from pyhs3.compile import function
 from pyhs3.context import Context
 from pyhs3.data import BinnedData
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
-from pyhs3.distributions.composite import ProductDist
+from pyhs3.distributions.composite import MixtureDist, ProductDist
 from pyhs3.domains import Domain
 from pyhs3.functions import Functions
 from pyhs3.networks import build_dependency_graph
@@ -138,6 +138,17 @@ class Model:
         # so that logpdf() continues to work; log_prob uses this dict to avoid
         # double-counting constraint terms when multiple channels share a parameter.
         self._hfdc_poisson: dict[str, TensorVar] = {}
+        # Extended-MixtureDist Poisson-term support.
+        # For each channel name we store two nodes built during _build_distribution_node:
+        #   _extended_yields[name]  = ν = Σcᵢ  (total expected yield)
+        #   _extended_unnorm[name]  = Σcᵢfᵢ    (unnormalized mixture numerator)
+        #
+        # log_prob uses them to compute the extended log-likelihood as
+        #   Σⱼ log(Σcᵢfᵢ(xⱼ))  −  ν
+        # which is equivalent to  Σⱼ log(PDF(xⱼ)) + N·log(ν) − ν  but avoids
+        # a separate pt.log(ν) node that triggers costly optimizer rewrites.
+        self._extended_yields: dict[str, TensorVar] = {}
+        self._extended_unnorm: dict[str, TensorVar] = {}
 
         # Build dependency graph with proper entity identification
         self._build_dependency_graph(functions, distributions, progress)
@@ -304,7 +315,25 @@ class Model:
                     is_shape = any(v.type.ndim >= 1 for v in free_inputs)
 
                     if is_shape:
-                        shape_log_terms.append(pt.log(factor_expr))
+                        unnorm_expr = self._extended_unnorm.get(factor_name)
+                        nu_expr = self._extended_yields.get(factor_name)
+                        if unnorm_expr is not None and nu_expr is not None and entries is not None:
+                            # Extended MixtureDist: use the unnormalized mixture to
+                            # avoid a separate pt.log(ν) node.
+                            #
+                            # The full extended log-likelihood per channel is:
+                            #   Σⱼ log(Σcᵢfᵢ(xⱼ)/ν)  +  N·log(ν)  −  ν
+                            # which simplifies (the log(ν) terms cancel) to:
+                            #   Σⱼ log(Σcᵢfᵢ(xⱼ))  −  ν
+                            #
+                            # This is algebraically identical but avoids introducing
+                            # pt.log(ν) into the graph, preventing costly optimizer
+                            # rewrite cascades triggered by log(a/b) + N·log(b).
+                            shape_log_terms.append(pt.log(unnorm_expr))
+                            terms.append(-nu_expr)
+                        else:
+                            # Non-extended shape factor: just add log(PDF).
+                            shape_log_terms.append(pt.log(factor_expr))
                     elif factor_name not in _seen_constraint_factors:
                         # Add each unique constraint exactly once globally.
                         _seen_constraint_factors.add(factor_name)
@@ -327,11 +356,24 @@ class Model:
                 # Non-ProductDist: standard unbinned log-likelihood.
                 # Weighted: Σᵢ wᵢ log f(xᵢ). Unweighted: Σᵢ log f(xᵢ).
                 # No /total_weight: that would give an average NLL (wrong scale).
-                log_pdf: TensorVar = pt.log(self.distributions[dist_name])
-                if weights_t is not None:
-                    terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                unnorm_expr = self._extended_unnorm.get(dist_name)
+                nu_expr = self._extended_yields.get(dist_name)
+                if unnorm_expr is not None and nu_expr is not None and entries is not None:
+                    # Extended MixtureDist without ProductDist wrapper: use
+                    # unnormalized mixture to avoid pt.log(ν) (see ProductDist
+                    # path above for the full explanation).
+                    log_pdf = pt.log(unnorm_expr)
+                    if weights_t is not None:
+                        terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                    else:
+                        terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                    terms.append(-nu_expr)
                 else:
-                    terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                    log_pdf = pt.log(self.distributions[dist_name])
+                    if weights_t is not None:
+                        terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                    else:
+                        terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
 
         # Auxiliary distributions (constraint terms) are scalars; they broadcast
         # onto the parameter-scan axis when non-scalar params are present.
@@ -490,7 +532,17 @@ class Model:
         """
         dist = distributions[node_name]
         if not isinstance(dist, HistFactoryDistChannel):
-            return dist.expression(context)
+            expr = dist.expression(context)
+            # For extended MixtureDist, cache the unnormalized mixture (Σcᵢfᵢ)
+            # and the expected yield (ν = Σcᵢ).  log_prob uses these to build
+            # the extended log-likelihood as
+            #   Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν
+            # rather than  Σⱼ log(PDF) + N·log(ν) − ν, avoiding a separate
+            # pt.log(ν) node that can trigger expensive optimiser rewrites.
+            if isinstance(dist, MixtureDist) and dist.extended:
+                self._extended_yields[node_name] = dist.expected_yield(context)
+                self._extended_unnorm[node_name] = dist.unnormalized_expression(context)
+            return expr
 
         # Poisson-only term; the full expression is returned below for logpdf.
         self._hfdc_poisson[node_name] = dist.likelihood(context)

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -138,17 +138,15 @@ class Model:
         # so that logpdf() continues to work; log_prob uses this dict to avoid
         # double-counting constraint terms when multiple channels share a parameter.
         self._hfdc_poisson: dict[str, TensorVar] = {}
-        # Extended-MixtureDist Poisson-term support.
-        # For each channel name we store two nodes built during _build_distribution_node:
-        #   _extended_yields[name]  = nu = Σcᵢ  (total expected yield)
-        #   _extended_unnorm[name]  = Σcᵢfᵢ    (unnormalized mixture numerator)
+        # Extended-MixtureDist Poisson-term support.  For each extended mixture
+        # we store a (unnormalized mixture Σcᵢfᵢ, expected yield nu = Σcᵢ) pair
+        # of nodes built during _build_distribution_node.
         #
         # log_prob uses them to compute the extended log-likelihood as
         #   Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
         # which is equivalent to  Σⱼ log(PDF(xⱼ)) + N·log(nu) - nu  but avoids
         # a separate pt.log(nu) node that triggers costly optimizer rewrites.
-        self._extended_yields: dict[str, TensorVar] = {}
-        self._extended_unnorm: dict[str, TensorVar] = {}
+        self._extended_mixtures: dict[str, tuple[TensorVar, TensorVar]] = {}
 
         # Build dependency graph with proper entity identification
         self._build_dependency_graph(functions, distributions, progress)
@@ -253,7 +251,7 @@ class Model:
         # (which do not depend on the observable) appear in a ProductDist alongside
         # the shape PDF: naively summing log(shape x Π_j constr_j) over N events
         # multiplies each constr_j term by N rather than counting it once.
-        _seen_constraint_factors: set[str] = set()
+        seen_constraint_factors: set[str] = set()
 
         for dist_obj, datum in zip(
             self._likelihood.distributions, self._likelihood.data, strict=True
@@ -299,14 +297,12 @@ class Model:
             #
             # This separation prevents constraints from being multiplied by N_events.
             # Observable arrays are built as pt.vector (ndim=1); NP scalars are pt.scalar (ndim=0).
-            _dist_obj = self._distribution_objects.get(dist_name)
-            if isinstance(_dist_obj, ProductDist):
+            channel_dist = self._distribution_objects.get(dist_name)
+            if isinstance(channel_dist, ProductDist):
                 shape_log_terms: list[TensorVar] = []
 
-                for factor_name in _dist_obj.factors:
-                    factor_expr: TensorVar | None = self.distributions.get(factor_name)
-                    if factor_expr is None:
-                        continue  # should not happen, but be safe
+                for factor_name in channel_dist.factors:
+                    factor_expr = self.distributions[factor_name]
                     free_inputs = [
                         v
                         for v in explicit_graph_inputs([factor_expr])
@@ -316,13 +312,8 @@ class Model:
                     is_shape = any(v.type.ndim >= 1 for v in free_inputs)
 
                     if is_shape:
-                        unnorm_expr = self._extended_unnorm.get(factor_name)
-                        nu_expr = self._extended_yields.get(factor_name)
-                        if (
-                            unnorm_expr is not None
-                            and nu_expr is not None
-                            and entries is not None
-                        ):
+                        extended = self._extended_mixtures.get(factor_name)
+                        if extended is not None:
                             # Extended MixtureDist: use the unnormalized mixture to
                             # avoid a separate pt.log(nu) node.
                             #
@@ -334,14 +325,19 @@ class Model:
                             # This is algebraically identical but avoids introducing
                             # pt.log(nu) into the graph, preventing costly optimizer
                             # rewrite cascades triggered by log(a/b) + N·log(b).
+                            #
+                            # For weighted data this form also reproduces RooFit's
+                            # sum-of-weights convention: weighting the log(Σcᵢfᵢ)
+                            # term gives Σⱼwⱼ·log(PDF) + (Σwⱼ)·log(nu) - nu.
+                            unnorm_expr, nu_expr = extended
                             shape_log_terms.append(pt.log(unnorm_expr))
                             terms.append(-nu_expr)
                         else:
                             # Non-extended shape factor: just add log(PDF).
                             shape_log_terms.append(pt.log(factor_expr))
-                    elif factor_name not in _seen_constraint_factors:
+                    elif factor_name not in seen_constraint_factors:
                         # Add each unique constraint exactly once globally.
-                        _seen_constraint_factors.add(factor_name)
+                        seen_constraint_factors.add(factor_name)
                         terms.append(pt.log(factor_expr))
                     # else: already counted from an earlier channel — skip.
 
@@ -361,16 +357,12 @@ class Model:
                 # Non-ProductDist: standard unbinned log-likelihood.
                 # Weighted: Σᵢ wᵢ log f(xᵢ). Unweighted: Σᵢ log f(xᵢ).
                 # No /total_weight: that would give an average NLL (wrong scale).
-                unnorm_expr = self._extended_unnorm.get(dist_name)
-                nu_expr = self._extended_yields.get(dist_name)
-                if (
-                    unnorm_expr is not None
-                    and nu_expr is not None
-                    and entries is not None
-                ):
+                extended = self._extended_mixtures.get(dist_name)
+                if extended is not None:
                     # Extended MixtureDist without ProductDist wrapper: use
                     # unnormalized mixture to avoid pt.log(nu) (see ProductDist
                     # path above for the full explanation).
+                    unnorm_expr, nu_expr = extended
                     log_pdf = pt.log(unnorm_expr)
                     if weights_t is not None:
                         terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
@@ -549,8 +541,10 @@ class Model:
             # rather than  Σⱼ log(PDF) + N·log(nu) - nu, avoiding a separate
             # pt.log(nu) node that can trigger expensive optimiser rewrites.
             if isinstance(dist, MixtureDist) and dist.extended:
-                self._extended_yields[node_name] = dist.expected_yield(context)
-                self._extended_unnorm[node_name] = dist.unnormalized_expression(context)
+                self._extended_mixtures[node_name] = (
+                    dist.unnormalized_expression(context),
+                    dist.expected_yield(context),
+                )
             return expr
 
         # Poisson-only term; the full expression is returned below for logpdf.

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -24,7 +24,6 @@ from pyhs3.compile import function
 from pyhs3.context import Context
 from pyhs3.data import BinnedData
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
-from pyhs3.distributions.composite import MixtureDist, ProductDist
 from pyhs3.domains import Domain
 from pyhs3.functions import Functions
 from pyhs3.networks import build_dependency_graph
@@ -138,16 +137,6 @@ class Model:
         # so that logpdf() continues to work; log_prob uses this dict to avoid
         # double-counting constraint terms when multiple channels share a parameter.
         self._hfdc_poisson: dict[str, TensorVar] = {}
-        # Extended-MixtureDist Poisson-term support.  For each extended mixture
-        # we store a (unnormalized mixture Σcᵢfᵢ, expected yield nu = Σcᵢ) pair
-        # of nodes built during _build_distribution_node.
-        #
-        # log_prob uses them to compute the extended log-likelihood as
-        #   Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
-        # which is equivalent to  Σⱼ log(PDF(xⱼ)) + N·log(nu) - nu  but avoids
-        # a separate pt.log(nu) node that triggers costly optimizer rewrites.
-        self._extended_mixtures: dict[str, tuple[TensorVar, TensorVar]] = {}
-
         # Build dependency graph with proper entity identification
         self._build_dependency_graph(functions, distributions, progress)
 
@@ -291,90 +280,39 @@ class Model:
                 # (N,) → (N, 1) so it broadcasts against (N, M) log_pdf.
                 weights_t = pt.constant(weights_arr)[:, None]
 
-            # For ProductDist channels, split factors into:
-            #   • shape factors  — depend on the observable (pt.vector inputs) → sum over events
-            #   • constraint factors — depend only on scalar NPs → add once globally
-            #
-            # This separation prevents constraints from being multiplied by N_events.
-            # Observable arrays are built as pt.vector (ndim=1); NP scalars are pt.scalar (ndim=0).
-            channel_dist = self._distribution_objects.get(dist_name)
-            if isinstance(channel_dist, ProductDist):
-                shape_log_terms: list[TensorVar] = []
+            # Each distribution describes its own structured contributions
+            # (per-event log-density, once-per-channel scalars, named
+            # constraints) via Distribution.log_prob_terms; the model owns
+            # the channel-dataset pairing and applies event weights, sums
+            # over events, and deduplicates constraints globally.
+            contrib = self._distribution_objects[dist_name].log_prob_terms(
+                self.distributions, self._distribution_objects
+            )
 
-                for factor_name in channel_dist.factors:
-                    factor_expr = self.distributions[factor_name]
-                    free_inputs = [
-                        v
-                        for v in explicit_graph_inputs([factor_expr])
-                        if v.name is not None
-                    ]
-                    # Observable-dependent factors have at least one vector (rank-1) input.
-                    is_shape = any(v.type.ndim >= 1 for v in free_inputs)
-
-                    if is_shape:
-                        extended = self._extended_mixtures.get(factor_name)
-                        if extended is not None:
-                            # Extended MixtureDist: use the unnormalized mixture to
-                            # avoid a separate pt.log(nu) node.
-                            #
-                            # The full extended log-likelihood per channel is:
-                            #   Σⱼ log(Σcᵢfᵢ(xⱼ)/nu)  +  N·log(nu)  -  nu
-                            # which simplifies (the log(nu) terms cancel) to:
-                            #   Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
-                            #
-                            # This is algebraically identical but avoids introducing
-                            # pt.log(nu) into the graph, preventing costly optimizer
-                            # rewrite cascades triggered by log(a/b) + N·log(b).
-                            #
-                            # For weighted data this form also reproduces RooFit's
-                            # sum-of-weights convention: weighting the log(Σcᵢfᵢ)
-                            # term gives Σⱼwⱼ·log(PDF) + (Σwⱼ)·log(nu) - nu.
-                            unnorm_expr, nu_expr = extended
-                            shape_log_terms.append(pt.log(unnorm_expr))
-                            terms.append(-nu_expr)
-                        else:
-                            # Non-extended shape factor: just add log(PDF).
-                            shape_log_terms.append(pt.log(factor_expr))
-                    elif factor_name not in seen_constraint_factors:
-                        # Add each unique constraint exactly once globally.
-                        seen_constraint_factors.add(factor_name)
-                        terms.append(pt.log(factor_expr))
-                    # else: already counted from an earlier channel — skip.
-
-                # Sum shape log over events.  No /total_weight: the correct weighted
-                # log-likelihood is Σᵢ wᵢ log f(xᵢ), not a per-event average.
-                if shape_log_terms:
-                    shape_log_pdf: TensorVar = (
-                        pt.add(*shape_log_terms)
-                        if len(shape_log_terms) > 1
-                        else shape_log_terms[0]
-                    )
-                    if weights_t is not None:
-                        terms.append(pt.sum(weights_t * shape_log_pdf, axis=0))  # type: ignore[no-untyped-call]
-                    else:
-                        terms.append(pt.sum(shape_log_pdf, axis=0))  # type: ignore[no-untyped-call]
-            else:
-                # Non-ProductDist: standard unbinned log-likelihood.
-                # Weighted: Σᵢ wᵢ log f(xᵢ). Unweighted: Σᵢ log f(xᵢ).
-                # No /total_weight: that would give an average NLL (wrong scale).
-                extended = self._extended_mixtures.get(dist_name)
-                if extended is not None:
-                    # Extended MixtureDist without ProductDist wrapper: use
-                    # unnormalized mixture to avoid pt.log(nu) (see ProductDist
-                    # path above for the full explanation).
-                    unnorm_expr, nu_expr = extended
-                    log_pdf = pt.log(unnorm_expr)
-                    if weights_t is not None:
-                        terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
-                    else:
-                        terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
-                    terms.append(-nu_expr)
+            # Sum the per-event log-density over events.  Weighted:
+            # Σᵢ wᵢ log f(xᵢ); unweighted: Σᵢ log f(xᵢ).  No /total_weight:
+            # that would give an average NLL (wrong scale).
+            if contrib.per_event:
+                log_pdf: TensorVar = (
+                    pt.add(*contrib.per_event)
+                    if len(contrib.per_event) > 1
+                    else contrib.per_event[0]
+                )
+                if weights_t is not None:
+                    terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
                 else:
-                    log_pdf = pt.log(self.distributions[dist_name])
-                    if weights_t is not None:
-                        terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
-                    else:
-                        terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                    terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
+
+            # Once-per-channel scalar terms (e.g. the -nu yield term of an
+            # extended mixture).
+            terms.extend(contrib.channel)
+
+            # Add each unique constraint exactly once globally; constraints
+            # shared with an earlier channel are skipped.
+            for factor_name, constraint_expr in contrib.constraints.items():
+                if factor_name not in seen_constraint_factors:
+                    seen_constraint_factors.add(factor_name)
+                    terms.append(constraint_expr)
 
         # Auxiliary distributions (constraint terms) are scalars; they broadcast
         # onto the parameter-scan axis when non-scalar params are present.
@@ -533,19 +471,7 @@ class Model:
         """
         dist = distributions[node_name]
         if not isinstance(dist, HistFactoryDistChannel):
-            expr = dist.expression(context)
-            # For extended MixtureDist, cache the unnormalized mixture (Σcᵢfᵢ)
-            # and the expected yield (nu = Σcᵢ).  log_prob uses these to build
-            # the extended log-likelihood as
-            #   Σⱼ log(Σcᵢfᵢ(xⱼ)) - nu
-            # rather than  Σⱼ log(PDF) + N·log(nu) - nu, avoiding a separate
-            # pt.log(nu) node that can trigger expensive optimiser rewrites.
-            if isinstance(dist, MixtureDist) and dist.extended:
-                self._extended_mixtures[node_name] = (
-                    dist.unnormalized_expression(context),
-                    dist.expected_yield(context),
-                )
-            return expr
+            return dist.expression(context)
 
         # Poisson-only term; the full expression is returned below for logpdf.
         self._hfdc_poisson[node_name] = dist.likelihood(context)

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -140,13 +140,13 @@ class Model:
         self._hfdc_poisson: dict[str, TensorVar] = {}
         # Extended-MixtureDist Poisson-term support.
         # For each channel name we store two nodes built during _build_distribution_node:
-        #   _extended_yields[name]  = ν = Σcᵢ  (total expected yield)
+        #   _extended_yields[name]  = nu = Σcᵢ  (total expected yield)
         #   _extended_unnorm[name]  = Σcᵢfᵢ    (unnormalized mixture numerator)
         #
         # log_prob uses them to compute the extended log-likelihood as
-        #   Σⱼ log(Σcᵢfᵢ(xⱼ))  −  ν
-        # which is equivalent to  Σⱼ log(PDF(xⱼ)) + N·log(ν) − ν  but avoids
-        # a separate pt.log(ν) node that triggers costly optimizer rewrites.
+        #   Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
+        # which is equivalent to  Σⱼ log(PDF(xⱼ)) + N·log(nu) - nu  but avoids
+        # a separate pt.log(nu) node that triggers costly optimizer rewrites.
         self._extended_yields: dict[str, TensorVar] = {}
         self._extended_unnorm: dict[str, TensorVar] = {}
 
@@ -251,7 +251,7 @@ class Model:
         # shared across multiple channels are only counted once globally.
         # This prevents the N-fold overcounting that occurs when constraint PDFs
         # (which do not depend on the observable) appear in a ProductDist alongside
-        # the shape PDF: naively summing log(shape × Π_j constr_j) over N events
+        # the shape PDF: naively summing log(shape x Π_j constr_j) over N events
         # multiplies each constr_j term by N rather than counting it once.
         _seen_constraint_factors: set[str] = set()
 
@@ -308,7 +308,8 @@ class Model:
                     if factor_expr is None:
                         continue  # should not happen, but be safe
                     free_inputs = [
-                        v for v in explicit_graph_inputs([factor_expr])
+                        v
+                        for v in explicit_graph_inputs([factor_expr])
                         if v.name is not None
                     ]
                     # Observable-dependent factors have at least one vector (rank-1) input.
@@ -317,17 +318,21 @@ class Model:
                     if is_shape:
                         unnorm_expr = self._extended_unnorm.get(factor_name)
                         nu_expr = self._extended_yields.get(factor_name)
-                        if unnorm_expr is not None and nu_expr is not None and entries is not None:
+                        if (
+                            unnorm_expr is not None
+                            and nu_expr is not None
+                            and entries is not None
+                        ):
                             # Extended MixtureDist: use the unnormalized mixture to
-                            # avoid a separate pt.log(ν) node.
+                            # avoid a separate pt.log(nu) node.
                             #
                             # The full extended log-likelihood per channel is:
-                            #   Σⱼ log(Σcᵢfᵢ(xⱼ)/ν)  +  N·log(ν)  −  ν
-                            # which simplifies (the log(ν) terms cancel) to:
-                            #   Σⱼ log(Σcᵢfᵢ(xⱼ))  −  ν
+                            #   Σⱼ log(Σcᵢfᵢ(xⱼ)/nu)  +  N·log(nu)  -  nu
+                            # which simplifies (the log(nu) terms cancel) to:
+                            #   Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
                             #
                             # This is algebraically identical but avoids introducing
-                            # pt.log(ν) into the graph, preventing costly optimizer
+                            # pt.log(nu) into the graph, preventing costly optimizer
                             # rewrite cascades triggered by log(a/b) + N·log(b).
                             shape_log_terms.append(pt.log(unnorm_expr))
                             terms.append(-nu_expr)
@@ -358,9 +363,13 @@ class Model:
                 # No /total_weight: that would give an average NLL (wrong scale).
                 unnorm_expr = self._extended_unnorm.get(dist_name)
                 nu_expr = self._extended_yields.get(dist_name)
-                if unnorm_expr is not None and nu_expr is not None and entries is not None:
+                if (
+                    unnorm_expr is not None
+                    and nu_expr is not None
+                    and entries is not None
+                ):
                     # Extended MixtureDist without ProductDist wrapper: use
-                    # unnormalized mixture to avoid pt.log(ν) (see ProductDist
+                    # unnormalized mixture to avoid pt.log(nu) (see ProductDist
                     # path above for the full explanation).
                     log_pdf = pt.log(unnorm_expr)
                     if weights_t is not None:
@@ -534,11 +543,11 @@ class Model:
         if not isinstance(dist, HistFactoryDistChannel):
             expr = dist.expression(context)
             # For extended MixtureDist, cache the unnormalized mixture (Σcᵢfᵢ)
-            # and the expected yield (ν = Σcᵢ).  log_prob uses these to build
+            # and the expected yield (nu = Σcᵢ).  log_prob uses these to build
             # the extended log-likelihood as
-            #   Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν
-            # rather than  Σⱼ log(PDF) + N·log(ν) − ν, avoiding a separate
-            # pt.log(ν) node that can trigger expensive optimiser rewrites.
+            #   Σⱼ log(Σcᵢfᵢ(xⱼ)) - nu
+            # rather than  Σⱼ log(PDF) + N·log(nu) - nu, avoiding a separate
+            # pt.log(nu) node that can trigger expensive optimiser rewrites.
             if isinstance(dist, MixtureDist) and dist.extended:
                 self._extended_yields[node_name] = dist.expected_yield(context)
                 self._extended_unnorm[node_name] = dist.unnormalized_expression(context)

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -240,6 +240,8 @@ class Model:
         # (which do not depend on the observable) appear in a ProductDist alongside
         # the shape PDF: naively summing log(shape x Π_j constr_j) over N events
         # multiplies each constr_j term by N rather than counting it once.
+        # Once-per-likelihood counting matches RooFit but is not specified by
+        # HS3; see https://github.com/scipp-atlas/pyhs3/issues/240.
         seen_constraint_factors: set[str] = set()
 
         for dist_obj, datum in zip(
@@ -253,8 +255,13 @@ class Model:
             if entries is None:
                 # HFDC: log_prob uses the Poisson-only term here; deduplicated
                 # constraint terms are added after the loop.  Non-HFDC distributions
-                # paired with BinnedData (e.g. a Gaussian used as a template) are
-                # skipped because there is no sensible unbinned likelihood for them.
+                # paired with BinnedData are skipped: HS3 does not define the
+                # likelihood of a continuous pdf evaluated on binned data
+                # (bin centers vs bin integrals), and ROOT exports do not record
+                # which convention the original fit used.  Native support is
+                # tracked in https://github.com/scipp-atlas/pyhs3/issues/242
+                # (spec: hep-statistics-serialization-standard issue #93,
+                # export: root-project/root issue #22598).
                 if dist_name in self._hfdc_poisson:
                     terms.append(pt.log(self._hfdc_poisson[dist_name]))
                 continue
@@ -291,7 +298,10 @@ class Model:
 
             # Sum the per-event log-density over events.  Weighted:
             # Σᵢ wᵢ log f(xᵢ); unweighted: Σᵢ log f(xᵢ).  No /total_weight:
-            # that would give an average NLL (wrong scale).
+            # that would give an average NLL (wrong scale).  The weighted form
+            # follows RooFit; HS3 does not define the weighted likelihood — see
+            # https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/92
+            # and https://github.com/scipp-atlas/pyhs3/issues/241.
             if contrib.per_event:
                 log_pdf: TensorVar = (
                     pt.add(*contrib.per_event)

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -24,6 +24,7 @@ from pyhs3.compile import function
 from pyhs3.context import Context
 from pyhs3.data import BinnedData
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
+from pyhs3.distributions.composite import ProductDist
 from pyhs3.domains import Domain
 from pyhs3.functions import Functions
 from pyhs3.networks import build_dependency_graph
@@ -235,6 +236,14 @@ class Model:
         # yields shape (M,) per term — the parameter batch size.
         terms: list[TensorVar] = []
 
+        # Track constraint factor names already contributed so that constraints
+        # shared across multiple channels are only counted once globally.
+        # This prevents the N-fold overcounting that occurs when constraint PDFs
+        # (which do not depend on the observable) appear in a ProductDist alongside
+        # the shape PDF: naively summing log(shape × Π_j constr_j) over N events
+        # multiplies each constr_j term by N rather than counting it once.
+        _seen_constraint_factors: set[str] = set()
+
         for dist_obj, datum in zip(
             self._likelihood.distributions, self._likelihood.data, strict=True
         ):
@@ -252,11 +261,9 @@ class Model:
                     terms.append(pt.log(self._hfdc_poisson[dist_name]))
                 continue
 
-            # model.distributions[name] is the normalized PDF expression with
-            # observables as symbolic pt.vector free inputs.
-            log_pdf: TensorVar = pt.log(self.distributions[dist_name])
-
+            # Resolve weight tensor once for this datum.
             weights = getattr(datum, "weights", None)
+            weights_t: TensorVar | None = None
             if weights is not None:
                 warnings.warn(
                     f"'{datum.name}' has per-event weights; weights are baked as "
@@ -264,7 +271,6 @@ class Model:
                     UserWarning,
                     stacklevel=2,
                 )
-                # (N,) → (N, 1) so it broadcasts correctly against (N, M) log_pdf
                 weights_arr = np.asarray(weights, dtype=np.float64)
                 total_weight = float(np.sum(weights_arr))
                 if not np.isfinite(total_weight) or np.isclose(total_weight, 0.0):
@@ -273,12 +279,59 @@ class Model:
                         "sum of weights must be finite and non-zero."
                     )
                     raise ValueError(msg)
+                # (N,) → (N, 1) so it broadcasts against (N, M) log_pdf.
                 weights_t = pt.constant(weights_arr)[:, None]
-                terms.append(
-                    pt.sum(weights_t * log_pdf, axis=0) / np.float64(total_weight)  # type: ignore[no-untyped-call]
-                )
+
+            # For ProductDist channels, split factors into:
+            #   • shape factors  — depend on the observable (pt.vector inputs) → sum over events
+            #   • constraint factors — depend only on scalar NPs → add once globally
+            #
+            # This separation prevents constraints from being multiplied by N_events.
+            # Observable arrays are built as pt.vector (ndim=1); NP scalars are pt.scalar (ndim=0).
+            _dist_obj = self._distribution_objects.get(dist_name)
+            if isinstance(_dist_obj, ProductDist):
+                shape_log_terms: list[TensorVar] = []
+
+                for factor_name in _dist_obj.factors:
+                    factor_expr: TensorVar | None = self.distributions.get(factor_name)
+                    if factor_expr is None:
+                        continue  # should not happen, but be safe
+                    free_inputs = [
+                        v for v in explicit_graph_inputs([factor_expr])
+                        if v.name is not None
+                    ]
+                    # Observable-dependent factors have at least one vector (rank-1) input.
+                    is_shape = any(v.type.ndim >= 1 for v in free_inputs)
+
+                    if is_shape:
+                        shape_log_terms.append(pt.log(factor_expr))
+                    elif factor_name not in _seen_constraint_factors:
+                        # Add each unique constraint exactly once globally.
+                        _seen_constraint_factors.add(factor_name)
+                        terms.append(pt.log(factor_expr))
+                    # else: already counted from an earlier channel — skip.
+
+                # Sum shape log over events.  No /total_weight: the correct weighted
+                # log-likelihood is Σᵢ wᵢ log f(xᵢ), not a per-event average.
+                if shape_log_terms:
+                    shape_log_pdf: TensorVar = (
+                        pt.add(*shape_log_terms)
+                        if len(shape_log_terms) > 1
+                        else shape_log_terms[0]
+                    )
+                    if weights_t is not None:
+                        terms.append(pt.sum(weights_t * shape_log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                    else:
+                        terms.append(pt.sum(shape_log_pdf, axis=0))  # type: ignore[no-untyped-call]
             else:
-                terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                # Non-ProductDist: standard unbinned log-likelihood.
+                # Weighted: Σᵢ wᵢ log f(xᵢ). Unweighted: Σᵢ log f(xᵢ).
+                # No /total_weight: that would give an average NLL (wrong scale).
+                log_pdf: TensorVar = pt.log(self.distributions[dist_name])
+                if weights_t is not None:
+                    terms.append(pt.sum(weights_t * log_pdf, axis=0))  # type: ignore[no-untyped-call]
+                else:
+                    terms.append(pt.sum(log_pdf, axis=0))  # type: ignore[no-untyped-call]
 
         # Auxiliary distributions (constraint terms) are scalars; they broadcast
         # onto the parameter-scan axis when non-scalar params are present.

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -80,6 +80,22 @@ class TestDistribution:
         f = function([], result)
         assert np.isclose(f(), 1.0)
 
+    def test_distribution_log_prob_terms_default(self):
+        """Base default: a single per-event log(PDF) term, nothing else."""
+
+        class TestDist(Distribution):
+            def likelihood(self, _context):
+                return pt.constant(0.5)
+
+        dist = TestDist(name="test", type="test")
+        terms = dist.log_prob_terms({"test": pt.constant(0.5)}, Distributions([]))
+
+        assert len(terms.per_event) == 1
+        assert terms.channel == []
+        assert terms.constraints == {}
+        f = function([], terms.per_event[0])
+        assert np.isclose(f(), np.log(0.5))
+
 
 class TestProductDist:
     """Test ProductDist implementation."""
@@ -97,6 +113,72 @@ class TestProductDist:
         dist = ProductDist(**config)
         assert dist.name == "test_product"
         assert dist.factors == ["pdf1", "pdf2", "pdf3"]
+
+    def test_product_dist_log_prob_terms_splits_factors(self):
+        """Observable-dependent factors contribute per-event; scalar-only factors
+        become named constraints."""
+        dist = ProductDist(name="channel", factors=["shape", "constr"])
+        x = pt.dvector("x")
+        alpha = pt.dscalar("alpha")
+        expressions = {
+            "shape": pt.exp(-x),
+            "constr": pt.exp(-(alpha**2)),
+        }
+        distributions = Distributions(
+            [
+                GaussianDist(name="shape", x="x", mean=0.0, sigma=1.0),
+                GaussianDist(name="constr", x="alpha", mean=0.0, sigma=1.0),
+            ]
+        )
+
+        terms = dist.log_prob_terms(expressions, distributions)
+
+        assert len(terms.per_event) == 1
+        assert terms.channel == []
+        assert set(terms.constraints) == {"constr"}
+        f = function([x, alpha], [terms.per_event[0], terms.constraints["constr"]])
+        per_event_val, constr_val = f([1.0, 2.0], 3.0)
+        np.testing.assert_allclose(per_event_val, [-1.0, -2.0])  # log(exp(-x)) = -x
+        np.testing.assert_allclose(constr_val, -9.0)  # log(exp(-alpha^2))
+
+    def test_product_dist_log_prob_terms_recurses_into_extended_mixture(self):
+        """A shape factor that is an extended mixture contributes its unnormalized
+        log term per event and its -nu yield term per channel."""
+        mix = MixtureDist(
+            name="mix",
+            summands=["s1", "s2"],
+            coefficients=["c1", "c2"],
+            extended=True,
+        )
+        x = pt.dvector("x")
+        alpha = pt.dscalar("alpha")
+        mix_context = {
+            "c1": pt.constant(10.0),
+            "c2": pt.constant(20.0),
+            "s1": pt.exp(-x),
+            "s2": pt.exp(-0.5 * x),
+        }
+        mix_expr = mix.likelihood(mix_context)
+
+        dist = ProductDist(name="channel", factors=["mix", "constr"])
+        expressions = {
+            "mix": mix_expr,
+            "constr": pt.exp(-(alpha**2)),
+        }
+        distributions = Distributions(
+            [mix, GaussianDist(name="constr", x="alpha", mean=0.0, sigma=1.0)]
+        )
+
+        terms = dist.log_prob_terms(expressions, distributions)
+
+        assert len(terms.per_event) == 1
+        assert len(terms.channel) == 1
+        assert set(terms.constraints) == {"constr"}
+        f = function([x], [terms.per_event[0], terms.channel[0]])
+        per_event_val, channel_val = f([0.0])
+        # per-event at x=0: log(10*1 + 20*1) = log(30); channel: -(10+20)
+        np.testing.assert_allclose(per_event_val, [np.log(30.0)])
+        np.testing.assert_allclose(channel_val, -30.0)
 
     def test_product_dist_expression(self):
         """Test ProductDist expression evaluation."""
@@ -2873,6 +2955,60 @@ class TestMixtureDist:
         unnorm_val, nu_val = f()
         assert np.isclose(unnorm_val, 10.0)
         assert np.isclose(nu_val, 30.0)
+
+    def test_mixture_dist_log_prob_terms_extended(self):
+        """Extended mixture contributes log(sum c_i f_i) per event and -nu per channel."""
+        dist = MixtureDist(
+            name="mix",
+            summands=["pdf1", "pdf2"],
+            coefficients=["coeff1", "coeff2"],
+            extended=True,
+        )
+        context = {
+            "coeff1": pt.constant(10.0),
+            "coeff2": pt.constant(20.0),
+            "pdf1": pt.constant(0.5),
+            "pdf2": pt.constant(0.25),
+        }
+        dist.likelihood(context)
+
+        terms = dist.log_prob_terms({}, Distributions([]))
+
+        assert len(terms.per_event) == 1
+        assert len(terms.channel) == 1
+        assert terms.constraints == {}
+        f = function([], [terms.per_event[0], terms.channel[0]])
+        per_event_val, channel_val = f()
+        # per-event: log(10*0.5 + 20*0.25) = log(10); channel: -nu = -(10+20)
+        assert np.isclose(per_event_val, np.log(10.0))
+        assert np.isclose(channel_val, -30.0)
+
+    def test_mixture_dist_log_prob_terms_requires_likelihood(self):
+        """Extended mixture log_prob_terms raises if likelihood() has not run."""
+        dist = MixtureDist(
+            name="mix",
+            summands=["pdf1", "pdf2"],
+            coefficients=["coeff1", "coeff2"],
+            extended=True,
+        )
+        with pytest.raises(RuntimeError, match="likelihood"):
+            dist.log_prob_terms({}, Distributions([]))
+
+    def test_mixture_dist_log_prob_terms_non_extended_uses_default(self):
+        """Non-extended mixture falls back to the base log(PDF) contribution."""
+        dist = MixtureDist(
+            name="mix",
+            summands=["pdf1", "pdf2"],
+            coefficients=["coeff1"],
+            extended=False,
+        )
+        terms = dist.log_prob_terms({"mix": pt.constant(0.7)}, Distributions([]))
+
+        assert len(terms.per_event) == 1
+        assert terms.channel == []
+        assert terms.constraints == {}
+        f = function([], terms.per_event[0])
+        assert np.isclose(f(), np.log(0.7))
 
     def test_mixture_dist_extended_likelihood_inherits_default(self):
         """MixtureDist does not override extended_likelihood; the Poisson yield

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -2822,66 +2822,77 @@ class TestMixtureDist:
         ):
             dist.expected_yield(context)
 
-    def test_mixture_dist_extended_likelihood(self):
-        """Test extended_likelihood method."""
+    def test_mixture_dist_unnormalized_expression(self):
+        """Test unnormalized_expression returns sum(c_i * f_i) without normalization."""
         dist = MixtureDist(
             name="test_mixture",
-            summands=["pdf1", "pdf2", "pdf3"],
-            coefficients=["coeff1", "coeff2", "coeff3"],
-            extended=True,
-        )
-
-        context = {
-            "coeff1": pt.constant(10.0),
-            "coeff2": pt.constant(20.0),
-            "coeff3": pt.constant(30.0),
-        }
-
-        n_observed = pt.constant(50.0)
-        result = dist.extended_likelihood(context, n_observed)
-        f = function([], result)
-        likelihood_val = f()
-
-        # Expected: Pois(50 | 60) = exp(50 * log(60) - 60 - log(50!))
-        log_pois = 50 * np.log(60) - 60 - math.lgamma(50 + 1)
-        expected = np.exp(log_pois)
-        assert np.isclose(likelihood_val, expected)
-
-    def test_mixture_dist_extended_likelihood_non_extended_error(self):
-        """Test that extended_likelihood raises error for non-extended PDFs."""
-        dist = MixtureDist(
-            name="test_mixture",
-            summands=["pdf1", "pdf2", "pdf3"],
+            summands=["pdf1", "pdf2"],
             coefficients=["coeff1", "coeff2"],
-            extended=False,
+            extended=True,
         )
 
-        context = {"coeff1": pt.constant(10.0), "coeff2": pt.constant(20.0)}
+        context = {
+            "coeff1": pt.constant(10.0),
+            "coeff2": pt.constant(20.0),
+            "pdf1": pt.constant(0.5),
+            "pdf2": pt.constant(0.25),
+        }
 
-        extended_likelihood = dist.extended_likelihood(context, pt.constant(50.0))
-        assert isinstance(extended_likelihood, pt.variable.TensorConstant)
-        assert extended_likelihood.value == 1.0
-        assert extended_likelihood.type == pt.TensorType(dtype=np.float32, shape=())
+        result = dist.unnormalized_expression(context)
+        f = function([], result)
 
-    def test_mixture_dist_extended_likelihood_no_data(self):
-        """Test extended_likelihood method when data is None."""
+        # Expected: 10 * 0.5 + 20 * 0.25 = 10.0 (no division by sum of coefficients)
+        assert np.isclose(f(), 10.0)
+
+    def test_mixture_dist_unnormalized_expression_reuses_likelihood_nodes(self):
+        """After likelihood(), unnormalized_expression and expected_yield return the
+        same PyTensor nodes built during likelihood() rather than fresh subgraphs."""
+        dist = MixtureDist(
+            name="test_mixture",
+            summands=["pdf1", "pdf2"],
+            coefficients=["coeff1", "coeff2"],
+            extended=True,
+        )
+
+        context = {
+            "coeff1": pt.constant(10.0),
+            "coeff2": pt.constant(20.0),
+            "pdf1": pt.constant(0.5),
+            "pdf2": pt.constant(0.25),
+        }
+
+        dist.likelihood(context)
+        unnorm = dist.unnormalized_expression(context)
+        nu = dist.expected_yield(context)
+
+        # Repeated calls return the identical cached nodes (no duplicate subgraphs)
+        assert dist.unnormalized_expression(context) is unnorm
+        assert dist.expected_yield(context) is nu
+
+        f = function([], [unnorm, nu])
+        unnorm_val, nu_val = f()
+        assert np.isclose(unnorm_val, 10.0)
+        assert np.isclose(nu_val, 30.0)
+
+    def test_mixture_dist_extended_likelihood_inherits_default(self):
+        """MixtureDist does not override extended_likelihood; the Poisson yield
+        term is data-dependent and assembled by Model.log_prob instead."""
         dist = MixtureDist(
             name="test_mixture",
             summands=["pdf1", "pdf2", "pdf3"],
             coefficients=["coeff1", "coeff2", "coeff3"],
             extended=True,
         )
+
         context = {
             "coeff1": pt.constant(10.0),
             "coeff2": pt.constant(20.0),
             "coeff3": pt.constant(30.0),
         }
 
-        # Test with data=None - should return 1.0 (no contribution)
-        result = dist.extended_likelihood(context, data=None)
+        result = dist.extended_likelihood(context)
         f = function([], result)
-        likelihood_val = f()
-        assert np.isclose(likelihood_val, 1.0)
+        assert np.isclose(f(), 1.0)
 
     def test_mixture_dist_log_expression(self):
         """Test log_expression method returns log of expression."""

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -815,6 +815,38 @@ def test_log_prob_product_dist_counts_constraint_once():
     assert val == pytest.approx(shape_lp + constraint_lp, abs=1e-6)
 
 
+def test_log_prob_product_dist_constraint_only_channel():
+    """A ProductDist with only constraint factors (no shape factor) contributes
+    just the constraint term — the per-event sum is skipped entirely."""
+    ws_dict = {
+        **_WS_PRODUCT_CONSTRAINT,
+        "distributions": [
+            d
+            for d in _WS_PRODUCT_CONSTRAINT["distributions"]
+            if d["name"] != "channel1"
+        ]
+        + [
+            {
+                "name": "channel1",
+                "type": "product_dist",
+                "factors": ["constr_alpha"],
+            }
+        ],
+    }
+    ws = Workspace(**ws_dict)
+    model = ws.model(ws.analyses["A"], progress=False)
+    lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    params = {k: v for k, v in model.nominal_params.items() if k in inputs_map}
+    val = float(fn(**params).item())
+
+    assert val == pytest.approx(float(norm.logpdf(0.5, loc=0.0, scale=1.0)), abs=1e-6)
+
+
 def test_log_prob_shared_constraint_across_channels_counted_once():
     """A constraint factor shared by two ProductDist channels is counted once globally."""
     ws_dict = {

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import numpy as np
 import pytensor
 import pytest
-from scipy.stats import truncnorm
+from scipy.stats import norm, truncnorm
 
 try:
     import jax.numpy as jnp
@@ -690,3 +690,357 @@ def test_log_prob_aux_distributions_contributes_to_log_prob():
     # With the constraint, log_prob gains an extra log(N(0|0,1)) term.
     assert val_with != pytest.approx(val_without)
     assert val_with < val_without  # constraint N(0|0,1) < 1, so log < 0
+
+
+# ---------------------------------------------------------------------------
+# Weighted data: log_prob is sum(w_i * log f(x_i)), not a weighted average
+# ---------------------------------------------------------------------------
+
+
+def test_log_prob_weighted_data_sums_weighted_logpdf():
+    """Weighted unbinned data contributes sum(w_i * log f(x_i)) at full scale."""
+    weights = [2.0, 1.0, 1.0, 1.0, 3.0]
+    ws_w = Workspace(
+        **{
+            **_WS_DICT,
+            "data": [
+                {
+                    "name": "data1",
+                    "type": "unbinned",
+                    "axes": [{"name": "x_obs", "min": -10.0, "max": 10.0}],
+                    "entries": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+                    "weights": weights,
+                },
+                _WS_DICT["data"][1],
+            ],
+        }
+    )
+    model = ws_w.model(ws_w.analyses["A"], progress=False)
+    with pytest.warns(UserWarning, match="weights"):
+        lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    val = float(fn(**model.data, **model.nominal_params).item())
+
+    events1 = [1.0, 2.0, 3.0, 4.0, 5.0]
+    events2 = [0.5, 1.5, 2.5, 3.5, 4.5]
+    expected = sum(
+        w * _truncnorm_logpdf(x, 2.0, 1.0, -10.0, 10.0)
+        for w, x in zip(weights, events1, strict=True)
+    ) + sum(_truncnorm_logpdf(y, 2.0, 2.0, -10.0, 10.0) for y in events2)
+
+    assert val == pytest.approx(expected, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# ProductDist channels: constraint factors counted once, not once per event
+# ---------------------------------------------------------------------------
+
+_WS_PRODUCT_CONSTRAINT: dict = {
+    "metadata": {"hs3_version": "0.2"},
+    "distributions": [
+        {
+            "name": "shape1",
+            "type": "gaussian_dist",
+            "x": "x_obs",
+            "mean": "mean",
+            "sigma": 1.0,
+        },
+        {
+            "name": "constr_alpha",
+            "type": "gaussian_dist",
+            "x": "alpha",
+            "mean": 0.0,
+            "sigma": 1.0,
+        },
+        {
+            "name": "channel1",
+            "type": "product_dist",
+            "factors": ["shape1", "constr_alpha"],
+        },
+    ],
+    "domains": [
+        {
+            "name": "main",
+            "type": "product_domain",
+            "axes": [
+                {"name": "mean", "min": -10.0, "max": 10.0},
+                {"name": "alpha", "min": -5.0, "max": 5.0},
+            ],
+        }
+    ],
+    "data": [
+        {
+            "name": "data1",
+            "type": "unbinned",
+            "axes": [{"name": "x_obs", "min": -10.0, "max": 10.0}],
+            "entries": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+        },
+    ],
+    "likelihoods": [{"name": "L", "distributions": ["channel1"], "data": ["data1"]}],
+    "analyses": [
+        {"name": "A", "likelihood": "L", "domains": ["main"], "init": "params"}
+    ],
+    "parameter_points": [
+        {
+            "name": "params",
+            "parameters": [
+                {"name": "mean", "value": 2.0},
+                {"name": "alpha", "value": 0.5},
+            ],
+        }
+    ],
+}
+
+
+def test_log_prob_product_dist_counts_constraint_once():
+    """A scalar constraint factor in a ProductDist contributes once, not N_events times."""
+    ws = Workspace(**_WS_PRODUCT_CONSTRAINT)
+    model = ws.model(ws.analyses["A"], progress=False)
+    lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    val = float(fn(**model.data, **model.nominal_params).item())
+
+    events1 = [1.0, 2.0, 3.0, 4.0, 5.0]
+    shape_lp = sum(_truncnorm_logpdf(x, 2.0, 1.0, -10.0, 10.0) for x in events1)
+    constraint_lp = float(norm.logpdf(0.5, loc=0.0, scale=1.0))
+
+    assert val == pytest.approx(shape_lp + constraint_lp, abs=1e-6)
+
+
+def test_log_prob_shared_constraint_across_channels_counted_once():
+    """A constraint factor shared by two ProductDist channels is counted once globally."""
+    ws_dict = {
+        **_WS_PRODUCT_CONSTRAINT,
+        "distributions": [
+            *_WS_PRODUCT_CONSTRAINT["distributions"],
+            {
+                "name": "shape2",
+                "type": "gaussian_dist",
+                "x": "y_obs",
+                "mean": "mean",
+                "sigma": 2.0,
+            },
+            {
+                "name": "channel2",
+                "type": "product_dist",
+                "factors": ["shape2", "constr_alpha"],
+            },
+        ],
+        "data": [
+            *_WS_PRODUCT_CONSTRAINT["data"],
+            {
+                "name": "data2",
+                "type": "unbinned",
+                "axes": [{"name": "y_obs", "min": -10.0, "max": 10.0}],
+                "entries": [[0.5], [1.5], [2.5]],
+            },
+        ],
+        "likelihoods": [
+            {
+                "name": "L",
+                "distributions": ["channel1", "channel2"],
+                "data": ["data1", "data2"],
+            }
+        ],
+    }
+    ws = Workspace(**ws_dict)
+    model = ws.model(ws.analyses["A"], progress=False)
+    lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    val = float(fn(**model.data, **model.nominal_params).item())
+
+    events1 = [1.0, 2.0, 3.0, 4.0, 5.0]
+    events2 = [0.5, 1.5, 2.5]
+    shape_lp = sum(_truncnorm_logpdf(x, 2.0, 1.0, -10.0, 10.0) for x in events1) + sum(
+        _truncnorm_logpdf(y, 2.0, 2.0, -10.0, 10.0) for y in events2
+    )
+    constraint_lp = float(norm.logpdf(0.5, loc=0.0, scale=1.0))
+
+    assert val == pytest.approx(shape_lp + constraint_lp, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Extended MixtureDist channels: Poisson yield term included in log_prob
+# ---------------------------------------------------------------------------
+
+_WS_EXTENDED_MIXTURE: dict = {
+    "metadata": {"hs3_version": "0.2"},
+    "distributions": [
+        {
+            "name": "sig",
+            "type": "gaussian_dist",
+            "x": "x_obs",
+            "mean": "mean",
+            "sigma": 1.0,
+        },
+        {
+            "name": "bkg",
+            "type": "gaussian_dist",
+            "x": "x_obs",
+            "mean": 0.0,
+            "sigma": 2.0,
+        },
+        {
+            "name": "mix",
+            "type": "mixture_dist",
+            "summands": ["sig", "bkg"],
+            "coefficients": ["c_sig", "c_bkg"],
+            "extended": True,
+        },
+    ],
+    "domains": [
+        {
+            "name": "main",
+            "type": "product_domain",
+            "axes": [
+                {"name": "mean", "min": -10.0, "max": 10.0},
+                {"name": "c_sig", "min": 0.0, "max": 100.0},
+                {"name": "c_bkg", "min": 0.0, "max": 100.0},
+            ],
+        }
+    ],
+    "data": [
+        {
+            "name": "data1",
+            "type": "unbinned",
+            "axes": [{"name": "x_obs", "min": -10.0, "max": 10.0}],
+            "entries": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+        },
+    ],
+    "likelihoods": [{"name": "L", "distributions": ["mix"], "data": ["data1"]}],
+    "analyses": [
+        {"name": "A", "likelihood": "L", "domains": ["main"], "init": "params"}
+    ],
+    "parameter_points": [
+        {
+            "name": "params",
+            "parameters": [
+                {"name": "mean", "value": 2.0},
+                {"name": "c_sig", "value": 30.0},
+                {"name": "c_bkg", "value": 20.0},
+            ],
+        }
+    ],
+}
+
+
+def _extended_mixture_logprob(
+    events: list[float], mean: float, c_sig: float, c_bkg: float
+) -> float:
+    """Reference extended log-likelihood: sum_j log(sum_i c_i f_i(x_j)) - nu.
+
+    Equivalent to sum_j log(PDF(x_j)) + N*log(nu) - nu with nu = sum_i c_i
+    (RooFit RooAddPdf extended-likelihood convention, up to the data-only
+    -log(N!) constant which pyhs3 omits).
+    """
+    nu = c_sig + c_bkg
+    lp = sum(
+        np.log(
+            c_sig * np.exp(_truncnorm_logpdf(x, mean, 1.0, -10.0, 10.0))
+            + c_bkg * np.exp(_truncnorm_logpdf(x, 0.0, 2.0, -10.0, 10.0))
+        )
+        for x in events
+    )
+    return float(lp - nu)
+
+
+def test_log_prob_extended_mixture_includes_poisson_term():
+    """Extended MixtureDist channel includes the -nu Poisson yield term."""
+    ws = Workspace(**_WS_EXTENDED_MIXTURE)
+    model = ws.model(ws.analyses["A"], progress=False)
+    lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    val = float(fn(**model.data, **model.nominal_params).item())
+
+    expected = _extended_mixture_logprob(
+        [1.0, 2.0, 3.0, 4.0, 5.0], mean=2.0, c_sig=30.0, c_bkg=20.0
+    )
+    assert val == pytest.approx(expected, abs=1e-6)
+
+
+def test_log_prob_extended_mixture_depends_on_yield():
+    """log_prob changes by -delta(nu) when only the total yield changes."""
+    ws = Workspace(**_WS_EXTENDED_MIXTURE)
+    model = ws.model(ws.analyses["A"], progress=False)
+    lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+
+    params = dict(model.nominal_params)
+    val_nominal = float(fn(**model.data, **params).item())
+    # Double both yields: the normalized PDF (shape) is unchanged, so the
+    # difference comes from N*log(2) - nu_extra in the extended term.
+    params["c_sig"] = np.float64(60.0)
+    params["c_bkg"] = np.float64(40.0)
+    val_doubled = float(fn(**model.data, **params).item())
+
+    n_events = 5
+    expected_delta = n_events * np.log(2.0) - 50.0
+    assert val_doubled - val_nominal == pytest.approx(expected_delta, abs=1e-6)
+
+
+def test_log_prob_product_extended_mixture_with_constraint():
+    """ProductDist(extended mixture, scalar constraint): both new paths combine."""
+    ws_dict = {
+        **_WS_EXTENDED_MIXTURE,
+        "distributions": [
+            *_WS_EXTENDED_MIXTURE["distributions"],
+            {
+                "name": "constr_alpha",
+                "type": "gaussian_dist",
+                "x": "alpha",
+                "mean": 0.0,
+                "sigma": 1.0,
+            },
+            {
+                "name": "channel1",
+                "type": "product_dist",
+                "factors": ["mix", "constr_alpha"],
+            },
+        ],
+        "likelihoods": [
+            {"name": "L", "distributions": ["channel1"], "data": ["data1"]}
+        ],
+        "parameter_points": [
+            {
+                "name": "params",
+                "parameters": [
+                    *_WS_EXTENDED_MIXTURE["parameter_points"][0]["parameters"],
+                    {"name": "alpha", "value": 0.5},
+                ],
+            }
+        ],
+    }
+    ws = Workspace(**ws_dict)
+    model = ws.model(ws.analyses["A"], progress=False)
+    lp_expr = model.log_prob
+
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    val = float(fn(**model.data, **model.nominal_params).item())
+
+    expected = _extended_mixture_logprob(
+        [1.0, 2.0, 3.0, 4.0, 5.0], mean=2.0, c_sig=30.0, c_bkg=20.0
+    ) + float(norm.logpdf(0.5, loc=0.0, scale=1.0))
+    assert val == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
## Summary

Extracts the core NLL fixes from @mhance's `profile-scan-v2` branch (debugging the dihiggs pyhs3-vs-quickFit validation), plus regression tests and a style/architecture cleanup. Three behavior fixes to `Model.log_prob`:

- **Constraint counting**: constraint factors inside `ProductDist` channels (scalar-only PDFs, e.g. NP constraints) are now added to the log-likelihood **once globally**, instead of being multiplied by the number of events via `sum(log(shape × constraint))`. Constraints shared across channels are also deduplicated.
- **Weighted data scale**: weighted unbinned data now contributes `Σ wᵢ·log f(xᵢ)` (the standard weighted log-likelihood) instead of dividing by the total weight, which produced a per-event *average* at the wrong scale.
- **Extended MixtureDist Poisson term**: channels with `extended=True` mixtures now include the extended-likelihood yield term. `log_prob` builds it as `Σⱼ log(Σcᵢfᵢ(xⱼ)) − ν` — algebraically identical to `Σⱼ log(PDF) + N·log(ν) − ν` but avoiding a `pt.log(ν)` node that triggers costly PyTensor rewrite cascades. For weighted data this form automatically reproduces RooFit's sum-of-weights convention.

## Architecture

`MixtureDist.extended_likelihood()` is **removed** (breaking for direct callers). The Poisson yield term depends on the observed event count, which `_expression(context)` never has — so the override could only ever return 1.0 in the model path, which is exactly how the term went missing. This mirrors RooFit: `RooAddPdf` provides `expectedEvents()` but the extended term is added by the NLL machinery (`RooNLLVar` → `RooAbsPdf::extendedTerm`), not by the pdf value. The distribution now exposes exactly the pieces the model needs: the `extended` flag, `expected_yield()`, and `unnormalized_expression()` (cached as declared `PrivateAttr`s so `log_prob` reuses the same PyTensor nodes built by `likelihood()`).

`extended_likelihood()` remains on the `Distribution` base class for context-only terms (HistFactory constraints).

## Tests

Six new value-level regression tests in `test_model_likelihood.py` validated against scipy `truncnorm`/`norm` references — **all six fail against main's `log_prob`** and pass with the fixes:

- constraint counted once (single channel + shared across two channels)
- weighted data at full scale
- extended mixture Poisson term (bare, yield-doubling delta, and `ProductDist(mixture, constraint)` as in the dihiggs workspace)

Plus unit tests for `unnormalized_expression()` (value + cached-node identity). Full suite: 942 passed; pre-commit and docs build clean.

## Validation context

With these fixes the binned/unbinned and true-unbinned representations of the dihiggs workspace agree with each other, and the pyhs3-vs-quickFit profile minima align at the same μ̂. A constant NLL offset vs quickFit remains (expected: data-only constants like −log N! that RooFit keeps), plus a small residual μ-dependent curvature difference still under investigation — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster mixture evaluations via cached internal expressions; mixture yields now contribute proper per-event and channel terms.
  * More accurate weighted unbinned likelihoods (sums of weighted log-PDFs).
  * Structured log-prob terms exposed for clearer per-event/channel/constraint separation.

* **Bug Fixes**
  * Constraint factors deduplicated so shared constraints count once across channels.

* **Documentation**
  * Clarified when to override extended-likelihood behavior.

* **Tests**
  * Expanded coverage for mixtures, weighting, and constraint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Spec and export ambiguities (upstream issues)

Several behaviors in this PR reproduce RooFit conventions that HS3 does not (yet) specify, and that ROOT's HS3 export does not make recoverable. Rather than silently hard-coding them, each convention point in the source cites the upstream issue and a pyhs3 tracking issue describing what should change once the semantics are pinned down:

**HS3 spec** (hep-statistics-serialization-standard):
- [#90](https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/90) — counting semantics of `product_dist` factors that don't depend on the paired dataset (the constraint-counting fix in this PR implements RooFit's once-per-likelihood reading)
- [#91](https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/91) — exact extended-term form (`−log N!` omitted here; `N_eff = Σw` for weighted data)
- [#92](https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/92) — weighted unbinned likelihood definition (`Σwᵢ·log f(xᵢ)`, not an average)
- [#93](https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/issues/93) — continuous pdf paired with binned data (bin centers vs bin integrals)

**ROOT export** (root-project/root):
- [#22597](https://github.com/root-project/root/issues/22597) — constraints serialized as product factors with global observables as `const` parameters
- [#22598](https://github.com/root-project/root/issues/22598) — binned-data-vs-continuous-pdf evaluation convention unrecoverable from the export

**pyhs3 follow-ups**:
- #240 — remove the structural shape-vs-constraint inference once the spec settles
- #241 — revisit extended/weighted conventions once specified
- #242 — native support for continuous pdfs paired with `BinnedData` (currently skipped; the dihiggs validation works around this via external binned→weighted-unbinned conversion)
