### PR TITLE
feat: analytic log-space likelihood for Gaussian, Poisson, and LogNormal

### DIFF
--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -64,6 +64,35 @@ class GaussianDist(Distribution):
         )
         return cast(TensorVar, norm_const * exponent)
 
+    def log_likelihood(self, context: Context) -> TensorVar:
+        r"""
+        Builds a symbolic expression for the Gaussian log-PDF.
+
+        Analytic log form of :meth:`likelihood`:
+
+        .. math::
+
+            \log f(x; \mu, \sigma) = -\frac{1}{2}z^2 - \log\sigma - \frac{1}{2}\log(2\pi),
+            \quad z = \frac{x-\mu}{\sigma}
+
+        Evaluating this directly (rather than ``pt.log(self.likelihood(...))``)
+        avoids computing :math:`\exp(-z^2/2)` and re-logging it, which
+        underflows to 0.0 (and then to ``-inf``) once :math:`|z|` exceeds
+        roughly 38 in float64.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Gaussian log-PDF.
+        """
+        sigma = context[self._parameters["sigma"]]
+        z = (context[self._parameters["x"]] - context[self._parameters["mean"]]) / sigma
+        return cast(
+            TensorVar,
+            -0.5 * z**2 - pt.log(sigma) - 0.5 * math.log(2.0 * math.pi),
+        )
+
 
 class UniformDist(Distribution):
     r"""
@@ -135,6 +164,40 @@ class PoissonDist(Distribution):
     mean: str | float | int
     x: str | float | int
 
+    def _log_pmf(self, context: Context) -> TensorVar:
+        r"""
+        Shared analytic log-PMF construction for :meth:`likelihood` and :meth:`log_likelihood`.
+
+        .. math::
+
+            \log P(k; \lambda) = k \log\lambda - \lambda - \log\Gamma(k+1)
+
+        using pt.gammaln for :math:`\log(k!) = \log\Gamma(k+1)`.
+
+        Guards the log's argument (not just the switch's output) against
+        ``0 * log(0) = NaN`` when both ``k == 0`` and ``lambda == 0``: pt.switch
+        differentiates both branches, so the untaken "full" branch would
+        otherwise contribute a NaN gradient at this point (d/dlambda of
+        ``k * log(lambda)`` is ``k/lambda = 0/0``). Poisson(k=0 | lambda=0) = 1,
+        so the switch's true branch (``-lambda = 0``) already gives the correct
+        log-pmf; substituting a nonzero placeholder for lambda inside the
+        untaken branch's log keeps both its value and its gradient finite there,
+        matching the guard pattern used by
+        :meth:`~pyhs3.distributions.histfactory.HistFactoryDistChannel._bin_log_probs`.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Poisson log-PMF.
+        """
+        mean = context[self._parameters["mean"]]
+        x = context[self._parameters["x"]]
+
+        safe_mean = pt.switch(pt.eq(x, 0), 1.0, mean)
+        full = x * pt.log(safe_mean) - mean - pt.gammaln(x + 1)
+        return cast(TensorVar, pt.switch(pt.eq(x, 0), -mean, full))
+
     def likelihood(self, context: Context) -> TensorVar:
         """
         Builds a symbolic expression for the Poisson PMF.
@@ -145,13 +208,25 @@ class PoissonDist(Distribution):
         Returns:
             pytensor.tensor.variable.TensorVariable: Symbolic representation of the Poisson PMF.
         """
-        mean = context[self._parameters["mean"]]
-        x = context[self._parameters["x"]]
-
         # Poisson PMF: λ^k * e^(-λ) / k!
-        # Using pt.gammaln for log(k!) = log(Γ(k+1))
-        log_pmf = x * pt.log(mean) - mean - pt.gammaln(x + 1)
-        return cast(TensorVar, pt.exp(log_pmf))
+        return cast(TensorVar, pt.exp(self._log_pmf(context)))
+
+    def log_likelihood(self, context: Context) -> TensorVar:
+        """
+        Builds a symbolic expression for the Poisson log-PMF.
+
+        Returns the analytic log-pmf directly (already computed internally by
+        :meth:`likelihood`), avoiding a ``pt.log(pt.exp(log_pmf))`` round-trip
+        that underflows to ``-inf`` once the true log-pmf is a large negative
+        number (e.g. far into the tail).
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Poisson log-PMF.
+        """
+        return self._log_pmf(context)
 
 
 class ExponentialDist(Distribution):
@@ -252,6 +327,42 @@ class LogNormalDist(Distribution):
             TensorVar,
             (1.0 / (x * sigma * pt.sqrt(2.0 * math.pi)))
             * pt.exp(-0.5 * normalized_log**2),
+        )
+
+    def log_likelihood(self, context: Context) -> TensorVar:
+        r"""
+        Builds a symbolic expression for the log-normal log-PDF.
+
+        Analytic log form of :meth:`likelihood`:
+
+        .. math::
+
+            \log f(x; \mu, \sigma) = -\log x - \log\sigma - \frac{1}{2}\log(2\pi)
+            - \frac{1}{2}z^2, \quad z = \frac{\ln x - \mu}{\sigma}
+
+        Evaluating this directly (rather than ``pt.log(self.likelihood(...))``)
+        avoids computing :math:`\exp(-z^2/2)` and re-logging it, which
+        underflows to 0.0 (and then to ``-inf``) once :math:`|z|` exceeds
+        roughly 38 in float64.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of log-normal log-PDF.
+        """
+        x = context[self._parameters["x"]]
+        mu = context[self._parameters["mu"]]
+        sigma = context[self._parameters["sigma"]]
+
+        log_x = pt.log(x)
+        normalized_log = (log_x - mu) / sigma
+        return cast(
+            TensorVar,
+            -log_x
+            - pt.log(sigma)
+            - 0.5 * math.log(2.0 * math.pi)
+            - 0.5 * normalized_log**2,
         )
 
 

--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -164,15 +164,37 @@ class PoissonDist(Distribution):
     mean: str | float | int
     x: str | float | int
 
-    def _log_pmf(self, context: Context) -> TensorVar:
+    def likelihood(self, context: Context) -> TensorVar:
+        """
+        Builds a symbolic expression for the Poisson PMF.
+
+        The analytic log-pmf in :meth:`log_likelihood` is the primary form;
+        the probability-space pmf is its exponential.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Poisson PMF.
+        """
+        # Poisson PMF: λ^k * e^(-λ) / k!
+        return cast(TensorVar, pt.exp(self.log_likelihood(context)))
+
+    def log_likelihood(self, context: Context) -> TensorVar:
         r"""
-        Shared analytic log-PMF construction for :meth:`likelihood` and :meth:`log_likelihood`.
+        Builds a symbolic expression for the Poisson log-PMF.
+
+        Primary analytic form of the distribution (:meth:`likelihood` is its
+        exponential):
 
         .. math::
 
             \log P(k; \lambda) = k \log\lambda - \lambda - \log\Gamma(k+1)
 
-        using pt.gammaln for :math:`\log(k!) = \log\Gamma(k+1)`.
+        using pt.gammaln for :math:`\log(k!) = \log\Gamma(k+1)`. Returning the
+        log-pmf directly avoids a ``pt.log(pt.exp(log_pmf))`` round-trip that
+        underflows to ``-inf`` once the true log-pmf is a large negative
+        number (e.g. far into the tail).
 
         Guards the log's argument (not just the switch's output) against
         ``0 * log(0) = NaN`` when both ``k == 0`` and ``lambda == 0``: pt.switch
@@ -197,36 +219,6 @@ class PoissonDist(Distribution):
         safe_mean = pt.switch(pt.eq(x, 0), 1.0, mean)
         full = x * pt.log(safe_mean) - mean - pt.gammaln(x + 1)
         return cast(TensorVar, pt.switch(pt.eq(x, 0), -mean, full))
-
-    def likelihood(self, context: Context) -> TensorVar:
-        """
-        Builds a symbolic expression for the Poisson PMF.
-
-        Args:
-            context (dict): Mapping of names to pytensor variables.
-
-        Returns:
-            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Poisson PMF.
-        """
-        # Poisson PMF: λ^k * e^(-λ) / k!
-        return cast(TensorVar, pt.exp(self._log_pmf(context)))
-
-    def log_likelihood(self, context: Context) -> TensorVar:
-        """
-        Builds a symbolic expression for the Poisson log-PMF.
-
-        Returns the analytic log-pmf directly (already computed internally by
-        :meth:`likelihood`), avoiding a ``pt.log(pt.exp(log_pmf))`` round-trip
-        that underflows to ``-inf`` once the true log-pmf is a large negative
-        number (e.g. far into the tail).
-
-        Args:
-            context (dict): Mapping of names to pytensor variables.
-
-        Returns:
-            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Poisson log-PMF.
-        """
-        return self._log_pmf(context)
 
 
 class ExponentialDist(Distribution):

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -241,9 +241,10 @@ class Distribution(Evaluable, ABC):
         Apply normalization to a raw likelihood expression.
 
         Normalizes a likelihood over observables present in the context.
-        Attempts analytical integration first via _normalization_integral(),
-        then falls back to nested Gauss-Legendre quadrature for
-        multi-dimensional integrals.
+        For a single matching observable, attempts analytical integration
+        first via _normalization_integral(), then falls back to Gauss-Legendre
+        quadrature. Multi-dimensional normalization is not yet supported and
+        raises NotImplementedError.
 
         Args:
             raw: Raw (unnormalized) likelihood expression

--- a/src/pyhs3/distributions/core.py
+++ b/src/pyhs3/distributions/core.py
@@ -94,6 +94,25 @@ class Distribution(Evaluable, ABC):
             TypeError: Must be implemented by subclasses
         """
 
+    def log_likelihood(self, context: Context) -> TensorVar:
+        """
+        Log-space counterpart of :meth:`likelihood`.
+
+        Default implementation takes the log of the probability-space
+        likelihood. Override with an analytic log-space form wherever one
+        exists (e.g. Gaussian, Poisson, LogNormal): the default round-trips
+        through a probability value that can underflow to 0.0 for parameter
+        points far from the mode, at which point ``pt.log(0.0)`` is ``-inf``
+        even though the true log-density is finite.
+
+        Args:
+            context: Mapping of names to pytensor variables
+
+        Returns:
+            TensorVar: Log of the main probability density
+        """
+        return cast(TensorVar, pt.log(self.likelihood(context)))
+
     def normalization_expression(
         self, _context: Context, _observable_name: str
     ) -> TensorVar | None:
@@ -143,6 +162,76 @@ class Distribution(Evaluable, ABC):
         lower_val = cast(TensorVar, graph_replace(expr, [(leaf, lower_t)]))
         return cast(TensorVar, upper_val - lower_val)
 
+    def _matching_observables(
+        self, context: Context
+    ) -> list[tuple[str, TensorVar, TensorVar]]:
+        """
+        Observable bounds from context that this distribution's parameters reference.
+
+        Shared by _apply_normalization() and log_expression() so both agree on
+        whether any normalization applies without duplicating the matching logic.
+
+        Args:
+            context: Mapping of names to pytensor variables (includes observables)
+
+        Returns:
+            List of (name, lower, upper) for each observable this distribution depends on.
+        """
+        return [
+            (name, lower, upper)
+            for name, (lower, upper) in context.observables.items()
+            if name in self.parameters
+        ]
+
+    def _normalization_integral_for(
+        self,
+        raw: TensorVar,
+        context: Context,
+        matching: list[tuple[str, TensorVar, TensorVar]],
+    ) -> TensorVar:
+        """
+        Compute the normalization integral for a non-empty set of matching observables.
+
+        Attempts analytical integration first via _normalization_integral(),
+        then falls back to nested Gauss-Legendre quadrature.
+
+        Args:
+            raw: Raw (unnormalized) likelihood expression, used only by the
+                Gauss-Legendre quadrature fallback (the analytical branch
+                integrates the antiderivative directly and does not need it).
+            context: Mapping of names to pytensor variables (includes observables)
+            matching: Non-empty list of (name, lower, upper), as returned by
+                _matching_observables().
+
+        Returns:
+            Symbolic normalization integral.
+
+        Raises:
+            NotImplementedError: If more than one observable matches (multi-dimensional
+                normalization is not yet supported).
+        """
+        # Single observable: try analytical integral first
+        if len(matching) == 1:
+            obs_name, lower, upper = matching[0]
+            integral = self._normalization_integral(context, obs_name, lower, upper)
+            if integral is not None:
+                return integral
+
+        if len(matching) > 1:
+            obs_names = [name for name, _, _ in matching]
+            msg = (
+                f"Multi-dimensional normalization is not yet supported "
+                f"(observables: {obs_names}). "
+                f"See https://github.com/scipp-atlas/pyhs3/issues/214"
+            )
+            raise NotImplementedError(msg)
+
+        # Single observable: fall back to Gauss-Legendre quadrature.
+        # Pass the leaf (not the view) so graph_replace substitutes through
+        # every ExpandDims(leaf) view inside the integrand.
+        obs_name, lower, upper = matching[0]
+        return gauss_legendre_integral(raw, context.parameters[obs_name], lower, upper)
+
     def _apply_normalization(
         self,
         raw: TensorVar,
@@ -167,38 +256,12 @@ class Distribution(Evaluable, ABC):
         if not self._normalizable:
             return raw
 
-        matching = [
-            (name, lower, upper)
-            for name, (lower, upper) in context.observables.items()
-            if name in self.parameters
-        ]
+        matching = self._matching_observables(context)
         if not matching:
             return raw
 
-        # Single observable: try analytical integral first
-        if len(matching) == 1:
-            obs_name, lower, upper = matching[0]
-            integral = self._normalization_integral(context, obs_name, lower, upper)
-            if integral is not None:
-                return cast(TensorVar, raw / integral)
-
-        if len(matching) > 1:
-            obs_names = [name for name, _, _ in matching]
-            msg = (
-                f"Multi-dimensional normalization is not yet supported "
-                f"(observables: {obs_names}). "
-                f"See https://github.com/scipp-atlas/pyhs3/issues/214"
-            )
-            raise NotImplementedError(msg)
-
-        # Single observable: fall back to Gauss-Legendre quadrature.
-        # Pass the leaf (not the view) so graph_replace substitutes through
-        # every ExpandDims(leaf) view inside the integrand.
-        obs_name, lower, upper = matching[0]
-        integral_expr = gauss_legendre_integral(
-            raw, context.parameters[obs_name], lower, upper
-        )
-        return cast(TensorVar, raw / integral_expr)
+        integral = self._normalization_integral_for(raw, context, matching)
+        return cast(TensorVar, raw / integral)
 
     def _expression(self, context: Context) -> TensorVar:
         """
@@ -230,9 +293,18 @@ class Distribution(Evaluable, ABC):
         """
         Log-probability combining main likelihood with extended terms.
 
-        Returns the sum of log(likelihood()) and log(extended_likelihood()).
-        This is mathematically equivalent to log(likelihood * extended_likelihood)
-        but can be more numerically stable.
+        Returns log_likelihood() plus log(extended_likelihood()), minus the log
+        of the normalization integral where normalization applies. This is
+        mathematically equivalent to log(likelihood * extended_likelihood) but
+        starts from log_likelihood() so that a distribution's analytic log form
+        (e.g. Gaussian, Poisson, LogNormal) is used directly instead of round-
+        tripping through a probability value that can underflow to 0.0.
+
+        Normalization itself stays probability-space: the normalization
+        integral (whether analytic or Gauss-Legendre quadrature) is a sum of
+        positive terms and is far less underflow-prone than the raw density,
+        so log(integral) is subtracted rather than computed as its own
+        analytic log form.
 
         All distributions are automatically normalized over observables present
         in the context, unless explicitly opted out via _normalizable = False.
@@ -245,14 +317,21 @@ class Distribution(Evaluable, ABC):
         Returns:
             TensorVar: Log-probability density
         """
-        raw = self.likelihood(context)
+        log_raw = self.log_likelihood(context)
 
-        # Apply normalization (respects _normalizable flag internally)
-        raw = self._apply_normalization(raw, context)
+        # Apply normalization (respects _normalizable flag internally). Only
+        # compute the raw (probability-space) likelihood when normalization
+        # actually applies -- it's needed for the Gauss-Legendre fallback.
+        if self._normalizable:
+            matching = self._matching_observables(context)
+            if matching:
+                raw = self.likelihood(context)
+                integral = self._normalization_integral_for(raw, context, matching)
+                log_raw = log_raw - pt.log(integral)
 
         return cast(
             TensorVar,
-            pt.log(raw) + pt.log(self.extended_likelihood(context)),
+            log_raw + pt.log(self.extended_likelihood(context)),
         )
 
     def extended_likelihood(

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -18,6 +18,7 @@ These tests assert that:
 from __future__ import annotations
 
 import math
+from typing import cast
 
 import numpy as np
 import pytensor
@@ -28,19 +29,38 @@ import pyhs3 as hs3
 from pyhs3.context import Context
 from pyhs3.data import BinnedData, Data
 from pyhs3.distributions import Distributions, HistFactoryDistChannel
+from pyhs3.distributions.basic import (
+    ExponentialDist,
+    GaussianDist,
+    LogNormalDist,
+    PoissonDist,
+)
 from pyhs3.domains import Domains, ProductDomain
 from pyhs3.likelihoods import Likelihood, Likelihoods
 from pyhs3.metadata import Metadata
 from pyhs3.parameter_points import ParameterPoints, ParameterSet
+from pyhs3.typing.aliases import TensorVar
 from pyhs3.workspace import Workspace
 
-# scipy.stats.poisson.logpmf is preferred for the analytic reference; fall back
-# to gammaln if scipy is unavailable in the test environment.
+# scipy.stats is preferred for analytic references; fall back to closed forms
+# built from stdlib math if scipy is unavailable in the test environment.
 try:
+    from scipy.stats import lognorm as _scipy_lognorm
+    from scipy.stats import norm as _scipy_norm
     from scipy.stats import poisson as _scipy_poisson
 
     def _poisson_logpmf(counts: np.ndarray, rates: np.ndarray) -> np.ndarray:
         return np.asarray(_scipy_poisson.logpmf(counts, rates), dtype=np.float64)
+
+    def _norm_logpdf(x: np.ndarray, mean: np.ndarray, sigma: np.ndarray) -> np.ndarray:
+        return np.asarray(
+            _scipy_norm.logpdf(x, loc=mean, scale=sigma), dtype=np.float64
+        )
+
+    def _lognorm_logpdf(x: np.ndarray, mu: np.ndarray, sigma: np.ndarray) -> np.ndarray:
+        return np.asarray(
+            _scipy_lognorm.logpdf(x, s=sigma, scale=np.exp(mu)), dtype=np.float64
+        )
 
 except ModuleNotFoundError:  # pragma: no cover - scipy is in the dev deps
 
@@ -48,6 +68,14 @@ except ModuleNotFoundError:  # pragma: no cover - scipy is in the dev deps
         # math.lgamma is a stdlib built-in (Python ≥ 3.5); no external deps needed.
         lgamma = np.vectorize(math.lgamma)
         return counts * np.log(rates) - rates - lgamma(counts + 1)
+
+    def _norm_logpdf(x: np.ndarray, mean: np.ndarray, sigma: np.ndarray) -> np.ndarray:
+        z = (x - mean) / sigma
+        return -0.5 * z**2 - np.log(sigma) - 0.5 * math.log(2.0 * math.pi)
+
+    def _lognorm_logpdf(x: np.ndarray, mu: np.ndarray, sigma: np.ndarray) -> np.ndarray:
+        z = (np.log(x) - mu) / sigma
+        return -np.log(x) - np.log(sigma) - 0.5 * math.log(2.0 * math.pi) - 0.5 * z**2
 
 
 def _underflow_workspace() -> tuple[Workspace, np.ndarray]:
@@ -268,3 +296,270 @@ def test_zero_bin_logprob_gradient_is_not_nan():
 
     grad_val = fn(np.array([0.0, 3.0]))
     assert np.all(np.isfinite(grad_val)), f"gradient has NaN/Inf: {grad_val}"
+
+
+# --------------------------------------------------------------------------
+# Layer 1 of #243: analytic log_likelihood() on GaussianDist, PoissonDist, and
+# LogNormalDist, so neither of them has to round-trip through a probability
+# value that can underflow to 0.0 before Layer 2 (modifier-level
+# log_constraint(), tracked separately) can rely on it.
+# --------------------------------------------------------------------------
+
+
+def _c(value: float) -> TensorVar:
+    """pt.constant() at explicit float64: bare Python floats otherwise get cast
+    to float32, which is nowhere near enough precision for the rtol=1e-12
+    parity checks below."""
+    return cast(TensorVar, pt.constant(value, dtype="float64"))
+
+
+class TestGaussianLogLikelihood:
+    """GaussianDist.log_likelihood is the analytic log form of likelihood()."""
+
+    @pytest.mark.parametrize(
+        ("x", "mean", "sigma"),
+        [
+            pytest.param(0.0, 0.0, 1.0, id="standard_normal_at_mode"),
+            pytest.param(2.0, 0.0, 1.0, id="standard_normal_offset"),
+            pytest.param(130.0, 125.0, 10.0, id="hep_mass_peak"),
+            pytest.param(-5.0, 3.0, 2.5, id="negative_x"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, x, mean, sigma):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = GaussianDist(name="g", x="x", mean="mean", sigma="sigma")
+        context = Context(
+            {
+                "x": _c(x),
+                "mean": _c(mean),
+                "sigma": _c(sigma),
+            }
+        )
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("x", "mean", "sigma"),
+        [
+            pytest.param(0.0, 0.0, 1.0, id="standard_normal_at_mode"),
+            pytest.param(2.0, 0.0, 1.0, id="standard_normal_offset"),
+            pytest.param(130.0, 125.0, 10.0, id="hep_mass_peak"),
+        ],
+    )
+    def test_matches_scipy_norm_logpdf(self, x, mean, sigma):
+        """likelihood() is the normalized Gaussian pdf, so this matches scipy exactly."""
+        dist = GaussianDist(name="g", x="x", mean="mean", sigma="sigma")
+        context = Context(
+            {
+                "x": _c(x),
+                "mean": _c(mean),
+                "sigma": _c(sigma),
+            }
+        )
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        expected = float(_norm_logpdf(np.array(x), np.array(mean), np.array(sigma)))
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+    def test_finite_at_large_pull_while_likelihood_underflows(self):
+        """|x-mu|/sigma = 40: likelihood underflows to 0.0, log_likelihood stays finite (~-800)."""
+        dist = GaussianDist(name="g", x="x", mean="mean", sigma="sigma")
+        context = Context(
+            {
+                "x": _c(40.0),
+                "mean": _c(0.0),
+                "sigma": _c(1.0),
+            }
+        )
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
+        expected = -0.5 * 40.0**2 - 0.5 * math.log(2.0 * math.pi)
+        assert log_val == pytest.approx(expected, rel=1e-10)
+        assert log_val == pytest.approx(-800.0, rel=1e-2)
+
+
+class TestPoissonLogLikelihood:
+    """PoissonDist.log_likelihood returns the analytic log-pmf directly."""
+
+    @pytest.mark.parametrize(
+        ("mean", "x"),
+        [
+            pytest.param(1.0, 0.0, id="lambda1_k0"),
+            pytest.param(3.0, 3.0, id="at_mode"),
+            pytest.param(5.0, 8.0, id="above_mode"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, mean, x):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = PoissonDist(name="p", mean="mean", x="x")
+        context = Context({"mean": _c(mean), "x": _c(x)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("mean", "x"),
+        [
+            pytest.param(1.0, 0.0, id="lambda1_k0"),
+            pytest.param(3.0, 3.0, id="at_mode"),
+            pytest.param(5.0, 8.0, id="above_mode"),
+        ],
+    )
+    def test_matches_scipy_poisson_logpmf(self, mean, x):
+        """likelihood() is the exact pmf, so this matches scipy.stats.poisson exactly."""
+        dist = PoissonDist(name="p", mean="mean", x="x")
+        context = Context({"mean": _c(mean), "x": _c(x)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        expected = float(_poisson_logpmf(np.array(x), np.array(mean)))
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+    def test_stable_at_large_mean_and_count(self):
+        """mean=x=1e5: the log-pmf subtracts ~1e6-magnitude terms to an O(1) result;
+        the analytic form stays accurate despite that cancellation."""
+        dist = PoissonDist(name="p", mean="mean", x="x")
+        context = Context({"mean": _c(1e5), "x": _c(1e5)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+
+        assert math.isfinite(log_val)
+        expected = float(_poisson_logpmf(np.array(1e5), np.array(1e5)))
+        assert log_val == pytest.approx(expected, rel=1e-8)
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-10)
+
+    def test_finite_at_deep_tail_while_likelihood_underflows(self):
+        """mean=100, x=1000 is far enough into the tail that the pmf underflows to 0.0."""
+        dist = PoissonDist(name="p", mean="mean", x="x")
+        context = Context({"mean": _c(100.0), "x": _c(1000.0)})
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
+        expected = float(_poisson_logpmf(np.array(1000.0), np.array(100.0)))
+        assert log_val == pytest.approx(expected, rel=1e-8)
+
+    def test_zero_zero_guard_matches_switch_pattern(self):
+        """mean=0, x=0: Poisson(0|0)=1, so the log-pmf is 0 (not NaN from 0 * log(0))."""
+        dist = PoissonDist(name="p", mean="mean", x="x")
+        context = Context({"mean": _c(0.0), "x": _c(0.0)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        assert log_val == pytest.approx(0.0, abs=1e-12)
+
+
+class TestLogNormalLogLikelihood:
+    """LogNormalDist.log_likelihood is the analytic log form of likelihood()."""
+
+    @pytest.mark.parametrize(
+        ("x", "mu", "sigma"),
+        [
+            pytest.param(1.0, 0.0, 1.0, id="standard_at_one"),
+            pytest.param(5.0, 1.0, 0.5, id="offset"),
+            pytest.param(0.1, -1.0, 2.0, id="small_x"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, x, mu, sigma):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = LogNormalDist(name="ln", x="x", mu="mu", sigma="sigma")
+        context = Context({"x": _c(x), "mu": _c(mu), "sigma": _c(sigma)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("x", "mu", "sigma"),
+        [
+            pytest.param(1.0, 0.0, 1.0, id="standard_at_one"),
+            pytest.param(5.0, 1.0, 0.5, id="offset"),
+            pytest.param(0.1, -1.0, 2.0, id="small_x"),
+        ],
+    )
+    def test_matches_scipy_lognorm_logpdf(self, x, mu, sigma):
+        """likelihood() is scipy's lognorm pdf with s=sigma, scale=exp(mu)."""
+        dist = LogNormalDist(name="ln", x="x", mu="mu", sigma="sigma")
+        context = Context({"x": _c(x), "mu": _c(mu), "sigma": _c(sigma)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        expected = float(_lognorm_logpdf(np.array(x), np.array(mu), np.array(sigma)))
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+    def test_finite_at_large_pull_while_likelihood_underflows(self):
+        """z = (ln(x)-mu)/sigma = 40: likelihood underflows to 0.0, log_likelihood stays finite."""
+        dist = LogNormalDist(name="ln", x="x", mu="mu", sigma="sigma")
+        x_val = math.exp(40.0)
+        context = Context(
+            {
+                "x": _c(x_val),
+                "mu": _c(0.0),
+                "sigma": _c(1.0),
+            }
+        )
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
+        expected = -math.log(x_val) - 0.5 * math.log(2.0 * math.pi) - 0.5 * 40.0**2
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+
+class TestBaseDistributionLogLikelihoodDefault:
+    """A distribution with no analytic override falls back to pt.log(likelihood())."""
+
+    @pytest.mark.parametrize(
+        ("x", "c"),
+        [
+            pytest.param(1.0, 0.5, id="ordinary_point"),
+            pytest.param(3.0, 2.0, id="larger_rate"),
+        ],
+    )
+    def test_exponential_dist_default_log_likelihood(self, x, c):
+        """ExponentialDist has no log_likelihood override, so it uses the base default."""
+        dist = ExponentialDist(name="e", x="x", c="c")
+        context = Context({"x": _c(x), "c": _c(c)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        assert log_val == pytest.approx(np.log(prob_val), rel=1e-12)
+
+
+class TestLogExpressionUsesAnalyticLogLikelihood:
+    """log_expression() is built from log_likelihood(), subtracting log(normalization)."""
+
+    def test_without_observable_equals_log_likelihood(self):
+        """No matching observable: no normalization applies, so log_expression == log_likelihood."""
+        dist = GaussianDist(name="constraint", mean="nom", sigma="sigma", x="alpha")
+        context = Context(
+            parameters={
+                "alpha": _c(0.5),
+                "nom": _c(0.0),
+                "sigma": _c(1.0),
+            },
+        )
+        log_expr_val = float(pytensor.function([], dist.log_expression(context))())
+        log_like_val = float(pytensor.function([], dist.log_likelihood(context))())
+        assert log_expr_val == pytest.approx(log_like_val, rel=1e-12)
+
+    def test_with_observable_matches_log_of_normalized_expression(self):
+        """Observable present: log_expression == log(likelihood / normalization_integral).
+
+        The observable leaf must be a pt.vector, not a pt.constant scalar: the
+        Gauss-Legendre quadrature fallback substitutes it with a 64-node vector
+        via graph_replace(), which every other normalization test in this
+        codebase also does (see test_normalization.py).
+        """
+        dist = GaussianDist(name="gauss", mean="mu", sigma="sigma", x="x")
+        x_var = pt.vector("x")
+        context = Context(
+            parameters={
+                "x": x_var,
+                "mu": _c(125.0),
+                "sigma": _c(10.0),
+            },
+            observables={"x": (_c(100.0), _c(160.0))},
+        )
+        log_expr_result = dist.log_expression(context)
+        expr_result = dist._expression(context)
+        log_expr_val = float(pytensor.function([x_var], log_expr_result)([130.0])[0])
+        expr_val = float(pytensor.function([x_var], expr_result)([130.0])[0])
+        assert log_expr_val == pytest.approx(math.log(expr_val), rel=1e-10)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -11,6 +11,7 @@ import pytest
 from pydantic import (
     ConfigDict,
     Field,
+    PrivateAttr,
 )
 
 from pyhs3.axes import RegularAxis
@@ -242,6 +243,35 @@ class TestDistributionNormalization:
         log_func = function([x_var], log_result)
         assert pytest.approx(log_func(np.array([1.0]))[0]) == np.log(0.02)
         assert pytest.approx(log_func(np.array([10.0]))[0]) == np.log(0.2)
+
+    def test_normalizable_false_skips_log_expression_normalization(self):
+        """_normalizable = False: log_expression() skips normalization entirely,
+        even with a matching observable in context -- it must not evaluate
+        likelihood() a second time or attempt to build a normalization integral."""
+
+        class NonNormalizableDist(Distribution):
+            _parameters: ClassVar = {"x": "x"}
+            _normalizable: bool = PrivateAttr(default=False)
+            model_config = ConfigDict(
+                arbitrary_types_allowed=True, serialize_by_alias=True
+            )
+
+            type: Literal["non_normalizable_dist"] = Field(
+                default="non_normalizable_dist", repr=False
+            )
+
+            def likelihood(self, context: Context) -> TensorVar:
+                return context["x"]
+
+        dist = NonNormalizableDist(name="test", expression="x")
+        x_var = pt.vector("x")
+        # An observable matching "x" is present, but _normalizable=False must
+        # short-circuit before any normalization machinery is invoked.
+        context = Context(parameters={"x": x_var}, observables={"x": (0, 10)})
+
+        log_result = dist.log_expression(context)
+        log_func = function([x_var], log_result)
+        assert pytest.approx(log_func(np.array([2.0]))[0]) == np.log(2.0)
 
     def test_composite_dist_not_normalized(self):
         """MixtureDist uses components but doesn't re-normalize."""


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Layer 1 of #243 (analytic log-space evaluation on the `Distribution` hierarchy, phase 2 of the roadmap in #254). Adds `log_likelihood(context)` to the base `Distribution` class and overrides it with closed-form log-density expressions on `GaussianDist`, `PoissonDist`, and `LogNormalDist`, so these three no longer have to round-trip through a probability-space value that can underflow to `0.0` before taking a log.

This does **not** touch the modifier hierarchy or `model.py` — that's Layer 2 (`log_constraint()` on `SingleParamConstraint`/`ShapeSysModifier`/`StatErrorModifier`, wiring `Model.log_prob`'s constraint terms to it), tracked separately as the actual fix for #243's `-inf` bug.

- `Distribution.log_likelihood()` defaults to `pt.log(self.likelihood(context))`; `log_expression()` now builds from `log_likelihood()` and subtracts `pt.log(normalization_integral)` rather than logging an already-normalized probability. Normalization itself stays probability-space (per the design decision in #254) — the integral is a sum of positive terms and far less underflow-prone than the raw density. `_apply_normalization()`'s matching/integral logic is factored into two shared helpers (`_matching_observables()`, `_normalization_integral_for()`) so both callers agree exactly.
- `GaussianDist.log_likelihood`: `-0.5*z^2 - log(sigma) - 0.5*log(2*pi)` — matches `likelihood()` exactly, since it already includes the `1/(sigma*sqrt(2*pi))` normalization factor.
- `LogNormalDist.log_likelihood`: same pattern with an extra `-log(x)` term.
- `PoissonDist.log_likelihood`: the log-pmf construction (`x*log(mean) - mean - gammaln(x+1)`) is factored out of `likelihood()` into a shared `_log_pmf()`, now returned directly instead of `pt.log(pt.exp(log_pmf))`. Also adds a `pt.switch` guard on the log's *argument* (not just the branch output) for `x == 0, mean == 0`, mirroring the guard pattern in `HistFactoryDistChannel._bin_log_probs` (untaken switch branches still get differentiated, so `0 * log(0)` can poison the gradient even when masked out of the value).

`HistFactoryDistChannel.log_likelihood` already existed with this exact name/signature; it now overrides the new base method rather than being an unrelated method.

## Tests

New coverage in `tests/test_log_space_likelihood.py`:

- Parity: `log_likelihood() == log(likelihood())` at ordinary points, `rtol=1e-12`, for all three distributions.
- Reference: matches `scipy.stats.norm`/`poisson`/`lognorm` log-density functions.
- Stability (the #243 acceptance criteria): Gaussian at `|x-mu|/sigma = 40` and the LogNormal equivalent both underflow to `0.0` in probability space while `log_likelihood` stays finite (~-800); Poisson checked at `mean=x=1e5` (large cancelling terms) and deep in the tail (`mean=100, x=1000`, where the pmf underflows but the log-pmf doesn't); a `mean=0, x=0` case covers the new guard.
- Base-class default: `ExponentialDist` (no override) falls back to `pt.log(likelihood())`.
- `log_expression()`: equals `log_likelihood()` with no matching observable, equals `log(likelihood()/integral)` with quadrature normalization, and (new test in `tests/test_normalization.py`) skips normalization entirely for a `_normalizable=False` distribution — a branch `HistFactoryDistChannel`'s own override never exercises for the base implementation.

Full quick suite (`pixi run --environment py312 test`) passes: 1078 passed. Coverage on `distributions/core.py` and `distributions/basic.py` is 100% (lines and branches). `pre-commit run --files <touched files>` is clean.

Refs #243, #254 (phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct log-likelihood support for common distributions, improving numerical stability and enabling more reliable probability calculations.
  * Log-space expressions now use analytic log-likelihoods when available, with normalization handled automatically when needed.

* **Bug Fixes**
  * Improved handling of zero-count Poisson cases to avoid invalid values and unstable results.
  * Reduced underflow issues so very small probabilities can still be evaluated in log space.

* **Tests**
  * Added coverage for analytic log-likelihoods, normalization behavior, and fallback handling across distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->