### PR TITLE
docs: document mathematical distributions as probability-space primary

### DIFF
--- a/src/pyhs3/distributions/mathematical.py
+++ b/src/pyhs3/distributions/mathematical.py
@@ -53,6 +53,13 @@ class GenericDist(GenericExpressionMixin, Distribution):
         Create a complex mathematical function:
 
         >>> dist = GenericDist(name="complex", expression="sin(x) + log(abs(y) + 1)")
+
+    Log-space drop-down:
+        This distribution implements the probability-space :meth:`likelihood`
+        as its primary form and inherits the base class's logarithmic
+        fallback (``log_likelihood = pt.log(likelihood)``). The expression is
+        an arbitrary user-supplied string with no general analytic log form,
+        so there is no closed-form ``log_likelihood`` to author here.
     """
 
     type: Literal["generic_dist"] = Field(default="generic_dist", repr=False)
@@ -95,6 +102,16 @@ class PolynomialDist(Distribution):
 
     ROOT Reference:
         :root:`RooPolynomial`
+
+    Log-space drop-down:
+        This distribution implements the probability-space :meth:`likelihood`
+        as its primary form and inherits the base class's logarithmic
+        fallback (``log_likelihood = pt.log(likelihood)``). The raw
+        polynomial value is negative or zero over parts of its domain by
+        construction (there is no positivity constraint on the
+        coefficients), so its logarithm is undefined/NaN there regardless of
+        which form computes it — there is no analytic log-space rewrite that
+        avoids this.
     """
 
     type: Literal["polynomial_dist"] = "polynomial_dist"
@@ -145,6 +162,15 @@ class BernsteinPolyDist(Distribution):
 
     ROOT Reference:
         :root:`RooBernstein`
+
+    Log-space drop-down:
+        This distribution implements the probability-space :meth:`likelihood`
+        as its primary form and inherits the base class's logarithmic
+        fallback (``log_likelihood = pt.log(likelihood)``). The Bernstein
+        basis polynomials are individually non-negative on [0, 1], but the
+        coefficients ``c_i`` are unconstrained, so the weighted sum can be
+        negative or zero over parts of the domain — its logarithm is
+        undefined/NaN there regardless of which form computes it.
     """
 
     type: Literal["bernstein_poly_dist"] = "bernstein_poly_dist"

--- a/tests/test_log_space_likelihood.py
+++ b/tests/test_log_space_likelihood.py
@@ -38,6 +38,11 @@ from pyhs3.distributions.basic import (
     UniformDist,
 )
 from pyhs3.distributions.core import Distribution
+from pyhs3.distributions.mathematical import (
+    BernsteinPolyDist,
+    GenericDist,
+    PolynomialDist,
+)
 from pyhs3.domains import Domains, ProductDomain
 from pyhs3.likelihoods import Likelihood, Likelihoods
 from pyhs3.metadata import Metadata
@@ -811,3 +816,136 @@ def test_logpdf_finite_for_normsys_constraint_at_alpha_40():
         + _norm_logpdf(np.array([40.0]), np.array([0.0]), np.array([1.0])).sum()
     )
     assert logpdf_val == pytest.approx(expected, rel=1e-8)
+
+
+# --------------------------------------------------------------------------
+# Phase 3 of #254: GenericDist, PolynomialDist, and BernsteinPolyDist are
+# explicit drop-downs — they implement only likelihood() and inherit the base
+# class's log_likelihood = pt.log(likelihood). These tests characterize that
+# behavior (including the NaN consequence for signed polynomials) rather than
+# asserting an analytic log form, since none exists for these classes.
+# --------------------------------------------------------------------------
+
+
+class TestGenericDistLogLikelihood:
+    """GenericDist has no log_likelihood override: it uses the base default.
+
+    The expression is an arbitrary user-supplied string with no general
+    analytic log form, so the drop-down to pt.log(likelihood) is permanent
+    rather than a placeholder awaiting a Phase 3 conversion.
+    """
+
+    @pytest.mark.parametrize(
+        ("expression", "params"),
+        [
+            pytest.param("x**2 + 1", {"x": 2.0}, id="polynomial_positive"),
+            pytest.param(
+                "exp(-x**2/2)", {"x": 1.5}, id="gaussian_kernel_always_positive"
+            ),
+            pytest.param("sin(x) + 2", {"x": 0.7}, id="shifted_sine_always_positive"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, expression, params):
+        """log_likelihood equals log(likelihood) wherever the expression is positive.
+
+        sympy_to_pytensor keys its variable substitution off each PyTensor
+        variable's own ``.name`` (not the context dict key), so the constants
+        here must be named to match the free symbols in the expression.
+        """
+        dist = GenericDist(name="g", expression=expression)
+        context = Context(
+            {
+                name: cast(TensorVar, pt.constant(value, dtype="float64", name=name))
+                for name, value in params.items()
+            }
+        )
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+
+class TestPolynomialDistLogLikelihood:
+    """PolynomialDist has no log_likelihood override: it uses the base default.
+
+    Unlike Gaussian/Poisson/LogNormal, the raw polynomial value has no
+    positivity constraint on its coefficients, so there is no analytic log
+    form to author — the drop-down documented on the class is permanent.
+    """
+
+    @pytest.mark.parametrize(
+        ("x", "coeffs"),
+        [
+            pytest.param(0.0, (1.0, 2.0, 3.0), id="quadratic_at_zero"),
+            pytest.param(1.0, (1.0, 2.0, 3.0), id="quadratic_at_one"),
+            pytest.param(2.0, (5.0, 3.0), id="linear_positive_slope"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, x, coeffs):
+        """log_likelihood equals log(likelihood) where the polynomial is positive."""
+        coeff_names = [f"a{i}" for i in range(len(coeffs))]
+        dist = PolynomialDist(name="p", x="x", coefficients=coeff_names)
+        context = Context(
+            {"x": _c(x)}
+            | {name: _c(value) for name, value in zip(coeff_names, coeffs, strict=True)}
+        )
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    def test_negative_polynomial_gives_nan_log_likelihood(self):
+        """Documented drop-down consequence: a signed polynomial can go negative,
+        and pt.log() of a negative value is NaN by construction (not a bug to
+        fix — PolynomialDist places no positivity constraint on coefficients).
+        """
+        # 1 - 3x is negative for x > 1/3.
+        dist = PolynomialDist(name="p", x="x", coefficients=["a0", "a1"])
+        context = Context({"x": _c(1.0), "a0": _c(1.0), "a1": _c(-3.0)})
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val < 0.0
+        assert math.isnan(log_val)
+
+
+class TestBernsteinPolyDistLogLikelihood:
+    """BernsteinPolyDist has no log_likelihood override: it uses the base default.
+
+    The Bernstein basis polynomials are individually non-negative on [0, 1],
+    but the coefficients are unconstrained, so the weighted sum can still go
+    negative — there is no analytic log form to author here either.
+    """
+
+    @pytest.mark.parametrize(
+        ("x", "coeffs"),
+        [
+            pytest.param(0.5, (2.0,), id="degree_zero_constant"),
+            pytest.param(0.3, (1.0, 3.0), id="degree_one_linear"),
+            pytest.param(0.6, (1.0, 4.0, 2.0), id="degree_two_quadratic"),
+        ],
+    )
+    def test_matches_log_of_likelihood(self, x, coeffs):
+        """log_likelihood equals log(likelihood) where the basis sum is positive."""
+        coeff_names = [f"c{i}" for i in range(len(coeffs))]
+        dist = BernsteinPolyDist(name="b", x="x", coefficients=coeff_names)
+        context = Context(
+            {"x": _c(x)}
+            | {name: _c(value) for name, value in zip(coeff_names, coeffs, strict=True)}
+        )
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        np.testing.assert_allclose(log_val, np.log(prob_val), rtol=1e-12)
+
+    def test_negative_bernstein_sum_gives_nan_log_likelihood(self):
+        """Documented drop-down consequence: unconstrained coefficients can make
+        the weighted basis sum negative, and pt.log() of a negative value is
+        NaN by construction (not a bug to fix).
+        """
+        # B_0,1(0.9) = 0.1, B_1,1(0.9) = 0.9 -> -5*0.1 + 1*0.9 = 0.4 > 0 doesn't
+        # go negative; use a stronger negative weight on the dominant basis term.
+        dist = BernsteinPolyDist(name="b", x="x", coefficients=["c0", "c1"])
+        context = Context({"x": _c(0.9), "c0": _c(1.0), "c1": _c(-5.0)})
+        prob_val = float(pytensor.function([], dist.likelihood(context))())
+        log_val = float(pytensor.function([], dist.log_likelihood(context))())
+
+        assert prob_val < 0.0
+        assert math.isnan(log_val)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Phase 3 of #254 for the `mathematical.py` family: makes the drop-down status of `GenericDist`, `PolynomialDist`, and `BernsteinPolyDist` explicit and tested, without any behavioral changes.

- Adds a docstring paragraph to each class stating that it implements the probability-space `likelihood()` as primary and inherits the base `log_likelihood = pt.log(likelihood)` fallback, and *why*:
  - `PolynomialDist` / `BernsteinPolyDist`: coefficients are unconstrained, so the raw value can be zero or negative over parts of the domain — `log` is undefined/NaN there by construction, regardless of which form computes it.
  - `GenericDist`: evaluates an arbitrary user-supplied expression with no general analytic log form.
- Adds characterization tests in `tests/test_log_space_likelihood.py` (following the existing `TestGaussianLogLikelihood`-style classes) for all three: `log_likelihood == log(likelihood)` at valid points (parametrized, `rtol=1e-12`), plus a test for `PolynomialDist`/`BernsteinPolyDist` documenting that a negative raw value yields `NaN` for `log_likelihood` — this is the expected drop-down consequence, not a bug.
- Confirmed none of the three classes has a pre-existing `log_likelihood` override.

## Investigated but not implemented

Checked whether `GenericDist` could cheaply pass through a user-supplied log expression (e.g. `sp.log(self._sympy_expr)` via the existing sympy → PyTensor path). This is feasible for expressions where sympy can algebraically simplify the result (e.g. `exp(f(x))` cancelling to `f(x)`), but for a general arbitrary expression the log form is not analytically better than `pt.log(likelihood)` — no closed-form log density exists in general. Left as a possible narrow future optimization rather than implemented here.

## Test plan

- [x] `pixi run --environment py312 test` — 1094 passed, 3 skipped (JAX), 1 xfail (pre-existing, unrelated)
- [x] `pixi run --environment py312 pytest --cov=pyhs3 ...` — `mathematical.py` at 100% coverage
- [x] `pixi run --environment dev bash -c "pre-commit run --files src/pyhs3/distributions/mathematical.py tests/test_log_space_likelihood.py"` — clean

Refs #254 (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)