### PR TITLE
feat: log-sum-exp evaluation for MixtureDist log-probability

### DIFF
--- a/src/pyhs3/distributions/composite.py
+++ b/src/pyhs3/distributions/composite.py
@@ -55,6 +55,16 @@ class MixtureDist(Distribution):
 
         f(x) = \frac{\sum_{i=1}^{n} c_i \cdot f_i(x)}{\sum_{j \in \text{ref\_coef\_norm}} c_j}
 
+    :meth:`log_prob_terms` is the log-space-safe path for an extended mixture:
+    it builds log(Σcᵢfᵢ) via logsumexp over each summand's own log-space
+    expression rather than pt.log of the probability-space sum, so it stays
+    finite even when every component underflows to 0.0.  The base-class
+    :meth:`~pyhs3.distributions.core.Distribution.log_expression` (used for
+    non-extended mixtures and standalone evaluation) still round-trips
+    through probability-space component tensors and cannot be converted
+    until composite distributions receive log-space component context (see
+    https://github.com/scipp-atlas/pyhs3/issues/254, phase 4).
+
     Parameters:
         coefficients (list[str]): Names of coefficient parameters.
         summands (list[str]): Names of component distributions.
@@ -81,6 +91,13 @@ class MixtureDist(Distribution):
     # then has to merge (a measurable compile-time cost on large workspaces).
     _cached_unnorm_expr: TensorVar | None = PrivateAttr(default=None)
     _cached_nu_expr: TensorVar | None = PrivateAttr(default=None)
+
+    # Per-summand coefficient nodes (context[coeff] for each entry in
+    # self.coefficients, N==N case only), cached alongside _cached_unnorm_expr
+    # so that log_prob_terms can build the log-space logsumexp directly from
+    # the same coefficient tensors used in the probability-space sum, rather
+    # than re-resolving them from a context it is not given.
+    _cached_coeffs: list[TensorVar] | None = PrivateAttr(default=None)
 
     @model_serializer(mode="wrap")
     def serialize_model(self, handler: Callable[[Any], Any]) -> Any:
@@ -199,9 +216,12 @@ class MixtureDist(Distribution):
             # N coefficients case: direct summation with normalization
 
             # Calculate the mixture sum (unnormalized: Σ cᵢ fᵢ)
+            coeff_tensors = [context[coeff] for coeff in self.coefficients]
             mixture_terms = [
-                context[coeff] * context[self.summands[i]]
-                for i, coeff in enumerate(self.coefficients)
+                coeff_tensor * context[summand]
+                for coeff_tensor, summand in zip(
+                    coeff_tensors, self.summands, strict=True
+                )
             ]
             mixturesum = balanced_sum(mixture_terms, pt.constant(0.0))
 
@@ -210,6 +230,11 @@ class MixtureDist(Distribution):
             # introducing a separate pt.log(nu) node that triggers costly
             # optimizer rewrites when combined with log(Σcᵢfᵢ/nu).
             self._cached_unnorm_expr = mixturesum
+            # Cache the per-summand coefficient nodes (same order as
+            # self.summands) so log_prob_terms can build the log-space
+            # equivalent Σᵢ cᵢfᵢ = logsumexp(log cᵢ + log fᵢ) directly, which
+            # stays finite where the probability-space fᵢ underflow to 0.0.
+            self._cached_coeffs = coeff_tensors
 
             # Handle normalization
             if self.ref_coef_norm is not None:
@@ -289,17 +314,13 @@ class MixtureDist(Distribution):
         """Return the unnormalized mixture Σcᵢfᵢ (before dividing by Σcᵢ).
 
         After :meth:`likelihood` has been called this just returns the cached
-        intermediate result; it is used by :meth:`pyhs3.model.Model.log_prob`
-        to build the extended log-likelihood as
-
-            Σⱼ log(Σcᵢfᵢ(xⱼ)) - nu
-
-        which is algebraically equivalent to
-
-            Σⱼ log(Σcᵢfᵢ(xⱼ)/nu)  +  N·log(nu)  -  nu
-
-        but avoids introducing a separate ``pt.log(nu)`` node that can trigger
-        expensive rewrite cascades in the PyTensor graph optimiser.
+        intermediate result.  This is a probability-space quantity: for the
+        per-event log-likelihood, :meth:`log_prob_terms` builds
+        log(Σcᵢfᵢ(xⱼ)) directly from each summand's own log-space expression
+        via logsumexp instead of taking ``pt.log`` of this sum, so that the
+        result stays finite where the probability-space fᵢ(xⱼ) underflow to
+        0.0.  This method remains available for callers wanting the raw
+        probability-space value itself.
 
         The Poisson yield term enters the likelihood once per channel and
         involves the observed event count, so it is assembled by
@@ -330,15 +351,33 @@ class MixtureDist(Distribution):
         For an extended mixture the per-channel log-likelihood is built from
         the unnormalized mixture and the expected yield:
 
-            Σⱼ log(Σcᵢfᵢ(xⱼ))  -  nu
+            Σⱼ log(Σᵢcᵢfᵢ(xⱼ))  -  nu
 
-        which simplifies from Σⱼ log(Σcᵢfᵢ(xⱼ)/nu) + N·log(nu) - nu (the
+        which simplifies from Σⱼ log(Σᵢcᵢfᵢ(xⱼ)/nu) + N·log(nu) - nu (the
         log(nu) terms cancel).  This is algebraically identical to the full
         extended likelihood but avoids introducing pt.log(nu) into the graph,
         preventing costly optimizer rewrite cascades triggered by
         log(a/b) + N·log(b).  For weighted data this form also reproduces
-        RooFit's sum-of-weights convention: weighting the log(Σcᵢfᵢ) term
+        RooFit's sum-of-weights convention: weighting the log(Σᵢcᵢfᵢ) term
         gives Σⱼwⱼ·log(PDF) + (Σwⱼ)·log(nu) - nu.
+
+        log(Σᵢcᵢfᵢ(xⱼ)) is evaluated as logsumexp(log cᵢ + log fᵢ(xⱼ)) using
+        each summand's own log-space expression (``log_expressions``) rather
+        than ``pt.log`` of the probability-space sum
+        (:attr:`_cached_unnorm_expr`).  fᵢ(xⱼ) can underflow to 0.0 in
+        float64 for xⱼ far in a component's tail, which would make every
+        cᵢfᵢ(xⱼ) — and hence their sum — exactly 0.0 and ``pt.log`` of it
+        ``-inf``, even though log fᵢ(xⱼ) itself is finite.  Building the sum
+        in log space keeps it finite in that regime.  The log cᵢ + log fᵢ(xⱼ)
+        terms are stacked on a new leading axis (shape ``(n_summands, N, M)``
+        for ``N`` events and parameter-batch size ``M``, matching the
+        per-event shape documented on :class:`LogProbTerms`) and reduced with
+        ``pt.logsumexp`` over that axis, giving the ``(N, M)`` per-event term.
+        This assumes cᵢ ≥ 0, matching the probabilistic meaning of a mixture
+        weight; :class:`MixtureDist` does not validate coefficient sign, so a
+        negative cᵢ produces NaN here (``pt.log`` of a negative number) just
+        as ``pt.log(Σᵢcᵢfᵢ)`` would if the probability-space sum itself were
+        negative.
 
         The data-only -log(N!) constant is omitted and N_eff = Σwⱼ is used
         for weighted data; both are RooFit conventions adopted because HS3
@@ -351,7 +390,11 @@ class MixtureDist(Distribution):
         if not self.extended:
             return super().log_prob_terms(expressions, log_expressions, distributions)
 
-        if self._cached_unnorm_expr is None or self._cached_nu_expr is None:
+        if (
+            self._cached_unnorm_expr is None
+            or self._cached_nu_expr is None
+            or self._cached_coeffs is None
+        ):
             msg = (
                 f"log_prob_terms for extended mixture '{self.name}' requires "
                 f"likelihood() to have been called (the model graph build does "
@@ -359,8 +402,17 @@ class MixtureDist(Distribution):
             )
             raise RuntimeError(msg)
 
+        log_terms = [
+            pt.log(coeff) + log_expressions[summand]
+            for coeff, summand in zip(self._cached_coeffs, self.summands, strict=True)
+        ]
+        per_event_term = cast(
+            TensorVar,
+            pt.logsumexp(pt.stack(log_terms, axis=0), axis=0),  # type: ignore[no-untyped-call]
+        )
+
         return LogProbTerms(
-            per_event=[pt.log(self._cached_unnorm_expr)],
+            per_event=[per_event_term],
             channel=[-self._cached_nu_expr],
         )
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -15,6 +15,7 @@ import pytensor.tensor as pt
 import pytest
 from pydantic import ValidationError
 from pytensor import function
+from scipy.special import logsumexp
 
 from pyhs3 import Workspace
 from pyhs3.context import Context
@@ -175,6 +176,8 @@ class TestProductDist:
         }
         log_expressions = {
             "mix": pt.log(mix_expr),
+            "s1": -x,
+            "s2": -0.5 * x,
             "constr": -(alpha**2),
         }
         distributions = Distributions(
@@ -2968,6 +2971,90 @@ class TestMixtureDist:
         assert np.isclose(unnorm_val, 10.0)
         assert np.isclose(nu_val, 30.0)
 
+    def test_mixture_dist_log_prob_terms_extended_logsumexp_stability(self):
+        """Per-event term stays finite via logsumexp even when every
+        component's probability-space value underflows to 0.0.
+
+        Mirrors evaluating a Gaussian mixture component ~40 sigma into its
+        tail: exp(-800) and exp(-810) both round to exactly 0.0 in float64,
+        so the probability-space sum Σc_i f_i is exactly 0.0 and the old
+        pt.log(_cached_unnorm_expr) path returned -inf.  log_prob_terms must
+        instead build the sum in log space from each summand's own log-space
+        expression, which stays finite.
+
+        The log-value inputs are genuine symbolic pytensor scalars (not
+        pt.constant literals): PyTensor's constant-folding rewrite would
+        otherwise collapse pt.exp(pt.constant(-800.0)) to the Python float
+        0.0 before the log-sum-exp stabilization rewrite can pattern-match
+        log(sum(exp(...))), masking the exact failure mode this test targets
+        (and not representative of real usage, where components always
+        depend on a symbolic observable).
+        """
+        dist = MixtureDist(
+            name="mix",
+            summands=["pdf1", "pdf2"],
+            coefficients=["coeff1", "coeff2"],
+            extended=True,
+        )
+        coeff1 = pt.dscalar("coeff1")
+        coeff2 = pt.dscalar("coeff2")
+        logv1 = pt.dscalar("logv1")
+        logv2 = pt.dscalar("logv2")
+        context = {
+            "coeff1": coeff1,
+            "coeff2": coeff2,
+            "pdf1": pt.exp(logv1),
+            "pdf2": pt.exp(logv2),
+        }
+        dist.likelihood(context)
+
+        log_expressions = {"pdf1": logv1, "pdf2": logv2}
+        terms = dist.log_prob_terms({}, log_expressions, Distributions([]))
+
+        f = function(
+            [coeff1, coeff2, logv1, logv2],
+            [terms.per_event[0], terms.channel[0], dist._cached_unnorm_expr],
+        )
+        per_event_val, channel_val, raw_val = f(10.0, 20.0, -800.0, -810.0)
+
+        # The probability-space sum underflows to exactly 0.0 -- this is the
+        # condition that made the old pt.log(...) path return -inf.
+        assert raw_val == 0.0
+
+        expected_per_event = logsumexp([np.log(10.0) - 800.0, np.log(20.0) - 810.0])
+        assert np.isfinite(per_event_val)
+        np.testing.assert_allclose(per_event_val, expected_per_event, rtol=1e-12)
+        assert np.isclose(channel_val, -30.0)
+
+    def test_mixture_dist_log_prob_terms_extended_zero_coefficient(self):
+        """A coefficient of exactly 0 drops that component (log(0) = -inf
+        contributes nothing to logsumexp), leaving a finite result equal to
+        the remaining component alone."""
+        dist = MixtureDist(
+            name="mix",
+            summands=["pdf1", "pdf2"],
+            coefficients=["coeff1", "coeff2"],
+            extended=True,
+        )
+        context = {
+            "coeff1": pt.constant(0.0),
+            "coeff2": pt.constant(20.0),
+            "pdf1": pt.constant(0.5),
+            "pdf2": pt.constant(0.25),
+        }
+        dist.likelihood(context)
+
+        log_expressions = {
+            "pdf1": pt.log(pt.constant(0.5)),
+            "pdf2": pt.log(pt.constant(0.25)),
+        }
+        terms = dist.log_prob_terms({}, log_expressions, Distributions([]))
+
+        per_event_val = function([], terms.per_event[0])()
+        assert np.isfinite(per_event_val)
+        # Only the coeff2/pdf2 component survives: log(20 * 0.25) = log(5)
+        np.testing.assert_allclose(per_event_val, np.log(5.0), rtol=1e-6)
+
     def test_mixture_dist_log_prob_terms_extended(self):
         """Extended mixture contributes log(sum c_i f_i) per event and -nu per channel."""
         dist = MixtureDist(
@@ -2984,7 +3071,11 @@ class TestMixtureDist:
         }
         dist.likelihood(context)
 
-        terms = dist.log_prob_terms({}, {}, Distributions([]))
+        log_expressions = {
+            "pdf1": pt.log(pt.constant(0.5)),
+            "pdf2": pt.log(pt.constant(0.25)),
+        }
+        terms = dist.log_prob_terms({}, log_expressions, Distributions([]))
 
         assert len(terms.per_event) == 1
         assert len(terms.channel) == 1

--- a/tests/test_model_likelihood.py
+++ b/tests/test_model_likelihood.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import numpy as np
 import pytensor
 import pytest
+from scipy.special import logsumexp
 from scipy.stats import norm, truncnorm
 
 try:
@@ -1107,3 +1108,113 @@ def test_log_prob_product_extended_mixture_with_constraint():
         [1.0, 2.0, 3.0, 4.0, 5.0], mean=2.0, c_sig=30.0, c_bkg=20.0
     ) + float(norm.logpdf(0.5, loc=0.0, scale=1.0))
     assert val == pytest.approx(expected, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Extended MixtureDist: log-sum-exp stability when every component
+# underflows to 0.0 in probability space (far into both tails).
+# ---------------------------------------------------------------------------
+
+_WS_EXTENDED_MIXTURE_FAR_TAILS: dict = {
+    "metadata": {"hs3_version": "0.2"},
+    "distributions": [
+        {
+            "name": "sig",
+            "type": "gaussian_dist",
+            "x": "x_obs",
+            "mean": -40.0,
+            "sigma": 1.0,
+        },
+        {
+            "name": "bkg",
+            "type": "gaussian_dist",
+            "x": "x_obs",
+            "mean": 40.0,
+            "sigma": 1.0,
+        },
+        {
+            "name": "mix",
+            "type": "mixture_dist",
+            "summands": ["sig", "bkg"],
+            "coefficients": ["c_sig", "c_bkg"],
+            "extended": True,
+        },
+    ],
+    "domains": [
+        {
+            "name": "main",
+            "type": "product_domain",
+            "axes": [
+                {"name": "c_sig", "min": 0.0, "max": 100.0},
+                {"name": "c_bkg", "min": 0.0, "max": 100.0},
+            ],
+        }
+    ],
+    "data": [
+        {
+            "name": "data1",
+            "type": "unbinned",
+            # A single event at x=0: exactly 40 sigma from both means (each
+            # sigma=1), so exp(-0.5*40**2) = exp(-800) underflows to exactly
+            # 0.0 in float64 for both components.
+            "axes": [{"name": "x_obs", "min": -100.0, "max": 100.0}],
+            "entries": [[0.0]],
+        },
+    ],
+    "likelihoods": [{"name": "L", "distributions": ["mix"], "data": ["data1"]}],
+    "analyses": [
+        {"name": "A", "likelihood": "L", "domains": ["main"], "init": "params"}
+    ],
+    "parameter_points": [
+        {
+            "name": "params",
+            "parameters": [
+                {"name": "c_sig", "value": 30.0},
+                {"name": "c_bkg", "value": 20.0},
+            ],
+        }
+    ],
+}
+
+
+def test_log_prob_extended_mixture_far_tails_stays_finite():
+    """model.log_prob stays finite when both mixture components underflow.
+
+    At x=0, both 'sig' (mean=-40) and 'bkg' (mean=40) are 40 sigma away, so
+    their probability-space densities underflow to exactly 0.0 in float64:
+    the old pt.log(Σc_i f_i) path would see log(0.0) = -inf here even though
+    each component's analytic log-density is finite.  log_prob_terms instead
+    builds the per-event term as logsumexp(log c_i + log f_i) directly from
+    each summand's log-space expression, which stays finite.
+
+    The reference combines each summand's own (independently compiled)
+    logpdf via scipy.special.logsumexp in plain Python -- an evaluation path
+    entirely independent of the PyTensor-graph-level logsumexp built inside
+    log_prob_terms, so agreement is a genuine cross-check rather than a
+    tautology.
+    """
+    ws = Workspace(**_WS_EXTENDED_MIXTURE_FAR_TAILS)
+    model = ws.model(ws.analyses["A"], progress=False)
+
+    # Each component's raw probability-space density underflows to exactly
+    # 0.0 -- the condition that made the old pt.log(...) path return -inf.
+    x_obs = np.array([0.0])
+    assert model.pdf("sig", x_obs=x_obs) == 0.0
+    assert model.pdf("bkg", x_obs=x_obs) == 0.0
+
+    lp_expr = model.log_prob
+    inputs_map = {
+        v.name: v for v in explicit_graph_inputs([lp_expr]) if v.name is not None
+    }
+    fn = pytensor.function(list(inputs_map.values()), lp_expr)
+    val = float(fn(**model.data, **model.nominal_params).item())
+    assert np.isfinite(val)
+
+    log_sig = float(model.logpdf("sig", x_obs=x_obs).item())
+    log_bkg = float(model.logpdf("bkg", x_obs=x_obs).item())
+    assert np.isfinite(log_sig)
+    assert np.isfinite(log_bkg)
+
+    nu = 30.0 + 20.0
+    expected = logsumexp([np.log(30.0) + log_sig, np.log(20.0) + log_bkg]) - nu
+    assert val == pytest.approx(expected, rel=1e-9)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- `MixtureDist.log_prob_terms` (extended mixtures only) built its per-event term as `pt.log(Σc_i·f_i)` from probability-space component tensors. When every component is deep in its tail, each `f_i` underflows to exactly `0.0` in float64, the sum is exactly `0.0`, and `log(0.0) = -inf` — even though each component's analytic log-density is finite.
- Replaced it with `logsumexp(log(c_i) + log_expressions[summand_i])`, built from each summand's own log-space expression (already log-space-safe for e.g. `GaussianDist`) instead of round-tripping through the probability-space sum. Per-summand coefficient tensors are cached during `likelihood()` (same pattern as the existing `_cached_unnorm_expr`/`_cached_nu_expr`) since `log_prob_terms` isn't given the context needed to re-resolve `context[coeff]`.
- The channel-level `-nu` yield term, `_cached_unnorm_expr`, and the probability-space `likelihood()`/`_expression()` path are unchanged.
- `ProductDist.log_prob_terms` already delegates to each factor's own `log_prob_terms` and reads `log_expressions` for constraint factors — audited, no change needed.
- Assumes non-negative coefficients (matching the probabilistic meaning of a mixture weight). `MixtureDist` does not validate coefficient sign today, so this is documented on `log_prob_terms` rather than adding new validation (a negative `c_i` already produced NaN in the old `pt.log(Σc_i·f_i)` path when the sum went negative; the new path can differ by producing NaN per-component instead, e.g. when offsetting positive/negative coefficients summed to a positive total — noted in the docstring).

## Underflow reproduction (before / after)

Two-component Gaussian mixture, means at ±40 with sigma=1, evaluated at x=0 (40σ from both means: `exp(-800)` underflows to exactly `0.0` in float64):

| | before | after |
|---|---|---|
| `model.pdf("sig", ...)` / `model.pdf("bkg", ...)` | `0.0` (underflow, both) | `0.0` (unchanged — probability-space path untouched) |
| `model.log_prob` | `-inf` | `-847.5572786032538` |
| independent reference (`logsumexp(log c_i + model.logpdf(summand_i)) - nu`, combined via `scipy.special.logsumexp` in plain Python) | n/a | `-847.5572786032538` (exact match) |

## Test plan

- [x] New RED-first regression test confirmed `-inf` on the pre-fix code, `finite` and matching an independent `scipy.special.logsumexp` reference after the fix — both at the isolated `MixtureDist.log_prob_terms` unit level (`tests/test_distributions.py::TestMixtureDist::test_mixture_dist_log_prob_terms_extended_logsumexp_stability`) and full `Workspace` → `Model.log_prob` level with real `GaussianDist` summands (`tests/test_model_likelihood.py::test_log_prob_extended_mixture_far_tails_stays_finite`).
- [x] New coefficient-edge-case test: one coefficient exactly `0` → finite result equal to the other component alone (`test_mixture_dist_log_prob_terms_extended_zero_coefficient`).
- [x] Existing extended-mixture parity tests (real `GaussianDist` summands, `pytest.approx(..., abs=1e-6)` against `scipy.stats.truncnorm`/`norm`) still pass unchanged — value-level regression coverage for ordinary (non-underflowing) points.
- [x] Updated two pre-existing unit tests (`test_mixture_dist_log_prob_terms_extended`, `test_product_dist_log_prob_terms_recurses_into_extended_mixture`) that called `log_prob_terms` directly with incomplete `log_expressions` dicts, to supply the summand log-space entries the new implementation requires.
- [x] `pixi run --environment py312 test`: 1086 passed, 3 skipped, 1 xfailed.
- [x] `pixi run --environment py312 test-slow tests/test_realworld.py -s`: 5 passed, 1 xfailed (~106s).
- [x] `composite.py` at 100% line coverage (`pixi run --environment py312 test-cov`). Branch coverage (`--cov-branch`) could not be verified in this sandbox — it hits a pre-existing `RecursionError` (numpy module reload) unrelated to this change, reproduced identically on an unmodified checkout; no new decision points were introduced beyond extending one existing `if` guard's boolean condition (still one `if`/`else` pair).
- [x] `pre-commit run --files src/pyhs3/distributions/composite.py tests/test_distributions.py tests/test_model_likelihood.py` and `pylint` (10.00/10): clean.

Refs #254 (phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
