### PR TITLE
feat: Set domain default to 'default_domain' when loading a model

### DIFF
--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -490,9 +490,10 @@ class Workspace(BaseModel):
         Args:
             domain: Explicit override (a ``Domain`` instance, int, or str key) or
                 ``None`` to use *default_index*.
-            default_index: Index/key to use when *domain* is ``None``.  If both are
-                ``None`` and no domain collection exists, returns a default
-                ``ProductDomain``.
+            default_index: Index/key to use when *domain* is ``None``. If both are
+                ``None``, ``default_domain`` is preferred when present before
+                falling back to the first domain. If no domain collection exists,
+                returns a default ``ProductDomain``.
         """
         if isinstance(domain, Domain):
             return domain
@@ -504,6 +505,9 @@ class Workspace(BaseModel):
         if default_index is not None and self.domains:
             return self.domains[default_index]
         if self.domains:
+            default_domain = self.domains.get("default_domain")
+            if default_domain is not None:
+                return default_domain
             return self.domains[0]
         return ProductDomain(name="default")
 
@@ -527,8 +531,9 @@ class Workspace(BaseModel):
           :attr:`~pyhs3.model.Model.log_prob`, :attr:`~pyhs3.model.Model.data`,
           and :attr:`~pyhs3.model.Model.free_params`.
         - :class:`~pyhs3.likelihoods.Likelihood` — observable bounds are derived
-          from the likelihood's data; ``domain`` and ``parameter_set`` fall back
-          to workspace defaults (index 0) unless overridden.
+          from the likelihood's data; ``domain`` falls back to ``default_domain``
+          then index 0, and ``parameter_set`` falls back to workspace defaults
+          unless overridden.
         - ``str`` — searches analyses then likelihoods by name; delegates to the
           appropriate registered path.  Falls back to legacy domain indexing if
           the name is not found in either.

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -118,6 +118,37 @@ def test_model_from_likelihood_returns_model():
     assert isinstance(model, Model)
 
 
+def test_model_from_likelihood_prefers_named_default_domain():
+    """ws.model(likelihood) uses default_domain before falling back to domains[0]."""
+    ws = Workspace(
+        **{
+            **_WS_DICT,
+            "domains": [
+                {
+                    "name": "a_nondefault_domain",
+                    "type": "product_domain",
+                    "axes": [{"name": "mean", "min": -1.0, "max": 1.0}],
+                },
+                {
+                    "name": "default_domain",
+                    "type": "product_domain",
+                    "axes": [{"name": "mean", "min": -10.0, "max": 10.0}],
+                },
+                {
+                    "name": "non_default_domain",
+                    "type": "product_domain",
+                    "axes": [{"name": "mean", "min": -5.0, "max": 5.0}],
+                },
+            ],
+            "analyses": [],
+        }
+    )
+
+    model = ws.model(ws.likelihoods["L"], progress=False)
+
+    assert model.domain.name == "default_domain"
+
+
 def test_model_legacy_int_still_works():
     ws = _ws()
     model = ws.model(0)


### PR DESCRIPTION
Change the current default settings for loading a domain when building a likelihood.

This PR fixes https://github.com/scipp-atlas/pyhs3/issues/229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how models choose a domain when no domain is explicitly provided and no default index is set, now preferring a named “default domain” before falling back to other options.

* **Documentation**
  * Updated the likelihood-related model documentation to match the revised domain-selection precedence.

* **Tests**
  * Added coverage to verify that the model selects the “default domain” when multiple domains are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->