### PR TITLE
fix: reject conflicting observable bounds across likelihoods

### DIFF
--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -411,10 +411,24 @@ class Workspace(BaseModel):
         gets bounds from the data axis itself (axis.min/max). Propagates observable
         info through composite distributions (MixtureDist, ProductDist).
 
+        Used by the legacy ``model(int)`` and name-fallback ``model(str)`` paths,
+        which have no single likelihood to scope observables to and therefore merge
+        axes across every likelihood in the workspace. This is unlike the
+        per-likelihood ``model(Likelihood)`` / ``model(Analysis)`` paths, which use
+        :meth:`_extract_observables` and never mix bounds across likelihoods.
+
         Returns:
             Dictionary mapping observable names to (min, max) tuples
+
+        Raises:
+            ValueError: If the same axis name appears in more than one likelihood
+                with different ``(min, max)`` bounds, since merging would silently
+                pick whichever likelihood happened to be processed last.
         """
         observables: dict[str, tuple[float, float]] = {}
+        # Track which likelihood first defined each axis, so a conflict error can
+        # name both sides.
+        sources: dict[str, str] = {}
 
         if not self.likelihoods or not self.data:
             return observables
@@ -439,7 +453,20 @@ class Workspace(BaseModel):
 
                 # For each axis, extract bounds
                 for axis in datum.axes:
-                    observables[axis.name] = (axis.min, axis.max)
+                    bounds = (axis.min, axis.max)
+                    prev_bounds = observables.get(axis.name)
+                    if prev_bounds is not None and prev_bounds != bounds:
+                        msg = (
+                            f"Observable axis '{axis.name}' has conflicting bounds "
+                            f"across likelihoods: {prev_bounds} in likelihood "
+                            f"'{sources[axis.name]}' vs {bounds} in likelihood "
+                            f"'{likelihood.name}'. Each observable axis name must "
+                            "have the same bounds everywhere it is used, or be "
+                            "accessed via its own likelihood (workspace.model(likelihood))."
+                        )
+                        raise ValueError(msg)
+                    observables[axis.name] = bounds
+                    sources[axis.name] = likelihood.name
 
         return observables
 

--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -466,7 +466,7 @@ class Workspace(BaseModel):
                         )
                         raise ValueError(msg)
                     observables[axis.name] = bounds
-                    sources[axis.name] = likelihood.name
+                    sources.setdefault(axis.name, likelihood.name)
 
         return observables
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -11,6 +11,9 @@ import pytest
 
 from pyhs3 import Workspace
 from pyhs3.analyses import Analyses, Analysis
+from pyhs3.data import BinnedData, Data
+from pyhs3.distributions import Distributions
+from pyhs3.distributions.mathematical import GenericDist
 from pyhs3.exceptions import WorkspaceValidationError
 from pyhs3.likelihoods import Likelihood, Likelihoods
 from pyhs3.metadata import Metadata
@@ -219,6 +222,71 @@ class TestWorkspaceFKResolutionWithNoneCollections:
                 distributions=None,
                 data=None,
             )
+
+
+class TestComputeObservablesConflict:
+    """Tests for Workspace._compute_observables() cross-likelihood bound conflicts."""
+
+    @staticmethod
+    def _make_workspace(
+        bounds_a: tuple[float, float], bounds_b: tuple[float, float]
+    ) -> Workspace:
+        """Build a workspace with two likelihoods that each define an 'x' axis."""
+        return Workspace(
+            metadata=Metadata(hs3_version="0.3.0"),
+            distributions=Distributions(
+                [
+                    GenericDist(name="dist_a", expression="exp(-x)"),
+                    GenericDist(name="dist_b", expression="exp(-x)"),
+                ]
+            ),
+            data=Data(
+                [
+                    BinnedData(
+                        name="data_a",
+                        axes=[
+                            {
+                                "name": "x",
+                                "min": bounds_a[0],
+                                "max": bounds_a[1],
+                                "nbins": 10,
+                            }
+                        ],
+                        contents=[1.0] * 10,
+                    ),
+                    BinnedData(
+                        name="data_b",
+                        axes=[
+                            {
+                                "name": "x",
+                                "min": bounds_b[0],
+                                "max": bounds_b[1],
+                                "nbins": 10,
+                            }
+                        ],
+                        contents=[1.0] * 10,
+                    ),
+                ]
+            ),
+            likelihoods=Likelihoods(
+                [
+                    Likelihood(name="lk_a", distributions=["dist_a"], data=["data_a"]),
+                    Likelihood(name="lk_b", distributions=["dist_b"], data=["data_b"]),
+                ]
+            ),
+        )
+
+    def test_conflicting_bounds_raise(self):
+        """Same axis name with different (min, max) across likelihoods must raise."""
+        workspace = self._make_workspace(bounds_a=(0.0, 10.0), bounds_b=(0.0, 20.0))
+        with pytest.raises(ValueError, match="conflicting bounds"):
+            workspace._compute_observables()
+
+    def test_identical_bounds_do_not_raise(self):
+        """Same axis name with identical (min, max) across likelihoods is fine."""
+        workspace = self._make_workspace(bounds_a=(0.0, 10.0), bounds_b=(0.0, 10.0))
+        observables = workspace._compute_observables()
+        assert observables["x"] == (0.0, 10.0)
 
 
 class TestWorkspaceRepr:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- `Workspace._compute_observables()` merged observable axes across **all** likelihoods with unconditional `observables[axis.name] = (axis.min, axis.max)` — last likelihood processed wins silently.
- If two likelihoods defined the same axis name with different `(min, max)` bounds, the legacy `ws.model(int)` / name-fallback `ws.model(str)` paths silently used the wrong bounds for one of them.
- Fix: keep merging, but raise a `ValueError` (naming both conflicting likelihoods and their bounds) when the same axis name appears with **different** bounds. Identical re-definitions across likelihoods still merge fine.
- The per-likelihood `model(Likelihood)` / `model(Analysis)` paths already scope observables to a single likelihood via `Workspace._extract_observables()` and are unaffected by this change.

Refs #230 (item 14c).

## Test plan

- [x] Added failing tests first (RED): `TestComputeObservablesConflict` in `tests/test_workspace.py` — one case with conflicting bounds across two likelihoods (`pytest.raises(ValueError, match="conflicting bounds")`), one case with identical bounds across two likelihoods that still succeeds.
- [x] Implemented the guard in `Workspace._compute_observables()`, confirmed GREEN.
- [x] Full quick suite: `pixi run --environment py312 test` → 1051 passed, 3 skipped, 9 deselected, 1 xfailed.
- [x] Coverage on `workspace.py` remains 100% (statements and branches).
- [x] `pre-commit run --files src/pyhs3/workspace.py tests/test_workspace.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for shared observable axis bounds so conflicting ranges now raise an error instead of being silently overwritten.
  * Improved handling of merged observables across multiple likelihoods to ensure consistent axis bounds are returned.
* **Tests**
  * Added coverage for both conflicting and matching bounds cases to verify the new error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->