### PR TITLE
feat: analytic log-space likelihood for Exponential, Uniform, and Landau

### DIFF
--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -141,6 +141,23 @@ class UniformDist(Distribution):
         # The variables in self.x define the domain but don't change the constant density
         return cast(TensorVar, pt.constant(1.0))
 
+    def log_likelihood(self, _context: Context) -> TensorVar:
+        """
+        Builds a symbolic expression for the uniform log-PDF.
+
+        Analytic log form of :meth:`likelihood`: ``log(1.0) == 0.0``, a
+        constant independent of any parameter, so there is no underflow
+        concern to guard against here.
+
+        Args:
+            _context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Constant value (0.0) representing
+            the uniform log-density.
+        """
+        return cast(TensorVar, pt.constant(0.0))
+
 
 class PoissonDist(Distribution):
     r"""
@@ -266,6 +283,32 @@ class ExponentialDist(Distribution):
 
         # Exponential PDF: exp(-c * x)
         return cast(TensorVar, (c) * pt.exp(-c * x))
+
+    def log_likelihood(self, context: Context) -> TensorVar:
+        r"""
+        Builds a symbolic expression for the exponential log-PDF.
+
+        Analytic log form of :meth:`likelihood`:
+
+        .. math::
+
+            \log f(x; c) = \log c - c x
+
+        Evaluating this directly (rather than ``pt.log(self.likelihood(...))``)
+        avoids computing :math:`\exp(-cx)` and re-logging it, which underflows
+        to 0.0 (and then to ``-inf``) once :math:`cx` exceeds roughly 745 in
+        float64.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of exponential log-PDF.
+        """
+        x = context[self._parameters["x"]]
+        c = context[self._parameters["c"]]
+
+        return cast(TensorVar, pt.log(c) - c * x)
 
 
 class LogNormalDist(Distribution):
@@ -432,6 +475,59 @@ class LandauDist(Distribution):
         return cast(
             TensorVar,
             (1.0 / normalization) * (1.0 / sigma) * gaussian_core * asymmetric_factor,
+        )
+
+    def log_likelihood(self, context: Context) -> TensorVar:
+        r"""
+        Builds a symbolic expression for the Landau approximation log-PDF.
+
+        Analytic log form of :meth:`likelihood`. The raw density there is a
+        product of two exponentials and a constant normalization factor
+        (``gaussian_core * asymmetric_factor / (sigma * normalization)``), so
+        its log is a plain sum -- no product term can partially cancel another:
+
+        .. math::
+
+            \log f(x; \mu, \sigma) = -\log\sigma - \frac{1}{2}z^2
+            - \frac{1}{10}\max(0, z-1)^2 - \log(\mathcal{N}),
+            \quad z = \frac{x-\mu}{\sigma}
+
+        where :math:`\mathcal{N}` is the same constant (parameter-independent)
+        normalization computed in :meth:`likelihood`. Evaluating this directly
+        avoids computing the two exponentials and re-logging their product,
+        which underflows to 0.0 (and then to ``-inf``) for large :math:`|z|`.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the Landau
+            approximation log-PDF.
+        """
+        x = context[self._parameters["x"]]
+        mean = context[self._parameters["mean"]]
+        sigma = context[self._parameters["sigma"]]
+
+        # Normalized variable
+        z = (x - mean) / sigma
+
+        # Log of the same Gaussian-core / asymmetric-tail approximation used in likelihood()
+        gaussian_log_term = -0.5 * z**2
+        asymmetric_log_term = -0.1 * pt.maximum(0.0, z - 1) ** 2
+        gaussian_term_integral = pt.sqrt(math.pi / 2) * (1 + pt.erf(1 / pt.sqrt(2.0)))
+        asymmetric_factor_integral = (
+            pt.exp(-1 / 12)
+            * (pt.sqrt(5 * math.pi / 3) / 2)
+            * pt.erfc((5 / 6) * pt.sqrt(3 / 5))
+        )
+        normalization = gaussian_term_integral + asymmetric_factor_integral
+
+        return cast(
+            TensorVar,
+            -pt.log(sigma)
+            - pt.log(normalization)
+            + gaussian_log_term
+            + asymmetric_log_term,
         )
 
 

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -18,7 +18,7 @@ These tests assert that:
 from __future__ import annotations
 
 import math
-from typing import cast
+from typing import Literal, cast
 
 import numpy as np
 import pytensor
@@ -32,9 +32,12 @@ from pyhs3.distributions import Distributions, HistFactoryDistChannel
 from pyhs3.distributions.basic import (
     ExponentialDist,
     GaussianDist,
+    LandauDist,
     LogNormalDist,
     PoissonDist,
+    UniformDist,
 )
+from pyhs3.distributions.core import Distribution
 from pyhs3.domains import Domains, ProductDomain
 from pyhs3.likelihoods import Likelihood, Likelihoods
 from pyhs3.metadata import Metadata
@@ -45,6 +48,7 @@ from pyhs3.workspace import Workspace
 # scipy.stats is preferred for analytic references; fall back to closed forms
 # built from stdlib math if scipy is unavailable in the test environment.
 try:
+    from scipy.stats import expon as _scipy_expon
     from scipy.stats import lognorm as _scipy_lognorm
     from scipy.stats import norm as _scipy_norm
     from scipy.stats import poisson as _scipy_poisson
@@ -62,6 +66,11 @@ try:
             _scipy_lognorm.logpdf(x, s=sigma, scale=np.exp(mu)), dtype=np.float64
         )
 
+    def _expon_logpdf(x: np.ndarray, c: np.ndarray) -> np.ndarray:
+        # ExponentialDist's rate parametrization (pdf = c * exp(-c*x)) maps onto
+        # scipy's loc/scale form as scale = 1/c.
+        return np.asarray(_scipy_expon.logpdf(x, scale=1.0 / c), dtype=np.float64)
+
 except ModuleNotFoundError:  # pragma: no cover - scipy is in the dev deps
 
     def _poisson_logpmf(counts: np.ndarray, rates: np.ndarray) -> np.ndarray:
@@ -76,6 +85,9 @@ except ModuleNotFoundError:  # pragma: no cover - scipy is in the dev deps
     def _lognorm_logpdf(x: np.ndarray, mu: np.ndarray, sigma: np.ndarray) -> np.ndarray:
         z = (np.log(x) - mu) / sigma
         return -np.log(x) - np.log(sigma) - 0.5 * math.log(2.0 * math.pi) - 0.5 * z**2
+
+    def _expon_logpdf(x: np.ndarray, c: np.ndarray) -> np.ndarray:
+        return np.log(c) - c * x
 
 
 def _underflow_workspace() -> tuple[Workspace, np.ndarray]:
@@ -504,6 +516,25 @@ class TestLogNormalLogLikelihood:
         assert log_val == pytest.approx(expected, rel=1e-10)
 
 
+class _NoLogOverrideDist(Distribution):
+    """Minimal Distribution subclass with no ``log_likelihood`` override.
+
+    As of Phase 3 of #254, every basic.py distribution has an analytic
+    ``log_likelihood`` override, so none of them exercise the base class's
+    ``pt.log(likelihood())`` default directly anymore. This standalone class
+    keeps that fallback path covered.
+    """
+
+    type: Literal["_no_log_override_dist"] = "_no_log_override_dist"
+    x: str | float | int
+    c: str | float | int
+
+    def likelihood(self, context: Context) -> TensorVar:
+        x = context[self._parameters["x"]]
+        c = context[self._parameters["c"]]
+        return cast(TensorVar, c * pt.exp(-c * x))
+
+
 class TestBaseDistributionLogLikelihoodDefault:
     """A distribution with no analytic override falls back to pt.log(likelihood())."""
 
@@ -514,13 +545,109 @@ class TestBaseDistributionLogLikelihoodDefault:
             pytest.param(3.0, 2.0, id="larger_rate"),
         ],
     )
-    def test_exponential_dist_default_log_likelihood(self, x, c):
-        """ExponentialDist has no log_likelihood override, so it uses the base default."""
-        dist = ExponentialDist(name="e", x="x", c="c")
+    def test_default_log_likelihood_matches_log_of_likelihood(self, x, c):
+        """With no log_likelihood override, log_likelihood() falls back to log(likelihood())."""
+        dist = _NoLogOverrideDist(name="e", x="x", c="c")
         context = Context({"x": _c(x), "c": _c(c)})
         log_val = float(pytensor.function([], dist.log_likelihood(context))())
         prob_val = float(pytensor.function([], dist.likelihood(context))())
         assert log_val == pytest.approx(np.log(prob_val), rel=1e-12)
+
+
+class TestExponentialLogLikelihood:
+    """ExponentialDist.log_likelihood is the analytic log form of likelihood()."""
+
+    @pytest.mark.parametrize(
+        ("x", "c"),
+        [
+            pytest.param(1.0, 0.5, id="ordinary_point"),
+            pytest.param(3.0, 2.0, id="larger_rate"),
+            pytest.param(0.0, 1.0, id="at_origin"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, x, c):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = ExponentialDist(name="e", x="x", c="c")
+        context = Context({"x": _c(x), "c": _c(c)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("x", "c"),
+        [
+            pytest.param(1.0, 0.5, id="ordinary_point"),
+            pytest.param(3.0, 2.0, id="larger_rate"),
+        ],
+    )
+    def test_matches_scipy_expon_logpdf(self, x, c):
+        """likelihood() is scipy's expon pdf with scale=1/c, matching exactly."""
+        dist = ExponentialDist(name="e", x="x", c="c")
+        context = Context({"x": _c(x), "c": _c(c)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        expected = float(_expon_logpdf(np.array(x), np.array(c)))
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+    def test_finite_deep_in_tail_while_likelihood_underflows(self):
+        """c*x = 800: likelihood underflows to 0.0, log_likelihood stays finite (~-800)."""
+        dist = ExponentialDist(name="e", x="x", c="c")
+        context = Context({"x": _c(800.0), "c": _c(1.0)})
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
+        assert log_val == pytest.approx(-800.0, rel=1e-10)
+
+
+class TestUniformLogLikelihood:
+    """UniformDist.log_likelihood is the analytic log form of likelihood()."""
+
+    def test_matches_log_of_likelihood(self):
+        """log_likelihood equals log(likelihood): both are parameter-independent constants."""
+        dist = UniformDist(name="u", x=["x"])
+        context = Context({"x": _c(1.23)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+        assert log_val == pytest.approx(0.0, abs=1e-12)
+
+
+class TestLandauLogLikelihood:
+    """LandauDist.log_likelihood is the analytic log form of likelihood().
+
+    The raw density is a product of two exponentials divided by a constant
+    normalization, so its log is a plain sum -- no product/sum term can
+    partially cancel another, unlike e.g. a piecewise density built from a
+    difference of two comparable-magnitude terms.
+    """
+
+    @pytest.mark.parametrize(
+        ("x", "mean", "sigma"),
+        [
+            pytest.param(0.0, 0.0, 1.0, id="at_mode"),
+            pytest.param(2.0, 0.0, 1.0, id="right_tail"),
+            pytest.param(-1.5, 0.0, 1.0, id="left_of_mode"),
+            pytest.param(130.0, 125.0, 10.0, id="hep_scale"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, x, mean, sigma):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = LandauDist(name="landau", x="x", mean="mean", sigma="sigma")
+        context = Context({"x": _c(x), "mean": _c(mean), "sigma": _c(sigma)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-10)
+
+    def test_finite_deep_in_tail_while_likelihood_underflows(self):
+        """z = (x-mean)/sigma = 100 deep in the tail: likelihood underflows, log_likelihood stays finite."""
+        dist = LandauDist(name="landau", x="x", mean="mean", sigma="sigma")
+        context = Context({"x": _c(100.0), "mean": _c(0.0), "sigma": _c(1.0)})
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
 
 
 class TestLogExpressionUsesAnalyticLogLikelihood:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Phase 3 of #254 (per-family conversion, item 1): converts the remaining `src/pyhs3/distributions/basic.py` distributions (`ExponentialDist`, `UniformDist`, `LandauDist`) to an analytic `log_likelihood()`, matching the pattern set by `GaussianDist`/`PoissonDist`/`LogNormalDist` in #261.

All three raw densities are closed-form products of exponentials and constants, so the log form is a plain sum with no risk of the kind of term-cancellation that would make an analytic log dishonest:

- **ExponentialDist**: `likelihood = c * exp(-c*x)` → `log_likelihood = log(c) - c*x`. Avoids re-logging `exp(-c*x)`, which underflows to 0.0 once `c*x` exceeds ~745 in float64.
- **UniformDist**: `likelihood = 1.0` (constant) → `log_likelihood = 0.0`. No underflow concern; included for completeness/consistency with the log-first contract.
- **LandauDist**: `likelihood = (1/normalization) * (1/sigma) * gaussian_core * asymmetric_factor` → `log_likelihood = -log(sigma) - log(normalization) - 0.5*z² - 0.1*max(0,z-1)²`. `normalization` is itself parameter-independent (a fixed constant built from `erf`/`erfc`), so `log(normalization)` carries no numerical risk; the product of the two exponential factors converts cleanly to a sum. No drop-down needed here — unlike e.g. `PolynomialDist`, this density has no sign-indeterminate or difference-of-comparable-magnitude terms.

## Test plan

- [x] `tests/test_log_space_likelihood.py`: added `TestExponentialLogLikelihood`, `TestUniformLogLikelihood`, `TestLandauLogLikelihood` following the existing `TestGaussianLogLikelihood`/`TestPoissonLogLikelihood` style — parity (`log_likelihood == log(likelihood)`, `rtol=1e-12`/`1e-10`), a `scipy.stats.expon` reference test for Exponential (rate parametrization mapped as `scale=1/c`), and tail-stability tests where the probability-space likelihood underflows to `0.0` but the log form stays finite.
- [x] Replaced the Exponential-specific base-class-fallback test with a standalone dummy `Distribution` subclass (`_NoLogOverrideDist`), since Exponential no longer exercises that fallback path (it now has an analytic override) but the fallback itself still needs coverage.
- [x] RED confirmed: stashed the `basic.py` changes and ran the new tests — the two tail-stability tests failed (`log_likelihood` was `-inf` under the base `pt.log(likelihood)` default) while the parity tests trivially passed, as expected.
- [x] Full quick suite green: `pixi run --environment py312 test` → 1095 passed, 3 skipped, 9 deselected, 1 xfailed.
- [x] `src/pyhs3/distributions/basic.py` at 100% line+branch coverage (`pixi run --environment py312 pytest -m 'not slow and not pydot' --cov=pyhs3 --cov-branch`).
- [x] `pre-commit run --files src/pyhs3/distributions/basic.py tests/test_log_space_likelihood.py` clean.

Refs #254 (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)