### PR TITLE
fix: resolve observables per likelihood instead of merging across likelihoods

### DIFF
--- a/src/pyhs3/workspace.py
+++ b/src/pyhs3/workspace.py
@@ -405,42 +405,44 @@ class Workspace(BaseModel):
 
     def _compute_observables(self) -> dict[str, tuple[float, float]]:
         """
-        Extract observable names and bounds from likelihoods + data + domain.
+        Resolve observables for model paths built without an explicit likelihood.
 
-        Walks likelihoods to find distribution-data pairings. For each dataset axis,
-        gets bounds from the data axis itself (axis.min/max). Propagates observable
-        info through composite distributions (MixtureDist, ProductDist).
+        Observables are a per-likelihood concept: an axis is only an observable
+        of the data actually loaded by a given likelihood, and every analysis
+        references exactly one likelihood, so axes from different likelihoods
+        are never combined in one calculation. The legacy ``model(int)`` and
+        name-fallback ``model(str)`` paths have no likelihood to scope to, so
+        observables are resolved from each likelihood independently (via
+        :meth:`_extract_observables`, the same resolution the per-likelihood
+        ``model(Likelihood)`` / ``model(Analysis)`` paths use) and only used
+        when every likelihood implies the same result.
 
         Returns:
-            Dictionary mapping observable names to (min, max) tuples
+            Dictionary mapping observable names to (min, max) tuples; empty
+            when the workspace has no likelihoods.
+
+        Raises:
+            ValueError: If the workspace's likelihoods imply different
+                observables, since a model built without a likelihood has no
+                principled way to choose between them.
         """
-        observables: dict[str, tuple[float, float]] = {}
+        if not self.likelihoods:
+            return {}
 
-        if not self.likelihoods or not self.data:
-            return observables
-
-        # For each likelihood, extract observable axes from paired data
+        first = self.likelihoods[0]
+        observables = self._extract_observables(first)
         for likelihood in self.likelihoods:
-            for data_item in likelihood.data:
-                # FK resolution guarantees data items are resolved objects
-                datum = (
-                    data_item
-                    if not isinstance(data_item, str)
-                    else self.data[data_item]
+            candidate = self._extract_observables(likelihood)
+            if candidate != observables:
+                msg = (
+                    f"Cannot determine observables for a model built without a "
+                    f"likelihood: likelihood '{first.name}' implies {observables} "
+                    f"but likelihood '{likelihood.name}' implies {candidate}. "
+                    f"Observables are resolved per likelihood; build the model "
+                    f"from a specific likelihood instead, e.g. "
+                    f"workspace.model(workspace.likelihoods[{likelihood.name!r}])."
                 )
-
-                if datum.axes is None:
-                    log.warning(
-                        "The likelihood '%s' references data '%s' without axes. This cannot be used to normalize any distribution.",
-                        likelihood.name,
-                        datum.name,
-                    )
-                    continue
-
-                # For each axis, extract bounds
-                for axis in datum.axes:
-                    observables[axis.name] = (axis.min, axis.max)
-
+                raise ValueError(msg)
         return observables
 
     @staticmethod

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 import pytest
 
-from pyhs3 import Workspace
+from pyhs3 import Model, Workspace
 from pyhs3.analyses import Analyses, Analysis
+from pyhs3.data import BinnedData, Data
+from pyhs3.distributions import Distributions
+from pyhs3.distributions.mathematical import GenericDist
 from pyhs3.exceptions import WorkspaceValidationError
 from pyhs3.likelihoods import Likelihood, Likelihoods
 from pyhs3.metadata import Metadata
@@ -219,6 +222,83 @@ class TestWorkspaceFKResolutionWithNoneCollections:
                 distributions=None,
                 data=None,
             )
+
+
+class TestPerLikelihoodObservables:
+    """Observables are resolved per likelihood, never merged across likelihoods."""
+
+    @staticmethod
+    def _make_workspace(
+        likelihood_bounds: dict[str, tuple[float, float]],
+    ) -> Workspace:
+        """Build a workspace with one likelihood per entry, each with an 'x' axis."""
+        return Workspace(
+            metadata=Metadata(hs3_version="0.3.0"),
+            distributions=Distributions(
+                [
+                    GenericDist(name=f"dist_{name}", expression="exp(-x)")
+                    for name in likelihood_bounds
+                ]
+            ),
+            data=Data(
+                [
+                    BinnedData(
+                        name=f"data_{name}",
+                        axes=[{"name": "x", "min": lo, "max": hi, "nbins": 10}],
+                        contents=[1.0] * 10,
+                    )
+                    for name, (lo, hi) in likelihood_bounds.items()
+                ]
+            ),
+            likelihoods=Likelihoods(
+                [
+                    Likelihood(
+                        name=name,
+                        distributions=[f"dist_{name}"],
+                        data=[f"data_{name}"],
+                    )
+                    for name in likelihood_bounds
+                ]
+            ),
+        )
+
+    @staticmethod
+    def _bounds(model: Model, name: str) -> tuple[float, float]:
+        """Evaluate a model observable's (min, max) tensor constants to floats."""
+        lower, upper = model._observables[name]
+        return (float(lower.data), float(upper.data))
+
+    def test_different_bounds_across_likelihoods_are_valid(self):
+        """Same axis name with different bounds across likelihoods is legitimate:
+        the workspace loads and each likelihood's model gets its own bounds."""
+        ws = self._make_workspace({"lk_a": (0.0, 10.0), "lk_b": (0.0, 20.0)})
+        model_a = ws.model(ws.likelihoods["lk_a"], progress=False)
+        model_b = ws.model(ws.likelihoods["lk_b"], progress=False)
+        assert self._bounds(model_a, "x") == pytest.approx((0.0, 10.0))
+        assert self._bounds(model_b, "x") == pytest.approx((0.0, 20.0))
+
+    def test_legacy_model_single_likelihood_uses_its_observables(self):
+        """Legacy ws.model(0) on a single-likelihood workspace resolves that
+        likelihood's observables."""
+        ws = self._make_workspace({"lk_a": (0.0, 10.0)})
+        assert ws._compute_observables() == {"x": (0.0, 10.0)}
+        model = ws.model(0, progress=False)
+        assert self._bounds(model, "x") == pytest.approx((0.0, 10.0))
+
+    def test_legacy_model_agreeing_likelihoods_share_observables(self):
+        """Legacy ws.model(0) still works when every likelihood implies the same
+        observables (e.g. asimov and observed data over identical axes)."""
+        ws = self._make_workspace({"lk_a": (0.0, 10.0), "lk_b": (0.0, 10.0)})
+        assert ws._compute_observables() == {"x": (0.0, 10.0)}
+        model = ws.model(0, progress=False)
+        assert self._bounds(model, "x") == pytest.approx((0.0, 10.0))
+
+    def test_legacy_model_disagreeing_likelihoods_raises(self):
+        """Legacy ws.model(0) has no principled observable choice when the
+        likelihoods disagree — the user must select a likelihood explicitly."""
+        ws = self._make_workspace({"lk_a": (0.0, 10.0), "lk_b": (0.0, 20.0)})
+        with pytest.raises(ValueError, match="Cannot determine observables"):
+            ws.model(0, progress=False)
 
 
 class TestWorkspaceRepr:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Replaces #258 (wrong design premise — please close that one).

## Corrected model

- Observables are a **per-likelihood** concept: an axis is only an observable of the data actually loaded by a given likelihood, and every analysis references exactly **one** likelihood, so axes from different likelihoods are never combined in one calculation.
- Cross-likelihood axis differences are therefore **valid**, not a conflict: different likelihoods legitimately reference different data with different axes/bounds (lk_a with data_a, lk_b with data_b, or any dist/data pairing).
- The actual bug (review issue #230, item 14c) was that `Workspace._compute_observables()` merged observable axes across **all** likelihoods with last-wins semantics, so the legacy `model(int)` / name-fallback `model(str)` paths could silently pick up bounds from the wrong likelihood. Even a conflict-free union is wrong — two axes are only both observables when their datasets are used together in the *same* likelihood.

## Changes

- `Workspace._compute_observables()` now resolves observables from each likelihood independently via `_extract_observables` (the same resolution the `model(Likelihood)` / `model(Analysis)` paths already use) and succeeds only when the answer is unambiguous:
  - zero likelihoods → empty (unchanged),
  - every likelihood implies the same observables → that common result (keeps e.g. RooFit HS3 exports with `simPdf_asimovData` + `simPdf_obsData` likelihoods over identical axes working through `ws.model(0)`),
  - likelihoods disagree → `ValueError` naming both likelihoods and directing the user to `workspace.model(workspace.likelihoods[...])`.
- The per-likelihood `model(Likelihood)` / `model(Analysis)` paths were already correct and are unchanged.
- No new load-time validation needed: within-likelihood duplicate axis names are already rejected at workspace load by `Likelihood.validate_unique_axis_names`.

## Test plan

- [x] `TestPerLikelihoodObservables` in `tests/test_workspace.py`: cross-likelihood different bounds load fine and each likelihood's model gets its own bounds; legacy `ws.model(0)` works for single-likelihood and agreeing multi-likelihood workspaces; disagreeing likelihoods raise a clear error (TDD: disagree case RED first, then GREEN).
- [x] Full quick suite: `pixi run --environment py312 test` → 1087 passed, 3 skipped, 9 deselected, 1 xfailed.
- [x] Coverage on `workspace.py` stays 100% (statements and branches).
- [x] `pre-commit` passes on touched files.

Refs #230 (item 14c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
