### PR TITLE
feat: analytic log-space likelihood for CMS background distributions

### DIFF
--- a/src/pyhs3/distributions/cms.py
+++ b/src/pyhs3/distributions/cms.py
@@ -35,6 +35,12 @@ class FastVerticalInterpHistPdf2Dist(Distribution):
     Note:
         This is a simplified implementation. The actual CMS implementation uses
         sophisticated interpolation algorithms and caching for performance.
+        Because the morphing here is a placeholder rather than the real
+        interpolation algorithm, there is no analytic log form to derive yet:
+        this class uses the probability-space :meth:`likelihood` as primary
+        and inherits the base class's ``pt.log(likelihood())`` fallback for
+        :meth:`~pyhs3.distributions.core.Distribution.log_likelihood`, pending
+        a real morphing implementation.
     """
 
     type: Literal["CMS::fastverticalinterphistpdf2"] = "CMS::fastverticalinterphistpdf2"
@@ -117,6 +123,36 @@ class GGZZBackgroundDist(Distribution):
 
         return cast(TensorVar, a1 * power_term * exp_term)
 
+    def log_likelihood(self, context: Context) -> TensorVar:
+        r"""
+        Builds a symbolic expression for the ggZZ background log-PDF.
+
+        Analytic log form of :meth:`likelihood`, which is a pure product of a
+        power law and an exponential decay (no summed terms), so the log is a
+        clean sum:
+
+        .. math::
+
+            \log f(m_{4\ell}; a_1, a_2, a_3) = \log a_1 + a_2 \log m_{4\ell} - a_3 m_{4\ell}
+
+        Evaluating this directly (rather than ``pt.log(self.likelihood(...))``)
+        avoids computing :math:`\exp(-a_3 m_{4\ell})` and re-logging it, which
+        underflows to 0.0 (and then to ``-inf``) once :math:`a_3 m_{4\ell}`
+        exceeds roughly 745 in float64.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the ggZZ background log-PDF.
+        """
+        m4l = context[self._parameters["m4l"]]
+        a1 = context[self._parameters["a1"]]
+        a2 = context[self._parameters["a2"]]
+        a3 = context[self._parameters["a3"]]
+
+        return cast(TensorVar, pt.log(a1) + a2 * pt.log(m4l) - a3 * m4l)
+
 
 class QQZZBackgroundDist(Distribution):
     r"""
@@ -170,6 +206,38 @@ class QQZZBackgroundDist(Distribution):
 
         return cast(TensorVar, a1 * power_term * exp_term)
 
+    def log_likelihood(self, context: Context) -> TensorVar:
+        r"""
+        Builds a symbolic expression for the qqZZ background log-PDF.
+
+        Analytic log form of :meth:`likelihood`, which is a pure product of a
+        power law and an exponential decay (no summed terms), so the log is a
+        clean sum:
+
+        .. math::
+
+            \log f(m_{4\ell}; a_1, a_2, a_3, a_4) = \log a_1 + a_3 \log(m_{4\ell} + a_2) - a_4 m_{4\ell}
+
+        Evaluating this directly (rather than ``pt.log(self.likelihood(...))``)
+        avoids computing :math:`\exp(-a_4 m_{4\ell})` and re-logging it, which
+        underflows to 0.0 (and then to ``-inf``) once :math:`a_4 m_{4\ell}`
+        exceeds roughly 745 in float64.
+
+        Args:
+            context (dict): Mapping of names to pytensor variables.
+
+        Returns:
+            pytensor.tensor.variable.TensorVariable: Symbolic representation of the qqZZ background log-PDF.
+        """
+        m4l = context[self._parameters["m4l"]]
+        a1 = context[self._parameters["a1"]]
+        a2 = context[self._parameters["a2"]]
+        a3 = context[self._parameters["a3"]]
+        a4 = context[self._parameters["a4"]]
+
+        shifted_mass = m4l + a2
+        return cast(TensorVar, pt.log(a1) + a3 * pt.log(shifted_mass) - a4 * m4l)
+
 
 class FastVerticalInterpHistPdf2D2Dist(Distribution):
     r"""
@@ -186,6 +254,12 @@ class FastVerticalInterpHistPdf2D2Dist(Distribution):
 
     Note:
         This is a simplified implementation for 2D histogram morphing.
+        Because the morphing here is a placeholder rather than the real
+        interpolation algorithm, there is no analytic log form to derive yet:
+        this class uses the probability-space :meth:`likelihood` as primary
+        and inherits the base class's ``pt.log(likelihood())`` fallback for
+        :meth:`~pyhs3.distributions.core.Distribution.log_likelihood`, pending
+        a real morphing implementation.
     """
 
     type: Literal["CMS::FastVerticalInterpHistPdf2D2"] = (

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -37,6 +37,12 @@ from pyhs3.distributions.basic import (
     PoissonDist,
     UniformDist,
 )
+from pyhs3.distributions.cms import (
+    FastVerticalInterpHistPdf2D2Dist,
+    FastVerticalInterpHistPdf2Dist,
+    GGZZBackgroundDist,
+    QQZZBackgroundDist,
+)
 from pyhs3.distributions.core import Distribution
 from pyhs3.distributions.mathematical import (
     BernsteinPolyDist,
@@ -949,3 +955,130 @@ class TestBernsteinPolyDistLogLikelihood:
 
         assert prob_val < 0.0
         assert math.isnan(log_val)
+
+
+# --------------------------------------------------------------------------
+# Phase 3.5 of #254: analytic log_likelihood() on the CMS ggZZ/qqZZ background
+# distributions (products of a power-law and an exponential decay, so the log
+# is a clean sum). The CMS FastVerticalInterp placeholders stay on the base
+# pt.log(likelihood()) fallback (see class docstrings for why).
+# --------------------------------------------------------------------------
+
+
+class TestGGZZBackgroundLogLikelihood:
+    """GGZZBackgroundDist.log_likelihood is the analytic log form of likelihood().
+
+    likelihood() = a1 * m4l**a2 * exp(-a3 * m4l), so the analytic log is
+    log(a1) + a2 * log(m4l) - a3 * m4l.
+    """
+
+    @pytest.mark.parametrize(
+        ("a1", "a2", "a3", "m4l"),
+        [
+            pytest.param(1.0, 2.0, 0.05, 200.0, id="typical"),
+            pytest.param(0.5, 1.5, 0.02, 150.0, id="smaller_norm"),
+            pytest.param(2.0, -1.0, 0.03, 300.0, id="negative_power"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, a1, a2, a3, m4l):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = GGZZBackgroundDist(name="ggzz", m4l="m4l", a1="a1", a2="a2", a3="a3")
+        context = Context({"m4l": _c(m4l), "a1": _c(a1), "a2": _c(a2), "a3": _c(a3)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    def test_finite_at_large_mass_while_likelihood_underflows(self):
+        """a3 * m4l = 800: exp(-800) underflows likelihood to 0.0, log stays finite."""
+        a1, a2, a3, m4l = 1.0, 2.0, 1.0, 800.0
+        dist = GGZZBackgroundDist(name="ggzz", m4l="m4l", a1="a1", a2="a2", a3="a3")
+        context = Context({"m4l": _c(m4l), "a1": _c(a1), "a2": _c(a2), "a3": _c(a3)})
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
+        expected = math.log(a1) + a2 * math.log(m4l) - a3 * m4l
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+
+class TestQQZZBackgroundLogLikelihood:
+    """QQZZBackgroundDist.log_likelihood is the analytic log form of likelihood().
+
+    likelihood() = a1 * (m4l + a2)**a3 * exp(-a4 * m4l), so the analytic log is
+    log(a1) + a3 * log(m4l + a2) - a4 * m4l.
+    """
+
+    @pytest.mark.parametrize(
+        ("a1", "a2", "a3", "a4", "m4l"),
+        [
+            pytest.param(1.0, 10.0, 2.0, 0.05, 200.0, id="typical"),
+            pytest.param(0.3, 5.0, 1.2, 0.02, 150.0, id="smaller_norm"),
+            pytest.param(2.0, -50.0, 1.5, 0.03, 300.0, id="negative_shift"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, a1, a2, a3, a4, m4l):
+        """log_likelihood equals log(likelihood) at ordinary parameter points."""
+        dist = QQZZBackgroundDist(
+            name="qqzz", m4l="m4l", a1="a1", a2="a2", a3="a3", a4="a4"
+        )
+        context = Context(
+            {
+                "m4l": _c(m4l),
+                "a1": _c(a1),
+                "a2": _c(a2),
+                "a3": _c(a3),
+                "a4": _c(a4),
+            }
+        )
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    def test_finite_at_large_mass_while_likelihood_underflows(self):
+        """a4 * m4l = 800: exp(-800) underflows likelihood to 0.0, log stays finite."""
+        a1, a2, a3, a4, m4l = 1.0, 10.0, 2.0, 1.0, 800.0
+        dist = QQZZBackgroundDist(
+            name="qqzz", m4l="m4l", a1="a1", a2="a2", a3="a3", a4="a4"
+        )
+        context = Context(
+            {
+                "m4l": _c(m4l),
+                "a1": _c(a1),
+                "a2": _c(a2),
+                "a3": _c(a3),
+                "a4": _c(a4),
+            }
+        )
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val == 0.0
+        assert math.isfinite(log_val)
+        expected = math.log(a1) + a3 * math.log(m4l + a2) - a4 * m4l
+        assert log_val == pytest.approx(expected, rel=1e-10)
+
+
+class TestFastVerticalInterpPlaceholdersUseBaseDefault:
+    """The FastVerticalInterp morphs are simplified placeholders (per their
+    docstrings) with no analytic log form; both stay on the base
+    pt.log(likelihood()) fallback until a real morphing implementation lands.
+    """
+
+    def test_fastverticalinterphistpdf2_matches_base_default(self):
+        dist = FastVerticalInterpHistPdf2Dist(
+            name="fvh2", x="x", coefList=["coef0", "coef1"]
+        )
+        context = Context({"x": _c(1.0), "coef0": _c(0.2), "coef1": _c(-0.3)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        assert log_val == pytest.approx(np.log(prob_val), rel=1e-12)
+
+    def test_fastverticalinterphistpdf2d2_matches_base_default(self):
+        dist = FastVerticalInterpHistPdf2D2Dist(
+            name="fvh2d2", x="x", y="y", coefList=["coef0"]
+        )
+        context = Context({"x": _c(1.0), "y": _c(2.0), "coef0": _c(0.4)})
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        assert log_val == pytest.approx(np.log(prob_val), rel=1e-12)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Phase 3 (item 5) of the log-first roadmap (#254): `GGZZBackgroundDist` and `QQZZBackgroundDist` now implement analytic `log_likelihood()`, following the pattern established for `GaussianDist`/`PoissonDist`/`LogNormalDist` in #261.

- `GGZZBackgroundDist.likelihood()` is `a1 * m4l**a2 * exp(-a3 * m4l)` — a pure product of a power law and an exponential decay, so the log is a clean closed form: `log(a1) + a2*log(m4l) - a3*m4l`. No summed terms, so there's no drop-down concern here.
- `QQZZBackgroundDist.likelihood()` is `a1 * (m4l + a2)**a3 * exp(-a4 * m4l)`, log is `log(a1) + a3*log(m4l + a2) - a4*m4l`.
- Both new `log_likelihood()` implementations evaluate this directly instead of `pt.log(self.likelihood(...))`, avoiding underflow once `a3*m4l` (resp. `a4*m4l`) exceeds ~745 in float64 (`exp()` underflows to `0.0`, `log(0.0) = -inf`, even though the true log-density is finite).
- `FastVerticalInterpHistPdf2Dist` and `FastVerticalInterpHistPdf2D2Dist` are explicitly documented as simplified/placeholder morphing implementations with no analytic log form; they intentionally stay on the base `pt.log(likelihood())` fallback until a real morphing implementation lands. No behavior change for these two classes.

## Test plan

- [x] New tests in `tests/test_log_space_likelihood.py`: `TestGGZZBackgroundLogLikelihood`, `TestQQZZBackgroundLogLikelihood` (parity against `np.log(likelihood())` at several valid parameter points, plus an underflow stability test against a hand-derived numpy analytic reference), and `TestFastVerticalInterpPlaceholdersUseBaseDefault` (pins the inherited base-class fallback for the two placeholder classes).
- [x] Confirmed RED: the two underflow stability tests failed with `log_likelihood == -inf` before the analytic implementations were added.
- [x] `pixi run --environment py312 test`: 1093 passed, 3 skipped, 9 deselected, 1 xfailed.
- [x] Coverage on `src/pyhs3/distributions/cms.py`: 100% lines, 100% branches.
- [x] `pixi run --environment dev bash -c "pre-commit run --files src/pyhs3/distributions/cms.py tests/test_log_space_likelihood.py"`: clean.

Refs #254 (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved log-likelihood calculations for GGZZ and QQZZ background models, preserving finite results when probability-space calculations underflow.
* **Bug Fixes**
  * Corrected numerical stability for background likelihood evaluations at large mass values.
  * Clarified behavior for placeholder morphing distributions, which continue to use the standard likelihood-based fallback.
* **Tests**
  * Added regression coverage for analytic log-likelihood accuracy, underflow handling, and placeholder distribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->