### PR TITLE
feat: evaluate HistFactory constraints in log space

### DIFF
--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -312,10 +312,10 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
                     return modifier
         return None
 
-    def _make_barlow_beeston_lite_constraint(
+    def _build_barlow_beeston_lite_dists(
         self, context: Context
-    ) -> TensorVar | None:
-        """Build BB-lite constraint from combined sample uncertainties.
+    ) -> list[tuple[GaussianDist | PoissonDist, Context]] | None:
+        """Construct the per-bin BB-lite Gauss/Poisson constraint distributions.
 
         BB-lite uses shared gamma parameters across samples with a channel-level
         constraint built from combined MC statistical uncertainties.
@@ -327,6 +327,12 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         Combined uncertainties from samples:
         - total_nominal = sum(sample.data.contents)
         - total_sigma = sqrt(sum(sample.data.errors^2))
+
+        Returns ``None`` when this channel has no staterror modifier (nothing
+        to constrain). Shared by :meth:`_make_barlow_beeston_lite_constraint`
+        (product of per-bin probabilities) and
+        :meth:`_make_barlow_beeston_lite_log_constraint` (sum of per-bin
+        log-probabilities) so the parametrization is defined exactly once.
         """
         total_bins = self._get_total_bins()
 
@@ -392,13 +398,38 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         if not dists:
             return None
 
-        # Evaluate all distributions with augmented context and multiply
-        factors = []
-        for dist in dists:
-            dist_ctx = Context({**augmented_context, **dist.constants})
-            factors.append(dist.expression(dist_ctx))
+        return [
+            (dist, Context({**augmented_context, **dist.constants})) for dist in dists
+        ]
 
+    def _make_barlow_beeston_lite_constraint(
+        self, context: Context
+    ) -> TensorVar | None:
+        """Build BB-lite constraint (product of per-bin probabilities) from
+        combined sample uncertainties, or ``None`` if this channel has no
+        staterror modifier."""
+        pairs = self._build_barlow_beeston_lite_dists(context)
+        if pairs is None:
+            return None
+
+        factors = [dist.expression(ctx) for dist, ctx in pairs]
         return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
+
+    def _make_barlow_beeston_lite_log_constraint(
+        self, context: Context
+    ) -> TensorVar | None:
+        """Log-space counterpart of :meth:`_make_barlow_beeston_lite_constraint`.
+
+        Sum of per-bin Gauss/Poisson log-probabilities instead of their
+        product, so the constraint stays finite where the probability-space
+        product would underflow to 0.0.
+        """
+        pairs = self._build_barlow_beeston_lite_dists(context)
+        if pairs is None:
+            return None
+
+        log_terms = [dist.log_expression(ctx) for dist, ctx in pairs]
+        return cast(TensorVar, pt.sum(pt.stack(log_terms), axis=0))  # type: ignore[no-untyped-call]
 
     def _compute_expected_rates(self, context: Context, total_bins: int) -> TensorVar:
         """
@@ -570,9 +601,12 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         """Log-space constraint sum for this channel.
 
         Log-space counterpart of :meth:`extended_likelihood`: returns the sum of
-        ``log(constraint)`` terms (deduped by parameter exactly as in
-        :meth:`extended_likelihood`) instead of their product, avoiding the
-        ``log(prod(...))`` round-trip.
+        each modifier's ``log_constraint(...)`` term (deduped by parameter
+        exactly as in :meth:`extended_likelihood`) instead of the product of
+        ``make_constraint(...)`` terms. ``log_constraint`` evaluates the same
+        constraint distribution(s) via their analytic log-space form, so this
+        never takes ``pt.log`` of a probability-space value that can underflow
+        to 0.0.
 
         Args:
             context: Mapping of parameter names to PyTensor variables
@@ -587,15 +621,13 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
                 if dedup_key in seen:
                     continue
                 seen.add(dedup_key)
-            log_constraints.append(
-                pt.log(modifier.make_constraint(context, sample_data))
-            )
+            log_constraints.append(modifier.log_constraint(context, sample_data))
 
         # Add channel-level BB-lite constraint if in lite mode
         if self.barlow_beeston_method == "lite":
-            lite_constraint = self._make_barlow_beeston_lite_constraint(context)
-            if lite_constraint is not None:
-                log_constraints.append(cast(TensorVar, pt.log(lite_constraint)))
+            lite_log_constraint = self._make_barlow_beeston_lite_log_constraint(context)
+            if lite_log_constraint is not None:
+                log_constraints.append(lite_log_constraint)
 
         if not log_constraints:
             return cast(TensorVar, pt.constant(0.0))

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -107,7 +107,18 @@ class HasConstraint(ABC):
 
     @abstractmethod
     def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
-        """Create constraint term for this modifier."""
+        """Create constraint term for this modifier (probability space)."""
+
+    @abstractmethod
+    def log_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
+        """Create constraint term for this modifier (log space).
+
+        Log-space counterpart of :meth:`make_constraint`: evaluates the same
+        constraint distribution(s) via their analytic ``log_likelihood``
+        instead of taking ``pt.log`` of the probability-space result, so the
+        constraint stays finite where the probability-space value would
+        underflow to 0.0.
+        """
 
 
 class SingleParamConstraint(HasConstraint, ABC):
@@ -116,8 +127,13 @@ class SingleParamConstraint(HasConstraint, ABC):
     name: str
     parameter: str
 
-    def make_constraint(self, context: Context, _: SampleData) -> TensorVar:
-        """Create constraint term using a Gauss, Poisson, or LogNormal distribution."""
+    def _build_constraint(self, context: Context) -> tuple[Distribution, Context]:
+        """Construct the Gauss/Poisson/LogNormal constraint distribution.
+
+        Shared by :meth:`make_constraint` and :meth:`log_constraint` so the
+        parametrization (which distribution, and with which parameter/constant
+        values) is defined exactly once.
+        """
         name = f"constraint_{self.name}"
         constraint_dist: Distribution
 
@@ -133,7 +149,17 @@ class SingleParamConstraint(HasConstraint, ABC):
             )
 
         augmented_context = {**context, **constraint_dist.constants}
-        return constraint_dist.expression(Context(augmented_context))
+        return constraint_dist, Context(augmented_context)
+
+    def make_constraint(self, context: Context, _: SampleData) -> TensorVar:
+        """Create constraint term using a Gauss, Poisson, or LogNormal distribution."""
+        constraint_dist, augmented_context = self._build_constraint(context)
+        return constraint_dist.expression(augmented_context)
+
+    def log_constraint(self, context: Context, _: SampleData) -> TensorVar:
+        """Create constraint term using the analytic log form of the same distribution."""
+        constraint_dist, augmented_context = self._build_constraint(context)
+        return constraint_dist.log_expression(augmented_context)
 
 
 # Parameterized modifier base (single parameter)
@@ -330,9 +356,15 @@ class ShapeSysModifier(HasConstraint, ParametersModifier):
         """Apply shapesys modifier (shape systematic with constraints)."""
         return cast("TensorVar", rates * self.expression(context))
 
-    def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
-        """Create constraint term using PyTensor operations."""
+    def _build_bin_constraints(
+        self, context: Context, sample_data: SampleData
+    ) -> list[tuple[Distribution, Context]]:
+        """Construct the per-bin Poisson constraint distributions.
 
+        Shared by :meth:`make_constraint` (product of per-bin probabilities)
+        and :meth:`log_constraint` (sum of per-bin log-probabilities) so the
+        parametrization is defined exactly once.
+        """
         name = f"constraint_{self.name}"
 
         # (sigma_b)^{-2} = (nominal / vals)^2, evaluated on concrete floats.
@@ -351,20 +383,27 @@ class ShapeSysModifier(HasConstraint, ParametersModifier):
             augmented_context[scaled_param_name] = context[parameter] * rate
 
             # Create Poisson distribution with scaled parameter
-            dist = PoissonDist(
+            dist: Distribution = PoissonDist(
                 name=f"{name}_{parameter}", x=rate, mean=scaled_param_name
             )
             dists.append(dist)
 
-        # Evaluate all distributions with augmented context (including constants)
-        factors = []
-        for dist in dists:
-            # Use the distribution's constants to augment the context
-            dist_augmented_context = {**augmented_context, **dist.constants}
-            augmented_ctx = Context(dist_augmented_context)
-            factors.append(dist.expression(augmented_ctx))
+        # Pair each distribution with a context augmented by its own constants.
+        return [
+            (dist, Context({**augmented_context, **dist.constants})) for dist in dists
+        ]
 
+    def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
+        """Create constraint term using PyTensor operations."""
+        pairs = self._build_bin_constraints(context, sample_data)
+        factors = [dist.expression(ctx) for dist, ctx in pairs]
         return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
+
+    def log_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
+        """Create constraint term as the sum of per-bin Poisson log-probabilities."""
+        pairs = self._build_bin_constraints(context, sample_data)
+        log_terms = [dist.log_expression(ctx) for dist, ctx in pairs]
+        return cast(TensorVar, pt.sum(pt.stack(log_terms), axis=0))  # type: ignore[no-untyped-call]
 
 
 class StatErrorModifier(HasConstraint, ParametersModifier):
@@ -386,23 +425,25 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
         """Apply staterror modifier (Barlow-Beeston statistical uncertainties)."""
         return cast("TensorVar", rates * self.expression(context))
 
-    def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
-        """Create constraint term using PyTensor operations.
+    def _build_bin_constraints(
+        self, context: Context, sample_data: SampleData, data: StatErrorData
+    ) -> list[tuple[Distribution, Context]]:
+        """Construct the per-bin Gauss/Poisson constraint distributions.
 
-        Only used in BB-full mode. In BB-lite mode, constraints are built at channel level.
+        Only used in BB-full mode. In BB-lite mode, constraints are built at
+        channel level. Shared by :meth:`make_constraint` (product of per-bin
+        probabilities) and :meth:`log_constraint` (sum of per-bin
+        log-probabilities) so the parametrization is defined exactly once.
+        ``data`` is taken as an explicit argument (rather than reading
+        ``self.data``) so callers narrow the ``StatErrorData | None`` type by
+        raising before calling, instead of asserting it here.
         """
-        if self.data is None:
-            msg = (
-                "StatErrorModifier.data is required for BB-full mode (make_constraint)"
-            )
-            raise ValueError(msg)
-
         name = f"constraint_{self.name}"
         augmented_context = dict(context)
-        dists = []
+        dists: list[Distribution] = []
 
         for i, (parameter, uncertainty) in enumerate(
-            zip(self.parameters, self.data.uncertainties, strict=False)
+            zip(self.parameters, data.uncertainties, strict=False)
         ):
             nominal_yield = sample_data.contents[i]
             # sigma_value is the relative uncertainty = uncertainty / nominal_yield
@@ -417,7 +458,7 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
                 tau = 1.0 / sigma_value**2
                 scaled_name = f"{parameter}_scaled"
                 augmented_context[scaled_name] = context[parameter] * tau
-                dist: GaussianDist | PoissonDist = PoissonDist(
+                dist: Distribution = PoissonDist(
                     name=f"{name}_{parameter}",
                     x=float(tau),
                     mean=scaled_name,
@@ -434,18 +475,44 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
                 )
             dists.append(dist)
 
-        if not dists:
+        # Pair each distribution with a context augmented by its own constants.
+        return [
+            (dist, Context({**augmented_context, **dist.constants})) for dist in dists
+        ]
+
+    def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
+        """Create constraint term using PyTensor operations.
+
+        Only used in BB-full mode. In BB-lite mode, constraints are built at channel level.
+        """
+        if self.data is None:
+            msg = (
+                "StatErrorModifier.data is required for BB-full mode (make_constraint)"
+            )
+            raise ValueError(msg)
+
+        pairs = self._build_bin_constraints(context, sample_data, self.data)
+        if not pairs:
             return pt.constant(1.0)
 
-        # Evaluate all distributions with augmented context (including constants) and multiply
-        factors = []
-        for dist in dists:
-            # Use the distribution's constants to augment the context
-            dist_augmented_context = {**augmented_context, **dist.constants}
-            augmented_ctx = Context(dist_augmented_context)
-            factors.append(dist.expression(augmented_ctx))
-
+        factors = [dist.expression(ctx) for dist, ctx in pairs]
         return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
+
+    def log_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
+        """Create constraint term as the sum of per-bin Gauss/Poisson log-probabilities.
+
+        Only used in BB-full mode. In BB-lite mode, constraints are built at channel level.
+        """
+        if self.data is None:
+            msg = "StatErrorModifier.data is required for BB-full mode (log_constraint)"
+            raise ValueError(msg)
+
+        pairs = self._build_bin_constraints(context, sample_data, self.data)
+        if not pairs:
+            return pt.constant(0.0)
+
+        log_terms = [dist.log_expression(ctx) for dist, ctx in pairs]
+        return cast(TensorVar, pt.sum(pt.stack(log_terms), axis=0))  # type: ignore[no-untyped-call]
 
 
 # Discriminated union of all modifier types.

--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -60,11 +60,15 @@ class Model:
     main Poisson term; ``log_prob`` uses it to assemble the joint NLL without
     double-counting constraint factors when multiple channels share a nuisance
     parameter.  Constraint expressions are appended to
-    ``self._hfdc_constraints`` exactly once per unique dedup key across all
-    channels: single-parameter modifiers (``normsys``, ``histosys``) are
-    deduped by parameter name using ``self._hfdc_constraint_params_seen``;
-    multi-parameter modifiers (``shapesys``, ``staterror``) are channel-local
-    by workspace validation and always emitted as-is.
+    ``self._hfdc_constraints`` (probability space) and, in lockstep,
+    ``self._hfdc_log_constraints`` (log space) exactly once per unique dedup
+    key across all channels: single-parameter modifiers (``normsys``,
+    ``histosys``) are deduped by parameter name using
+    ``self._hfdc_constraint_params_seen``; multi-parameter modifiers
+    (``shapesys``, ``staterror``) are channel-local by workspace validation
+    and always emitted as-is.  ``log_prob`` sums ``self._hfdc_log_constraints``
+    directly rather than taking ``pt.log`` of ``self._hfdc_constraints``, so it
+    stays finite where the probability-space constraints underflow to 0.0.
 
     HS3 Reference:
         Models are computational representations of :hs3:label:`HS3 workspaces <hs3.file-format>`.
@@ -151,6 +155,11 @@ class Model:
         # ParameterModifier constraints are deduped by parameter name across channels;
         # ParametersModifier constraints (shapesys/staterror) are emitted per-channel.
         self._hfdc_constraints: list[TensorVar] = []
+        # Log-space counterpart of self._hfdc_constraints, built alongside it
+        # (one modifier.log_constraint() call per modifier.make_constraint()
+        # call) so log_prob never has to take pt.log() of a probability-space
+        # constraint that can underflow to 0.0.
+        self._hfdc_log_constraints: list[TensorVar] = []
         self._hfdc_constraint_params_seen: set[str] = set()
         # Poisson-only (no constraint product) expressions for HFDC channels.
         # self.distributions[name] stores the full expression (Poisson x constraints)
@@ -364,10 +373,10 @@ class Model:
             )
 
         # HFDC constraint terms: collected once per unique nuisance parameter
-        # across all channels during graph construction.
-        terms.extend(
-            pt.log(constraint_expr) for constraint_expr in self._hfdc_constraints
-        )
+        # across all channels during graph construction. Log-space terms are
+        # used directly (rather than pt.log(self._hfdc_constraints)) so this
+        # stays finite where the probability-space constraints underflow to 0.0.
+        terms.extend(self._hfdc_log_constraints)
 
         if not terms:
             return pt.constant(np.float64(0.0))
@@ -486,9 +495,9 @@ class Model:
         is returned and stored in ``self.distributions`` so that :meth:`logpdf`
         continues to work as before.  In addition, the Poisson-only term is
         stored in ``self._hfdc_poisson`` and the deduplicated constraint terms
-        are appended to ``self._hfdc_constraints`` so that :attr:`log_prob` can
-        combine them without double-counting when multiple channels share a
-        nuisance parameter.
+        are appended to ``self._hfdc_constraints``/``self._hfdc_log_constraints``
+        so that :attr:`log_prob` can combine them without double-counting when
+        multiple channels share a nuisance parameter.
         """
         dist = distributions[node_name]
         if not isinstance(dist, HistFactoryDistChannel):
@@ -503,8 +512,8 @@ class Model:
         # shared pieces.  This mirrors Distribution._expression/log_expression
         # (likelihood -> normalization -> x/+ constraints) and
         # HistFactoryDistChannel.extended_likelihood/log_extended_likelihood
-        # without rebuilding the Poisson subgraph or re-running make_constraint
-        # a second time.
+        # without rebuilding the Poisson subgraph or re-running
+        # make_constraint/log_constraint a second time.
         poisson = dist.likelihood(context)
         self._hfdc_poisson[node_name] = poisson
         # Log-space Poisson-only term (sum of per-bin Poisson log-pmfs).
@@ -519,19 +528,23 @@ class Model:
             for d in self._likelihood.distributions
         )
 
-        # Single pass over constraint specs builds each constraint factor once.
+        # Single pass over constraint specs builds each constraint factor (both
+        # probability- and log-space) exactly once.
         # - channel_seen dedups by parameter for the per-channel product
         #   (matches extended_likelihood's local dedup),
         # - self._hfdc_constraint_params_seen dedups across channels for log_prob.
         channel_seen: set[str] = set()
         channel_constraints: list[TensorVar] = []
+        channel_log_constraints: list[TensorVar] = []
         for dedup_key, modifier, sample_data in dist.constraint_specs():
             constraint = modifier.make_constraint(context, sample_data)
+            log_constraint = modifier.log_constraint(context, sample_data)
 
             if dedup_key is None or dedup_key not in channel_seen:
                 if dedup_key is not None:
                     channel_seen.add(dedup_key)
                 channel_constraints.append(constraint)
+                channel_log_constraints.append(log_constraint)
 
             if in_likelihood:
                 if dedup_key is not None:
@@ -539,6 +552,7 @@ class Model:
                         continue
                     self._hfdc_constraint_params_seen.add(dedup_key)
                 self._hfdc_constraints.append(constraint)
+                self._hfdc_log_constraints.append(log_constraint)
 
         # BB-lite mode's channel-level constraint (shared gamma parameters
         # combining all samples' statistical uncertainties) is not a
@@ -548,10 +562,17 @@ class Model:
         # so it is always appended, with no cross-channel dedup key.
         if dist.barlow_beeston_method == "lite":
             lite_constraint = dist._make_barlow_beeston_lite_constraint(context)  # pylint: disable=protected-access
+            lite_log_constraint = dist._make_barlow_beeston_lite_log_constraint(  # pylint: disable=protected-access
+                context
+            )
             if lite_constraint is not None:
                 channel_constraints.append(lite_constraint)
+                channel_log_constraints.append(cast(TensorVar, lite_log_constraint))
                 if in_likelihood:
                     self._hfdc_constraints.append(lite_constraint)
+                    self._hfdc_log_constraints.append(
+                        cast(TensorVar, lite_log_constraint)
+                    )
 
         # Assemble the full per-channel expression: normalized Poisson term times
         # the constraint product (extended likelihood).  HFDC is not normalizable
@@ -568,7 +589,7 @@ class Model:
             )
             log_extended = cast(
                 TensorVar,
-                pt.sum(pt.stack([pt.log(c) for c in channel_constraints])),  # type: ignore[no-untyped-call]
+                pt.sum(pt.stack(channel_log_constraints)),  # type: ignore[no-untyped-call]
             )
         full = cast(TensorVar, raw * extended)
         full.name = dist.name  # Evaluable.expression sets the name

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -623,6 +623,29 @@ class TestBBLiteStaterrorModelBuild:
         expected = poisson_lp + lite_lp
         assert val == pytest.approx(expected, rel=1e-6)
 
+    def test_bblite_log_constraint_matches_log_of_constraint(self):
+        """``_make_barlow_beeston_lite_log_constraint`` (#243 Layer 2) must equal
+        ``log(_make_barlow_beeston_lite_constraint(...))`` at ordinary gamma
+        values, for both the Gauss and Poisson BB-lite constraint types."""
+        for constraint_type in ("Gauss", "Poisson"):
+            channel_dict = self._lite_staterror_channel_dict()
+            for sample in channel_dict["samples"]:
+                for modifier in sample["modifiers"]:
+                    modifier["constraint"] = constraint_type
+            dist = HistFactoryDistChannel(**channel_dict)
+
+            context = Context(
+                {
+                    "gamma_bin0": pt.constant(1.02, dtype="float64"),
+                    "gamma_bin1": pt.constant(0.98, dtype="float64"),
+                }
+            )
+            prob = float(dist._make_barlow_beeston_lite_constraint(context).eval())  # pylint: disable=protected-access
+            log_prob = float(
+                dist._make_barlow_beeston_lite_log_constraint(context).eval()  # pylint: disable=protected-access
+            )
+            assert log_prob == pytest.approx(math.log(prob), rel=1e-8), constraint_type
+
     def test_model_expression_matches_dist_expression(self):
         """The model's per-channel expression matches ``dist.expression()`` directly.
 
@@ -878,6 +901,29 @@ class TestHFDCSubgraphBuildCounts:
 
         assert calls == ["lumi"], (
             f"expected exactly one make_constraint call per constraint spec, got {calls}"
+        )
+
+    def test_log_constraint_called_once_per_spec(self, monkeypatch):
+        """``log_constraint`` (#243 Layer 2) must build each log-space constraint
+        factor exactly once during model construction, alongside the single
+        ``make_constraint`` call asserted above."""
+        calls: list[str] = []
+        original = SingleParamConstraint.log_constraint
+
+        def counted(
+            self: SingleParamConstraint, context: Context, sample_data: object
+        ) -> object:
+            calls.append(self.name)
+            return original(self, context, sample_data)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(SingleParamConstraint, "log_constraint", counted)
+
+        ws = _single_channel_normsys_workspace()
+        likelihood = next(iter(ws.likelihoods))
+        ws.model(likelihood, progress=False)
+
+        assert calls == ["lumi"], (
+            f"expected exactly one log_constraint call per constraint spec, got {calls}"
         )
 
     def test_logpdf_matches_log_pdf_for_hfdc_with_constraint(self):

--- a/tests/test_histfactory_modifiers.py
+++ b/tests/test_histfactory_modifiers.py
@@ -11,6 +11,7 @@ import math
 import numpy as np
 import pytensor.tensor as pt
 import pytest
+from scipy.stats import norm as scipy_norm
 
 from pyhs3.context import Context
 from pyhs3.distributions.histfactory.data import SampleData
@@ -701,3 +702,154 @@ class TestModifierEdgeCases:
 
         np.testing.assert_allclose(result1_zero, 100.0, rtol=1e-6)
         np.testing.assert_allclose(result4_zero, 100.0, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 of #243: log_constraint() on the modifier hierarchy.
+#
+# log_constraint() must agree with log(make_constraint()) at ordinary
+# parameter values (where make_constraint() is representable in float64) and
+# must stay finite where make_constraint() underflows to 0.0.
+# ---------------------------------------------------------------------------
+
+
+class TestLogConstraintParity:
+    """log_constraint() == log(make_constraint()) at ordinary parameter values."""
+
+    @pytest.mark.parametrize("constraint_type", ["Gauss", "Poisson", "LogNormal"])
+    def test_normsys(self, constraint_type):
+        data = NormSysData(hi=1.1, lo=0.9)
+        modifier = NormSysModifier(
+            name="lumi", parameter="alpha_lumi", data=data, constraint=constraint_type
+        )
+        context = Context({"alpha_lumi": pt.constant(1.0, dtype="float64")})
+        sample_data = SampleData(contents=[10.0, 20.0], errors=[1.0, 2.0])
+
+        prob = float(modifier.make_constraint(context, sample_data).eval())
+        log_prob = float(modifier.log_constraint(context, sample_data).eval())
+        assert log_prob == pytest.approx(math.log(prob), rel=1e-10)
+
+    @pytest.mark.parametrize("constraint_type", ["Gauss", "Poisson", "LogNormal"])
+    def test_histosys(self, constraint_type):
+        hi_contents = HistoSysDataContents(contents=[15.0, 25.0])
+        lo_contents = HistoSysDataContents(contents=[5.0, 15.0])
+        data = HistoSysData(hi=hi_contents, lo=lo_contents, interpolation="code0")
+        modifier = HistoSysModifier(
+            name="shape_unc",
+            parameter="alpha_shape",
+            data=data,
+            constraint=constraint_type,
+        )
+        context = Context({"alpha_shape": pt.constant(1.0, dtype="float64")})
+        sample_data = SampleData(contents=[10.0, 20.0], errors=[1.0, 2.0])
+
+        prob = float(modifier.make_constraint(context, sample_data).eval())
+        log_prob = float(modifier.log_constraint(context, sample_data).eval())
+        assert log_prob == pytest.approx(math.log(prob), rel=1e-10)
+
+    def test_shapesys(self):
+        data = ShapeSysData(vals=[0.06, 0.1346153846153846])
+        modifier = ShapeSysModifier(
+            name="uncorr_bkguncrt",
+            parameters=["uncorr_bkguncrt_0", "uncorr_bkguncrt_1"],
+            data=data,
+        )
+        context = Context(
+            {
+                "uncorr_bkguncrt_0": pt.constant(1.02, dtype="float64"),
+                "uncorr_bkguncrt_1": pt.constant(0.98, dtype="float64"),
+            }
+        )
+        sample_data = SampleData(contents=[50.0, 52.0], errors=[3.0, 3.5])
+
+        prob = float(modifier.make_constraint(context, sample_data).eval())
+        log_prob = float(modifier.log_constraint(context, sample_data).eval())
+        assert log_prob == pytest.approx(math.log(prob), rel=1e-8)
+
+    @pytest.mark.parametrize("constraint_type", ["Gauss", "Poisson"])
+    def test_staterror(self, constraint_type):
+        data = StatErrorData(uncertainties=[2.0, 3.0])
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0", "gamma_stat_bin1"],
+            constraint=constraint_type,
+            data=data,
+        )
+        context = Context(
+            {
+                "gamma_stat_bin0": pt.constant(1.02, dtype="float64"),
+                "gamma_stat_bin1": pt.constant(0.98, dtype="float64"),
+            }
+        )
+        sample_data = SampleData(contents=[50.0, 75.0], errors=[2.0, 3.0])
+
+        prob = float(modifier.make_constraint(context, sample_data).eval())
+        log_prob = float(modifier.log_constraint(context, sample_data).eval())
+        assert log_prob == pytest.approx(math.log(prob), rel=1e-8)
+
+    def test_staterror_poisson_skips_zero_yield_bin(self):
+        """Parity must also hold when a zero-yield bin is skipped (Poisson)."""
+        data = StatErrorData(uncertainties=[1.0, 1.0])
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0", "gamma_stat_bin1"],
+            constraint="Poisson",
+            data=data,
+        )
+        context = Context(
+            {
+                "gamma_stat_bin0": pt.constant(1.0, dtype="float64"),
+                "gamma_stat_bin1": pt.constant(1.0, dtype="float64"),
+            }
+        )
+        sample_data = SampleData(contents=[0.0, 10.0], errors=[0.0, 1.0])
+
+        prob = float(modifier.make_constraint(context, sample_data).eval())
+        log_prob = float(modifier.log_constraint(context, sample_data).eval())
+        assert log_prob == pytest.approx(math.log(prob), rel=1e-8)
+
+    def test_staterror_empty_parameters_edge_case(self):
+        """log_constraint() with no parameters returns log(1.0) == 0.0."""
+        data = StatErrorData(uncertainties=[])
+        modifier = StatErrorModifier(name="stat", parameters=[], data=data)
+        context = Context({})
+        sample_data = SampleData(contents=[], errors=[])
+
+        log_constraint = modifier.log_constraint(context, sample_data)
+        assert float(log_constraint.eval()) == pytest.approx(0.0)
+
+    def test_staterror_log_constraint_requires_data(self):
+        """log_constraint() raises ValueError when data=None (BB-full mode guard),
+        mirroring make_constraint()'s guard."""
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0"],
+            data=None,
+        )
+        context = Context({"gamma_stat_bin0": pt.constant(1.0, dtype="float64")})
+        sample_data = SampleData(contents=[50.0], errors=[2.0])
+
+        with pytest.raises(ValueError, match="data is required for BB-full mode"):
+            modifier.log_constraint(context, sample_data)
+
+
+class TestLogConstraintUnderflow:
+    """log_constraint() stays finite where make_constraint() underflows to 0.0."""
+
+    def test_normsys_gauss_alpha_40_matches_scipy_norm_logpdf(self):
+        """At |alpha|=40 the Gaussian constraint underflows in probability
+        space but log_constraint() must stay finite and match
+        scipy.stats.norm.logpdf(alpha) (the constraint is N(0 | alpha, 1))."""
+        data = NormSysData(hi=1.1, lo=0.9)
+        modifier = NormSysModifier(
+            name="lumi", parameter="alpha_lumi", data=data, constraint="Gauss"
+        )
+        context = Context({"alpha_lumi": pt.constant(40.0, dtype="float64")})
+        sample_data = SampleData(contents=[10.0, 20.0], errors=[1.0, 2.0])
+
+        prob = float(modifier.make_constraint(context, sample_data).eval())
+        assert prob == 0.0  # probability-space underflow
+
+        log_prob = float(modifier.log_constraint(context, sample_data).eval())
+        assert math.isfinite(log_prob)
+        assert log_prob == pytest.approx(float(scipy_norm.logpdf(40.0)), rel=1e-10)

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -563,3 +563,124 @@ class TestLogExpressionUsesAnalyticLogLikelihood:
         log_expr_val = float(pytensor.function([x_var], log_expr_result)([130.0])[0])
         expr_val = float(pytensor.function([x_var], expr_result)([130.0])[0])
         assert log_expr_val == pytest.approx(math.log(expr_val), rel=1e-10)
+
+
+# --------------------------------------------------------------------------
+# Layer 2 of #243: modifier.log_constraint() and the HistFactoryDistChannel /
+# Model log-space constraint assembly built on top of it, so neither
+# HistFactoryDistChannel.log_extended_likelihood nor Model.log_prob ever
+# takes pt.log() of a probability-space constraint that can underflow to 0.0.
+# --------------------------------------------------------------------------
+
+
+def _normsys_workspace(alpha_value: float) -> Workspace:
+    """Single-channel, single-bin HFDC workspace with one normsys (Gaussian)
+    constraint on ``alpha_lumi``, observed data equal to the nominal yield.
+    """
+    obs_name = "x_SR"
+    channel = HistFactoryDistChannel(
+        name="SR",
+        axes=[{"name": obs_name, "min": 0.0, "max": 10.0, "nbins": 1}],
+        samples=[
+            {
+                "name": "signal",
+                "data": {"contents": [10.0], "errors": [1.0]},
+                "modifiers": [
+                    {
+                        "name": "lumi",
+                        "type": "normsys",
+                        "parameter": "alpha_lumi",
+                        "constraint": "Gauss",
+                        "data": {"hi": 1.1, "lo": 0.9},
+                    }
+                ],
+            }
+        ],
+    )
+    binned = BinnedData(
+        name="SR_data",
+        axes=[{"name": obs_name, "min": 0.0, "max": 10.0, "nbins": 1}],
+        contents=[10.0],
+    )
+    return Workspace(
+        metadata=Metadata(hs3_version="0.3.0"),
+        distributions=Distributions([channel]),
+        data=Data([binned]),
+        likelihoods=Likelihoods(
+            [Likelihood(name="L", distributions=[channel], data=[binned])]
+        ),
+        domains=Domains([ProductDomain(name="default")]),
+        parameter_points=ParameterPoints(
+            [
+                ParameterSet(
+                    name="default",
+                    parameters=[{"name": "alpha_lumi", "value": alpha_value}],
+                )
+            ]
+        ),
+    )
+
+
+def test_log_prob_finite_for_normsys_constraint_at_alpha_40():
+    """model.log_prob stays finite when the normsys nuisance is pushed to
+    |alpha|=40, where the probability-space Gaussian constraint underflows to
+    0.0 (exp(-40**2/2) < 2.2e-308).  See issue #243.
+    """
+    ws = _normsys_workspace(alpha_value=40.0)
+    model = ws.model(next(iter(ws.likelihoods)), progress=False)
+
+    # The probability-space constraint underflows to 0.0 at |alpha|=40.
+    dist = next(iter(ws.distributions))
+    _, modifier, sample_data = next(dist.constraint_specs())
+    prob_constraint = float(
+        np.asarray(
+            modifier.make_constraint(
+                Context({"alpha_lumi": pt.constant(40.0, dtype="float64")}),
+                sample_data,
+            ).eval()
+        )
+    )
+    assert prob_constraint == 0.0
+
+    lp = model.log_prob
+    inputs = {
+        v.name: v
+        for v in pytensor.graph.traversal.explicit_graph_inputs([lp])
+        if v.name
+    }
+    fn = pytensor.function(list(inputs.values()), lp)
+    val = float(np.asarray(fn(**model.data, **model.nominal_params)).item())
+    assert math.isfinite(val)
+
+    # code4 interpolation for alpha >= alpha0=1: factor = hi**alpha (nominal
+    # factor is 1.0), so expected_rate = contents * hi**alpha.
+    expected_rate = 10.0 * (1.1**40.0)
+    expected = float(
+        _poisson_logpmf(np.array([10.0]), np.array([expected_rate])).sum()
+        + _norm_logpdf(np.array([40.0]), np.array([0.0]), np.array([1.0])).sum()
+    )
+    assert val == pytest.approx(expected, rel=1e-8)
+
+
+def test_logpdf_finite_for_normsys_constraint_at_alpha_40():
+    """logpdf() for a single HFDC channel with a normsys constraint at
+    |alpha|=40 stays finite and matches the analytic sum of the Poisson
+    log-pmf term and scipy.stats.norm.logpdf(alpha) for the constraint. See
+    issue #243.
+    """
+    ws = _normsys_workspace(alpha_value=40.0)
+    model = ws.model(next(iter(ws.likelihoods)), progress=False)
+
+    logpdf_val = float(
+        np.asarray(
+            model.logpdf_unsafe("SR", alpha_lumi=40.0, SR_observed=np.array([10.0]))
+        )
+    )
+    assert math.isfinite(logpdf_val)
+
+    expected_rate = 10.0 * (1.1**40.0)
+    expected = float(
+        _poisson_logpmf(np.array([10.0]), np.array([expected_rate])).sum()
+        + _norm_logpdf(np.array([40.0]), np.array([0.0]), np.array([1.0])).sum()
+    )
+    assert logpdf_val == pytest.approx(expected, rel=1e-8)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Layer 2 of #243: no site computes `pt.log(<probability-space constraint>)` anymore. `HasConstraint` (and the channel-level BB-lite helper) now expose a `log_constraint` counterpart to `make_constraint`, built from the *same* constraint distribution object(s) via their analytic `log_likelihood`/`log_expression` (from #261) instead of round-tripping through a probability value.

- **`src/pyhs3/distributions/histfactory/modifiers.py`**: `HasConstraint.log_constraint()` is now abstract alongside `make_constraint()`. Each modifier factors its distribution construction into a shared private helper consumed by both:
  - `SingleParamConstraint` (`NormSys`/`HistoSys`): `_build_constraint()` builds the single Gauss/Poisson/LogNormal distribution once; `make_constraint`/`log_constraint` call `expression()`/`log_expression()` on it.
  - `ShapeSysModifier`: `_build_bin_constraints()` builds the per-bin Poisson distributions once; `make_constraint` takes their product, `log_constraint` sums their log-probabilities.
  - `StatErrorModifier` (BB-full): same per-bin sharing, for whichever of Gauss/Poisson the modifier is configured with.
- **`src/pyhs3/distributions/histfactory/__init__.py`**: the channel-level BB-lite constraint gets the same treatment — `_build_barlow_beeston_lite_dists()` is shared by `_make_barlow_beeston_lite_constraint()` and the new `_make_barlow_beeston_lite_log_constraint()`. `HistFactoryDistChannel.log_extended_likelihood` now sums `modifier.log_constraint(...)` and the BB-lite log constraint directly, never `pt.log(make_constraint(...))`.
- **`src/pyhs3/model.py`**: `Model._build_distribution_node`'s single pass over constraint specs now calls `modifier.log_constraint(...)` alongside `modifier.make_constraint(...)` (and the BB-lite log helper alongside the prob one), building each constraint's log-space subgraph exactly once per spec. A new `self._hfdc_log_constraints` cache mirrors `self._hfdc_constraints` with the same cross-channel dedup semantics; `Model.log_prob` extends its terms with `self._hfdc_log_constraints` directly instead of `pt.log(self._hfdc_constraints)`, and the per-channel `log_distributions` entry is assembled from `channel_log_constraints` instead of `pt.log(channel_constraints)`.

No normalization-quadrature complication was found in the constraint path: `SingleParamConstraint`/`ShapeSysModifier`/`StatErrorModifier`/BB-lite all build a fresh `Context` from a plain dict (losing the outer `observables` dict), so `Distribution._apply_normalization` never applies to these constraint distributions and `log_expression() == log_likelihood()` exactly for all of them — `log_constraint` is a clean analytic mirror of `make_constraint` everywhere.

Fixes #243
Refs #254 (phase 2)

## Acceptance evidence

For a single-bin HFDC channel with one `normsys` (Gaussian) constraint, pushed to `alpha_lumi = 40.0` (probability-space Gaussian constraint underflows to exactly `0.0` — `exp(-40**2/2) < 2.2e-308`):

- `model.log_prob` (compiled): **finite**, `-1207.4659839363708`
- `logpdf("SR", alpha_lumi=40.0, ...)`: **finite**, `-1207.4659839363708`
- Analytic reference (Poisson log-pmf + `scipy.stats.norm.logpdf(40.0)`): `-1207.4659839363708` (Poisson term `-406.5470454031661` + Gaussian term `-800.9189385332047`)
- Both match to `rel=1e-8` in the added regression tests.

For the bare `normsys` modifier constraint at `alpha_lumi = 40.0`:
- `make_constraint(...)` → `0.0` (probability-space underflow)
- `log_constraint(...)` → `-800.9189385332047`, matching `scipy.stats.norm.logpdf(40.0)` to `rel=1e-10`

Parity (`log_constraint == log(make_constraint)`, `rtol` 1e-8 to 1e-10) verified at ordinary parameter values for every constraint-bearing modifier: `NormSysModifier`/`HistoSysModifier` (Gauss/Poisson/LogNormal), `ShapeSysModifier`, `StatErrorModifier` (Gauss/Poisson, including the zero-yield-bin skip and empty-parameters edge cases), and the channel-level BB-lite constraint (Gauss/Poisson).

## Test plan

- [x] New tests added first (TDD): `tests/test_histfactory_modifiers.py::TestLogConstraintParity`/`TestLogConstraintUnderflow`, `tests/test_hfdc_model_constraints.py::TestBBLiteStaterrorModelBuild::test_bblite_log_constraint_matches_log_of_constraint` and `TestHFDCSubgraphBuildCounts::test_log_constraint_called_once_per_spec`, `tests/test_log_space_likelihood.py::test_log_prob_finite_for_normsys_constraint_at_alpha_40`/`test_logpdf_finite_for_normsys_constraint_at_alpha_40`
- [x] Full quick suite green: `pixi run --environment py312 test` (1100 passed, 3 skipped, 1 xfailed)
- [x] Coverage 100% lines+branches on all touched files (`modifiers.py`, `distributions/histfactory/__init__.py`; `model.py`'s only miss is the pre-existing, unrelated `--runpydot`-gated graph-visualization method)
- [x] `pre-commit run --files <touched files>` clean
- [x] Slow real-world suite: `pixi run --environment py312 test-slow tests/test_realworld.py` (5 passed, 1 xfailed, ~2m9s)
- [x] No existing tolerance loosened

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved likelihood calculations to stay finite when constraint probabilities become extremely small.
  * Fixed constraint handling so log-space results now match probability-space results across several modifier types.
  * Added safeguards for zero-yield bins and empty constraint cases.

* **Tests**
  * Added regression coverage for log-space constraint consistency and underflow behavior.
  * Expanded checks for HistFactory model constraint construction and log-likelihood calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->