### PR TITLE
fix: make interpolate_code2 continuous at alpha=±1

### DIFF
--- a/src/pyhs3/distributions/histfactory/interpolations.py
+++ b/src/pyhs3/distributions/histfactory/interpolations.py
@@ -291,6 +291,20 @@ def interpolate_code2(
         \end{cases}
 
     with :math:`a = \frac{1}{2}((I^+ - I^0) + (I^- - I^0))` and :math:`b = \frac{1}{2}((I^+ - I^0) - (I^- - I^0))`.
+
+    .. note::
+
+        This is deliberately discontinuous at :math:`\alpha = \pm 1`: the linear
+        extrapolation branches omit the ``+ (hi - nom)`` / ``+ (lo - nom)`` offset
+        that would make them meet the quadratic branch. This faithfully reproduces
+        pyhf's ``code2`` interpolator, whose reference ("slow") implementation
+        computes exactly the same unshifted extrapolation
+        (``pyhf/interpolators/code2.py::_slow_code2.summand``, scikit-hep/pyhf,
+        e.g. https://github.com/scikit-hep/pyhf/blob/main/src/pyhf/interpolators/code2.py).
+        ROOT's ``FlexibleInterpVar``/``PiecewiseInterpolation`` code 2
+        (``RooFit::Detail::MathFuncs::flexibleInterpSingle``) *does* include the
+        offset and is therefore continuous at the boundary -- see
+        :func:`interpolate_parabolic` for that variant.
     """
     # Calculate quadratic coefficients
     hi_delta = hi - nom
@@ -302,7 +316,10 @@ def interpolate_code2(
     # Quadratic interpolation for |alpha| < 1
     quad_result = nom + a * alpha**2 + b * alpha
 
-    # Linear extrapolation for |alpha| >= 1
+    # Linear extrapolation for |alpha| >= 1.
+    # Intentionally omits the "+ hi_delta" / "+ lo_delta" offset (unlike
+    # interpolate_parabolic): pyhf's code2 extrapolation is discontinuous at
+    # alpha=+-1 by construction, and this mirrors that behavior exactly.
     high_ext = nom + (b + 2 * a) * (alpha - 1)
     low_ext = nom + (b - 2 * a) * (alpha + 1)
 

--- a/src/pyhs3/distributions/histfactory/interpolations.py
+++ b/src/pyhs3/distributions/histfactory/interpolations.py
@@ -274,7 +274,9 @@ def interpolate_code2(
     alpha: TensorVar, nom: TensorVar, hi: TensorVar, lo: TensorVar
 ) -> TensorVar:
     r"""
-    pyhf code2 quadratic interpolation with linear extrapolation (additive deltas).
+    Code2 quadratic interpolation with continuous linear extrapolation (additive deltas).
+
+    Alias for :func:`interpolate_parabolic`.
 
     .. math::
 
@@ -285,52 +287,25 @@ def interpolate_code2(
     .. math::
 
         I_{\text{quad|lin}}(\alpha; I^0, I^+, I^-) = \begin{cases}
-        (b + 2a)(\alpha - 1) & \text{if } \alpha \geq 1 \\
-        a\alpha^2 + b\alpha & \text{if } |\alpha| < 1 \\
-        (b - 2a)(\alpha + 1) & \text{if } \alpha < -1
+        (b + 2a)(\alpha - 1) + (a + b) & \text{if } \alpha > 1 \\
+        a\alpha^2 + b\alpha & \text{if } |\alpha| \leq 1 \\
+        (b - 2a)(\alpha + 1) + (a - b) & \text{if } \alpha < -1
         \end{cases}
 
     with :math:`a = \frac{1}{2}((I^+ - I^0) + (I^- - I^0))` and :math:`b = \frac{1}{2}((I^+ - I^0) - (I^- - I^0))`.
 
     .. note::
 
-        This is deliberately discontinuous at :math:`\alpha = \pm 1`: the linear
-        extrapolation branches omit the ``+ (hi - nom)`` / ``+ (lo - nom)`` offset
-        that would make them meet the quadratic branch. This faithfully reproduces
-        pyhf's ``code2`` interpolator, whose reference ("slow") implementation
-        computes exactly the same unshifted extrapolation
-        (``pyhf/interpolators/code2.py::_slow_code2.summand``, scikit-hep/pyhf,
-        e.g. https://github.com/scikit-hep/pyhf/blob/main/src/pyhf/interpolators/code2.py).
-        ROOT's ``FlexibleInterpVar``/``PiecewiseInterpolation`` code 2
-        (``RooFit::Detail::MathFuncs::flexibleInterpSingle``) *does* include the
-        offset and is therefore continuous at the boundary -- see
-        :func:`interpolate_parabolic` for that variant.
+        The extrapolation branches include the :math:`(a + b) = I^+ - I^0` and
+        :math:`(a - b) = I^- - I^0` offsets, making the function continuous at
+        :math:`\alpha = \pm 1`. This matches ROOT's
+        ``FlexibleInterpVar``/``PiecewiseInterpolation`` code 2
+        (``RooFit::Detail::MathFuncs::flexibleInterpSingle``, case 2). pyhf's
+        ``code2`` interpolator omits these offsets and is discontinuous at the
+        boundary; pyhs3 deliberately diverges from pyhf here in favor of
+        continuity -- see https://github.com/scikit-hep/pyhf/issues/2729.
     """
-    # Calculate quadratic coefficients
-    hi_delta = hi - nom
-    lo_delta = lo - nom
-
-    a = 0.5 * (hi_delta + lo_delta)
-    b = 0.5 * (hi_delta - lo_delta)
-
-    # Quadratic interpolation for |alpha| < 1
-    quad_result = nom + a * alpha**2 + b * alpha
-
-    # Linear extrapolation for |alpha| >= 1.
-    # Intentionally omits the "+ hi_delta" / "+ lo_delta" offset (unlike
-    # interpolate_parabolic): pyhf's code2 extrapolation is discontinuous at
-    # alpha=+-1 by construction, and this mirrors that behavior exactly.
-    high_ext = nom + (b + 2 * a) * (alpha - 1)
-    low_ext = nom + (b - 2 * a) * (alpha + 1)
-
-    return cast(
-        TensorVar,
-        pt.where(  # type: ignore[no-untyped-call]
-            alpha > 1,
-            high_ext,
-            pt.where(alpha < -1, low_ext, quad_result),  # type: ignore[no-untyped-call]
-        ),
-    )
+    return interpolate_parabolic(alpha, nom, hi, lo)
 
 
 def interpolate_code4p(

--- a/tests/test_histfactory_interpolations.py
+++ b/tests/test_histfactory_interpolations.py
@@ -837,3 +837,77 @@ class TestInterpolationPyhfComparison:
             assert vector_vals == pytest.approx(scalar_vals, rel=1e-6), (
                 f"Vector/scalar mismatch for {method_name}"
             )
+
+
+class TestCode2BoundaryDiscontinuity:
+    """Characterization tests pinning interpolate_code2's pyhf-faithful boundary behavior.
+
+    interpolate_code2's linear extrapolation branches (|alpha| > 1) omit the
+    "+ (hi - nom)" / "+ (lo - nom)" offset that interpolate_parabolic includes,
+    which makes it discontinuous at alpha=+-1. This is intentional: it reproduces
+    pyhf's code2 interpolator exactly, including its reference "slow" formula
+    (pyhf/interpolators/code2.py::_slow_code2.summand), which is itself
+    discontinuous there. ROOT's FlexibleInterpVar code 2 does include the offset
+    and is continuous -- see interpolate_parabolic for that behavior instead.
+    These tests pin the numeric values just inside/outside the boundary so any
+    future change to this deliberate behavior is caught explicitly.
+    """
+
+    def test_discontinuity_at_positive_boundary(self):
+        """Pin values approaching alpha=1 from both sides to show the jump."""
+        nom = pt.constant(1.0)
+        hi = pt.constant(2.0)
+        lo = pt.constant(0.5)
+
+        just_below = interpolate_code2(pt.constant(0.999), nom, hi, lo).eval()
+        at_boundary = interpolate_code2(pt.constant(1.0), nom, hi, lo).eval()
+        just_above = interpolate_code2(pt.constant(1.001), nom, hi, lo).eval()
+
+        assert just_below == pytest.approx(1.99875025)
+        assert at_boundary == pytest.approx(2.0)
+        # Discontinuous: the extrapolation branch resets towards `nom` instead
+        # of continuing from `hi` as alpha crosses 1.
+        assert just_above == pytest.approx(1.0012499999999998)
+        assert abs(just_above - at_boundary) > 0.9  # sanity check on the jump
+
+    def test_discontinuity_at_negative_boundary(self):
+        """Pin values approaching alpha=-1 from both sides to show the jump."""
+        nom = pt.constant(1.0)
+        hi = pt.constant(2.0)
+        lo = pt.constant(0.5)
+
+        just_above = interpolate_code2(pt.constant(-0.999), nom, hi, lo).eval()
+        at_boundary = interpolate_code2(pt.constant(-1.0), nom, hi, lo).eval()
+        just_below = interpolate_code2(pt.constant(-1.001), nom, hi, lo).eval()
+
+        assert just_above == pytest.approx(0.50025025)
+        assert at_boundary == pytest.approx(0.5)
+        # Discontinuous: the extrapolation branch resets towards `nom` instead
+        # of continuing from `lo` as alpha crosses -1.
+        assert just_below == pytest.approx(0.99975)
+        assert abs(just_below - at_boundary) > 0.4  # sanity check on the jump
+
+    def test_matches_pyhf_slow_code2_reference(self):
+        """interpolate_code2 must numerically match pyhf's canonical reference formula.
+
+        Values from pyhf.interpolators.code2._slow_code2.summand(down=0.5, nom=1.0,
+        up=2.0, alpha) for alpha in {0.999, 1.0, 1.001, -0.999, -1.0, -1.001}.
+        """
+        nom = pt.constant(1.0)
+        hi = pt.constant(2.0)
+        lo = pt.constant(0.5)
+
+        pyhf_reference = {
+            0.999: 1.99875025,
+            1.0: 2.0,
+            1.001: 1.0012499999999998,
+            -0.999: 0.50025025,
+            -1.0: 0.5,
+            -1.001: 0.99975,
+        }
+
+        for alpha_val, expected in pyhf_reference.items():
+            result = interpolate_code2(pt.constant(alpha_val), nom, hi, lo).eval()
+            assert result == pytest.approx(expected), (
+                f"alpha={alpha_val}: got {result}, pyhf reference={expected}"
+            )

--- a/tests/test_histfactory_interpolations.py
+++ b/tests/test_histfactory_interpolations.py
@@ -425,8 +425,9 @@ class TestInterpolationComparison:
             result = interpolate_code2(alpha, nom_t, hi_t, lo_t)
             result_val = result.eval()
 
-            # Expected linear extrapolation: nom + (b + 2*a) * (alpha - 1)
-            expected = nom + (b + 2 * a) * (alpha_val - 1)
+            # Expected linear extrapolation, continuous at alpha=1:
+            # nom + (b + 2*a) * (alpha - 1) + (hi - nom)
+            expected = nom + (b + 2 * a) * (alpha_val - 1) + hi_delta
             assert result_val == pytest.approx(expected)
 
         # Test alpha < -1 (negative extrapolation) - note: alpha = -1 uses quadratic
@@ -436,8 +437,9 @@ class TestInterpolationComparison:
             result = interpolate_code2(alpha, nom_t, hi_t, lo_t)
             result_val = result.eval()
 
-            # Expected linear extrapolation: nom + (b - 2*a) * (alpha + 1)
-            expected = nom + (b - 2 * a) * (alpha_val + 1)
+            # Expected linear extrapolation, continuous at alpha=-1:
+            # nom + (b - 2*a) * (alpha + 1) + (lo - nom)
+            expected = nom + (b - 2 * a) * (alpha_val + 1) + lo_delta
             assert result_val == pytest.approx(expected)
 
         # Test boundary case alpha = -1 (should use quadratic)
@@ -517,20 +519,19 @@ class TestInterpolationPyhfComparison:
             )
 
     def test_code2_vs_pyhf_slow_formula(self):
-        """Test that interpolate_code2 matches pyhf's slow (correct) mathematical formula."""
-        # Based on pyhf's _slow_code2.summand implementation which is the reference
-        # Note: We use the slow formula because there's a bug in pyhf's fast implementation
-        # for alpha < -1 case. See: https://github.com/scikit-hep/pyhf/issues/2610
+        """Test that interpolate_code2 matches pyhf's code2 formula within |alpha| <= 1."""
+        # Based on pyhf's _slow_code2.summand implementation which is the reference.
+        # Only the central quadratic region is compared: pyhf's extrapolation for
+        # |alpha| > 1 omits the (a+b)/(a-b) offsets and is discontinuous at
+        # alpha=+-1 (https://github.com/scikit-hep/pyhf/issues/2729), whereas
+        # pyhs3 deliberately uses ROOT's continuous extrapolation instead.
 
-        alpha_vals = [-2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0]
+        alpha_vals = [-1.0, -0.5, 0.0, 0.5, 1.0]
         nom = 1.0
         hi = 2.0
         lo = 0.5
 
-        # Commented out: pyhf fast implementation (has bug for alpha < -1)
-        # interpolator = pyhf.interpolators.code2(histogramssets, subscribe=False)
-
-        # pyhf slow formula coefficients (correct reference implementation)
+        # pyhf slow formula coefficients (reference implementation)
         a = 0.5 * (hi + lo) - nom  # 0.25
         b = 0.5 * (hi - lo)  # 0.75
 
@@ -544,21 +545,10 @@ class TestInterpolationPyhfComparison:
             our_result = interpolate_code2(alpha, nom_t, hi_t, lo_t)
             our_val = our_result.eval()
 
-            # Expected result based on pyhf slow formula (correct reference)
-            if alpha_val > 1:
-                delta = (b + 2 * a) * (alpha_val - 1)
-            elif -1 <= alpha_val <= 1:
-                delta = a * alpha_val * alpha_val + b * alpha_val
-            else:  # alpha_val < -1
-                delta = (b - 2 * a) * (alpha_val + 1)
+            # Expected result based on pyhf slow formula, |alpha| <= 1 branch
+            delta = a * alpha_val * alpha_val + b * alpha_val
 
             expected = nom + delta
-
-            # Commented out: comparison with pyhf fast implementation (buggy)
-            # alphasets = pyhf.tensorlib.astensor([[alpha_val]])
-            # pyhf_deltas = interpolator(alphasets)
-            # pyhf_result = nom + pyhf.tensorlib.tolist(pyhf_deltas)[0][0][0][0]
-            # assert our_val == pytest.approx(pyhf_result), f"Fast mismatch at alpha={alpha_val}: our={our_val}, pyhf={pyhf_result}"
 
             assert our_val == pytest.approx(expected), (
                 f"Mismatch at alpha={alpha_val}: our={our_val}, expected={expected}"
@@ -651,11 +641,11 @@ class TestInterpolationPyhfComparison:
                 # Quadratic interpolation
                 expected = nom + a * alpha_val**2 + b * alpha_val
             elif alpha_val > 1.0:
-                # Linear extrapolation beyond +1
-                expected = nom + (b + 2 * a) * (alpha_val - 1)
+                # Linear extrapolation beyond +1, continuous at alpha=1
+                expected = nom + (b + 2 * a) * (alpha_val - 1) + hi_delta
             else:
-                # Linear extrapolation beyond -1
-                expected = nom + (b - 2 * a) * (alpha_val + 1)
+                # Linear extrapolation beyond -1, continuous at alpha=-1
+                expected = nom + (b - 2 * a) * (alpha_val + 1) + lo_delta
 
             assert our_val == pytest.approx(expected), (
                 f"Mismatch at alpha={alpha_val}: our={our_val}, expected={expected}"
@@ -839,22 +829,22 @@ class TestInterpolationPyhfComparison:
             )
 
 
-class TestCode2BoundaryDiscontinuity:
-    """Characterization tests pinning interpolate_code2's pyhf-faithful boundary behavior.
+class TestCode2BoundaryContinuity:
+    """Tests pinning interpolate_code2's continuous boundary behavior.
 
-    interpolate_code2's linear extrapolation branches (|alpha| > 1) omit the
-    "+ (hi - nom)" / "+ (lo - nom)" offset that interpolate_parabolic includes,
-    which makes it discontinuous at alpha=+-1. This is intentional: it reproduces
-    pyhf's code2 interpolator exactly, including its reference "slow" formula
-    (pyhf/interpolators/code2.py::_slow_code2.summand), which is itself
-    discontinuous there. ROOT's FlexibleInterpVar code 2 does include the offset
-    and is continuous -- see interpolate_parabolic for that behavior instead.
-    These tests pin the numeric values just inside/outside the boundary so any
-    future change to this deliberate behavior is caught explicitly.
+    interpolate_code2's linear extrapolation branches (|alpha| > 1) include the
+    "+ (hi - nom)" / "+ (lo - nom)" offsets so the function is continuous at
+    alpha=+-1, matching ROOT's FlexibleInterpVar code 2
+    (RooFit::Detail::MathFuncs::flexibleInterpSingle, case 2). pyhf's code2
+    interpolator omits these offsets and is discontinuous at the boundary;
+    pyhs3 deliberately diverges from pyhf here in favor of continuity
+    (https://github.com/scikit-hep/pyhf/issues/2729). These tests pin the
+    numeric values just inside/outside the boundary so any regression back to
+    the discontinuous form is caught explicitly.
     """
 
-    def test_discontinuity_at_positive_boundary(self):
-        """Pin values approaching alpha=1 from both sides to show the jump."""
+    def test_continuity_at_positive_boundary(self):
+        """Pin values approaching alpha=1 from both sides: no jump."""
         nom = pt.constant(1.0)
         hi = pt.constant(2.0)
         lo = pt.constant(0.5)
@@ -863,15 +853,17 @@ class TestCode2BoundaryDiscontinuity:
         at_boundary = interpolate_code2(pt.constant(1.0), nom, hi, lo).eval()
         just_above = interpolate_code2(pt.constant(1.001), nom, hi, lo).eval()
 
+        # quadratic: nom + a*alpha^2 + b*alpha with a=0.25, b=0.75
         assert just_below == pytest.approx(1.99875025)
         assert at_boundary == pytest.approx(2.0)
-        # Discontinuous: the extrapolation branch resets towards `nom` instead
-        # of continuing from `hi` as alpha crosses 1.
-        assert just_above == pytest.approx(1.0012499999999998)
-        assert abs(just_above - at_boundary) > 0.9  # sanity check on the jump
+        # linear extrapolation continues from hi: nom + (b+2a)(alpha-1) + (a+b)
+        assert just_above == pytest.approx(2.00125)
+        # adjacent values stay within the expected local slope (~1.25 per unit alpha)
+        assert abs(just_above - at_boundary) < 0.002
+        assert abs(at_boundary - just_below) < 0.002
 
-    def test_discontinuity_at_negative_boundary(self):
-        """Pin values approaching alpha=-1 from both sides to show the jump."""
+    def test_continuity_at_negative_boundary(self):
+        """Pin values approaching alpha=-1 from both sides: no jump."""
         nom = pt.constant(1.0)
         hi = pt.constant(2.0)
         lo = pt.constant(0.5)
@@ -880,34 +872,48 @@ class TestCode2BoundaryDiscontinuity:
         at_boundary = interpolate_code2(pt.constant(-1.0), nom, hi, lo).eval()
         just_below = interpolate_code2(pt.constant(-1.001), nom, hi, lo).eval()
 
+        # quadratic: nom + a*alpha^2 + b*alpha with a=0.25, b=0.75
         assert just_above == pytest.approx(0.50025025)
         assert at_boundary == pytest.approx(0.5)
-        # Discontinuous: the extrapolation branch resets towards `nom` instead
-        # of continuing from `lo` as alpha crosses -1.
-        assert just_below == pytest.approx(0.99975)
-        assert abs(just_below - at_boundary) > 0.4  # sanity check on the jump
+        # linear extrapolation continues from lo: nom + (b-2a)(alpha+1) + (a-b)
+        assert just_below == pytest.approx(0.49975)
+        # adjacent values stay within the expected local slope (~0.25 per unit alpha)
+        assert abs(just_below - at_boundary) < 0.002
+        assert abs(at_boundary - just_above) < 0.002
 
-    def test_matches_pyhf_slow_code2_reference(self):
-        """interpolate_code2 must numerically match pyhf's canonical reference formula.
+    def test_central_region_is_pure_quadratic(self):
+        """The |alpha| <= 1 region is exactly nom + a*alpha^2 + b*alpha.
 
-        Values from pyhf.interpolators.code2._slow_code2.summand(down=0.5, nom=1.0,
-        up=2.0, alpha) for alpha in {0.999, 1.0, 1.001, -0.999, -1.0, -1.001}.
+        The continuity fix only touches the extrapolation branches; the central
+        quadratic region matches pyhf's code2 formula exactly.
         """
-        nom = pt.constant(1.0)
-        hi = pt.constant(2.0)
-        lo = pt.constant(0.5)
+        nom_val, hi_val, lo_val = 1.0, 2.0, 0.5
+        nom = pt.constant(nom_val)
+        hi = pt.constant(hi_val)
+        lo = pt.constant(lo_val)
 
-        pyhf_reference = {
-            0.999: 1.99875025,
-            1.0: 2.0,
-            1.001: 1.0012499999999998,
-            -0.999: 0.50025025,
-            -1.0: 0.5,
-            -1.001: 0.99975,
-        }
+        a = 0.5 * ((hi_val - nom_val) + (lo_val - nom_val))  # 0.25
+        b = 0.5 * ((hi_val - nom_val) - (lo_val - nom_val))  # 0.75
 
-        for alpha_val, expected in pyhf_reference.items():
+        for alpha_val in [-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0]:
             result = interpolate_code2(pt.constant(alpha_val), nom, hi, lo).eval()
-            assert result == pytest.approx(expected), (
-                f"alpha={alpha_val}: got {result}, pyhf reference={expected}"
+            expected = nom_val + a * alpha_val**2 + b * alpha_val
+            assert result == expected, (
+                f"alpha={alpha_val}: got {result}, expected {expected}"
             )
+
+    def test_code2_equals_parabolic_everywhere(self):
+        """interpolate_code2 is an alias for interpolate_parabolic: identical on a grid."""
+        alphas = pt.vector("alphas")
+        nom = pt.constant(100.0)
+        hi = pt.constant(120.0)
+        lo = pt.constant(80.0)
+
+        alpha_grid = np.linspace(-3.0, 3.0, 121)
+
+        code2_vals = interpolate_code2(alphas, nom, hi, lo).eval({alphas: alpha_grid})
+        parabolic_vals = interpolate_parabolic(alphas, nom, hi, lo).eval(
+            {alphas: alpha_grid}
+        )
+
+        np.testing.assert_array_equal(code2_vals, parabolic_vals)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Resolves review issue #230, item 7: `interpolate_code2` in
`src/pyhs3/distributions/histfactory/interpolations.py` was discontinuous at
alpha=+-1 because its linear extrapolation branches
(`nom + (b + 2a)(alpha - 1)` / `nom + (b - 2a)(alpha + 1)`) omitted the
`+ (hi - nom)` / `+ (lo - nom)` offsets that `interpolate_parabolic` (in the
same file) includes.

**Design decision: continuity over pyhf-faithfulness.** The old form
faithfully reproduced pyhf's `code2` interpolator, which is genuinely
discontinuous at the boundary — verified against pyhf's actual implementation,
not just its docs. That discontinuity is now tracked upstream at
[scikit-hep/pyhf#2729](https://github.com/scikit-hep/pyhf/issues/2729), which
serves as the record of this deliberate divergence. pyhs3's `interpolate_code2`
now matches ROOT's continuous behavior instead.

### Evidence

pyhf's reference "slow" implementation,
[`src/pyhf/interpolators/code2.py::_slow_code2.summand`](https://github.com/scikit-hep/pyhf/blob/main/src/pyhf/interpolators/code2.py#L124-L134):

```python
if alpha > 1:
    delta = (b + 2 * a) * (alpha - 1)
elif -1 <= alpha <= 1:
    delta = a * alpha * alpha + b * alpha
else:
    delta = (b - 2 * a) * (alpha + 1)
```

— no offset in the extrapolation branches; pyhf's tensorized "fast"
`code2.__call__` uses the identical unshifted formula. ROOT's
`FlexibleInterpVar`/`PiecewiseInterpolation` code 2
(`RooFit::Detail::MathFuncs::flexibleInterpSingle`, case 2, in
[`roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h`](https://github.com/root-project/root/blob/master/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h#L271-L282))
*does* include the offsets:

```cpp
if (paramVal > 1) {
   return (2 * a + b) * (paramVal - 1) + high - nominal;
} else if (paramVal < -1) {
   return -1 * (2 * a - b) * (paramVal + 1) + low - nominal;
} else {
   return a * paramVal * paramVal + b * paramVal + c;
}
```

### Boundary values (nom=1.0, hi=2.0, lo=0.5)

| alpha | before (pyhf-style) | after (ROOT-style, continuous) |
|---|---|---|
| 0.999 | 1.99875025 | 1.99875025 |
| 1.0 | 2.0 | 2.0 |
| 1.001 | 1.00125 | 2.00125 |
| -0.999 | 0.50025025 | 0.50025025 |
| -1.0 | 0.5 | 0.5 |
| -1.001 | 0.99975 | 0.49975 |

The central quadratic region (|alpha| <= 1) is unchanged.

### Changes

- `interpolate_code2` with the offsets included is algebraically identical to
  `interpolate_parabolic` (`a = s`, `b = d`, `a+b = hi-nom`, `a-b = lo-nom`,
  same `alpha > 1` / `alpha < -1` boundary conditions and signature), so it is
  now an **alias** for it, following the file's existing alias pattern
  (`interpolate_code0` -> `interpolate_lin`, `interpolate_code1` ->
  `interpolate_exp`). Docstring documents the continuous formula and cites
  pyhf#2729 for the deliberate divergence.
- `test_code2_linear_extrapolation` and `test_mathematical_equivalence_code2`:
  extrapolation expectations updated to the continuous form (exact values, no
  tolerance loosening).
- `test_code2_vs_pyhf_slow_formula`: now compares against pyhf only within
  |alpha| <= 1, with a comment citing pyhf#2729 for why extrapolation
  deliberately differs.
- New `TestCode2BoundaryContinuity`: pins boundary values at
  alpha in {0.999, 1.0, 1.001} and the negative mirror, asserts adjacent values
  stay within the local linear step, asserts the central region is *exactly*
  the pure quadratic (bit-identical to before), and asserts
  `interpolate_code2 == interpolate_parabolic` across a 121-point grid.

## Test plan

- [x] `pixi run --environment py312 test` — full quick suite green
      (1053 passed, 3 skipped, 9 deselected, 1 xfailed)
- [x] `pytest --cov=pyhs3 --cov-report=term-missing` —
      `interpolations.py` at 100% coverage
- [x] `pixi run --environment dev bash -c "pre-commit run --files
      src/pyhs3/distributions/histfactory/interpolations.py
      tests/test_histfactory_interpolations.py"` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
