### PR TITLE
perf: vectorize per-bin constraint subgraphs

### DIFF
--- a/src/pyhs3/distributions/histfactory/__init__.py
+++ b/src/pyhs3/distributions/histfactory/__init__.py
@@ -312,13 +312,17 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
                     return modifier
         return None
 
-    def _build_barlow_beeston_lite_dists(
+    def _build_barlow_beeston_lite_dist(
         self, context: Context
-    ) -> list[tuple[GaussianDist | PoissonDist, Context]] | None:
-        """Construct the per-bin BB-lite Gauss/Poisson constraint distributions.
+    ) -> tuple[GaussianDist | PoissonDist, Context] | None:
+        """Construct a single vectorized BB-lite Gauss/Poisson constraint distribution.
 
         BB-lite uses shared gamma parameters across samples with a channel-level
-        constraint built from combined MC statistical uncertainties.
+        constraint built from combined MC statistical uncertainties. Stacks
+        the per-bin gamma parameters into one length-B tensor and builds ONE
+        GaussianDist/PoissonDist over vector-valued inputs, instead of one
+        scalar distribution per bin (mirroring
+        :meth:`~pyhs3.distributions.histfactory.modifiers.ShapeSysModifier._build_bin_constraint`).
 
         The constraint can be either Poisson or Gaussian:
         - Poisson: Poisson(tau | gamma * tau) where tau = (nu/sigma)^2
@@ -328,11 +332,20 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         - total_nominal = sum(sample.data.contents)
         - total_sigma = sqrt(sum(sample.data.errors^2))
 
-        Returns ``None`` when this channel has no staterror modifier (nothing
-        to constrain). Shared by :meth:`_make_barlow_beeston_lite_constraint`
-        (product of per-bin probabilities) and
-        :meth:`_make_barlow_beeston_lite_log_constraint` (sum of per-bin
-        log-probabilities) so the parametrization is defined exactly once.
+        Bins with zero (or negative) combined nominal yield are excluded
+        from the vector entirely -- for BOTH Poisson and Gauss, unlike
+        :meth:`~pyhs3.distributions.histfactory.modifiers.StatErrorModifier._build_bin_constraint`
+        (BB-full), which only skips Poisson bins and falls back to
+        ``sigma_value = 1.0`` for Gauss. This is a genuine semantic
+        difference between the two code paths, not an oversight -- preserved
+        exactly from the pre-vectorization implementation.
+
+        Returns ``None`` when this channel has no staterror modifier, or
+        when every bin was excluded. Shared by
+        :meth:`_make_barlow_beeston_lite_constraint` (product of per-bin
+        probabilities) and :meth:`_make_barlow_beeston_lite_log_constraint`
+        (sum of per-bin log-probabilities) so the parametrization is defined
+        exactly once.
         """
         total_bins = self._get_total_bins()
 
@@ -359,48 +372,39 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
 
         total_sigma = np.sqrt(total_variance)
 
-        augmented_context = dict(context)
-        dists: list[GaussianDist | PoissonDist] = []
-
-        for i, param_name in enumerate(gamma_params):
-            nu, sigma = total_nominal[i], total_sigma[i]
-
-            # Skip bins with zero nominal yield; sigma=0 is caught by the parsing layer
-            if nu <= 0:
-                continue
-
-            if constraint_type == "Poisson":
-                # Poisson: Poisson(tau | gamma * tau) where tau = (nu/sigma)^2
-                tau = (nu / sigma) ** 2
-                scaled_name = f"{param_name}_scaled"
-                augmented_context[scaled_name] = context[param_name] * tau
-                dists.append(
-                    PoissonDist(
-                        name=f"constraint_bblite_{self.name}_{i}",
-                        x=float(tau),
-                        mean=scaled_name,
-                    )
-                )
-            else:  # "Gauss"
-                # Gaussian: N(1.0 | gamma, relerr) where relerr = sigma / nu
-                relerr = sigma / nu
-                sigma_name = f"{param_name}_sigma"
-                augmented_context[sigma_name] = pt.constant(relerr)
-                dists.append(
-                    GaussianDist(
-                        name=f"constraint_bblite_{self.name}_{i}",
-                        x=1.0,
-                        mean=param_name,
-                        sigma=sigma_name,
-                    )
-                )
-
-        if not dists:
+        # Skip bins with zero nominal yield; sigma=0 is caught by the parsing layer.
+        keep = total_nominal > 0
+        params = [p for p, k in zip(gamma_params, keep, strict=True) if k]
+        if not params:
             return None
 
-        return [
-            (dist, Context({**augmented_context, **dist.constants})) for dist in dists
-        ]
+        # (B',) concrete combined yields/sigmas for the surviving bins.
+        nu = total_nominal[keep]
+        sigma = total_sigma[keep]
+        gamma = pt.stack([context[param_name] for param_name in params])
+
+        name = f"constraint_bblite_{self.name}"
+        augmented_context = dict(context)
+
+        dist: GaussianDist | PoissonDist
+        if constraint_type == "Poisson":
+            # Poisson: Poisson(tau | gamma * tau) where tau = (nu/sigma)^2
+            tau = (nu / sigma) ** 2
+            scaled_name = f"{name}_scaled"
+            x_name = f"{name}_x"
+            augmented_context[x_name] = pt.constant(tau)
+            augmented_context[scaled_name] = gamma * pt.constant(tau)
+            dist = PoissonDist(name=name, x=x_name, mean=scaled_name)
+        else:  # "Gauss"
+            # Gaussian: N(1.0 | gamma, relerr) where relerr = sigma / nu
+            relerr = sigma / nu
+            mean_name = f"{name}_mean"
+            sigma_name = f"{name}_sigma"
+            augmented_context[mean_name] = gamma
+            augmented_context[sigma_name] = pt.constant(relerr)
+            dist = GaussianDist(name=name, x=1.0, mean=mean_name, sigma=sigma_name)
+
+        return dist, Context({**augmented_context, **dist.constants})
 
     def _make_barlow_beeston_lite_constraint(
         self, context: Context
@@ -408,12 +412,12 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         """Build BB-lite constraint (product of per-bin probabilities) from
         combined sample uncertainties, or ``None`` if this channel has no
         staterror modifier."""
-        pairs = self._build_barlow_beeston_lite_dists(context)
-        if pairs is None:
+        pair = self._build_barlow_beeston_lite_dist(context)
+        if pair is None:
             return None
 
-        factors = [dist.expression(ctx) for dist, ctx in pairs]
-        return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
+        dist, augmented_context = pair
+        return cast(TensorVar, pt.prod(dist.expression(augmented_context)))  # type: ignore[no-untyped-call]
 
     def _make_barlow_beeston_lite_log_constraint(
         self, context: Context
@@ -424,12 +428,12 @@ class HistFactoryDistChannel(Distribution, HasInternalNodes):
         product, so the constraint stays finite where the probability-space
         product would underflow to 0.0.
         """
-        pairs = self._build_barlow_beeston_lite_dists(context)
-        if pairs is None:
+        pair = self._build_barlow_beeston_lite_dist(context)
+        if pair is None:
             return None
 
-        log_terms = [dist.log_expression(ctx) for dist, ctx in pairs]
-        return cast(TensorVar, pt.sum(pt.stack(log_terms), axis=0))  # type: ignore[no-untyped-call]
+        dist, augmented_context = pair
+        return cast(TensorVar, pt.sum(dist.log_expression(augmented_context)))  # type: ignore[no-untyped-call]
 
     def _compute_expected_rates(self, context: Context, total_bins: int) -> TensorVar:
         """

--- a/src/pyhs3/distributions/histfactory/modifiers.py
+++ b/src/pyhs3/distributions/histfactory/modifiers.py
@@ -356,54 +356,50 @@ class ShapeSysModifier(HasConstraint, ParametersModifier):
         """Apply shapesys modifier (shape systematic with constraints)."""
         return cast("TensorVar", rates * self.expression(context))
 
-    def _build_bin_constraints(
+    def _build_bin_constraint(
         self, context: Context, sample_data: SampleData
-    ) -> list[tuple[Distribution, Context]]:
-        """Construct the per-bin Poisson constraint distributions.
+    ) -> tuple[Distribution, Context]:
+        """Construct a single vectorized Poisson constraint distribution.
 
-        Shared by :meth:`make_constraint` (product of per-bin probabilities)
-        and :meth:`log_constraint` (sum of per-bin log-probabilities) so the
-        parametrization is defined exactly once.
+        Stacks the B per-bin nuisance parameters into one length-B tensor and
+        builds ONE :class:`PoissonDist` over vector-valued ``x``/``mean``,
+        instead of one scalar :class:`PoissonDist` per bin. ``PoissonDist``'s
+        ``likelihood``/``log_likelihood`` are elementwise pytensor expressions,
+        so a vector input produces a vector output; :meth:`make_constraint`
+        and :meth:`log_constraint` reduce the resulting (B,) vector with
+        ``pt.prod``/``pt.sum``. Shared by both so the parametrization is
+        defined exactly once.
         """
         name = f"constraint_{self.name}"
 
         # (sigma_b)^{-2} = (nominal / vals)^2, evaluated on concrete floats.
+        # Shape: (B,) -- one rate per bin, in self.parameters order.
         rates = (
             np.asarray(sample_data.contents, dtype=np.float64)
             / np.asarray(self.data.vals, dtype=np.float64)
         ) ** 2
 
-        # Use augmented context pattern for parameter * rate scaling
+        # gamma: (B,) stacked per-bin nuisance-parameter tensors.
+        gamma = pt.stack([context[parameter] for parameter in self.parameters])
+        scaled_name = f"{name}_scaled"
+        x_name = f"{name}_x"
+
         augmented_context = dict(context)
-        dists = []
+        augmented_context[x_name] = pt.constant(rates)
+        augmented_context[scaled_name] = gamma * pt.constant(rates)
 
-        for parameter, rate in zip(self.parameters, rates, strict=False):
-            # Create scaled parameter in augmented context
-            scaled_param_name = f"{parameter}_scaled"
-            augmented_context[scaled_param_name] = context[parameter] * rate
-
-            # Create Poisson distribution with scaled parameter
-            dist: Distribution = PoissonDist(
-                name=f"{name}_{parameter}", x=rate, mean=scaled_param_name
-            )
-            dists.append(dist)
-
-        # Pair each distribution with a context augmented by its own constants.
-        return [
-            (dist, Context({**augmented_context, **dist.constants})) for dist in dists
-        ]
+        dist: Distribution = PoissonDist(name=name, x=x_name, mean=scaled_name)
+        return dist, Context({**augmented_context, **dist.constants})
 
     def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
         """Create constraint term using PyTensor operations."""
-        pairs = self._build_bin_constraints(context, sample_data)
-        factors = [dist.expression(ctx) for dist, ctx in pairs]
-        return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
+        dist, augmented_context = self._build_bin_constraint(context, sample_data)
+        return cast(TensorVar, pt.prod(dist.expression(augmented_context)))  # type: ignore[no-untyped-call]
 
     def log_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
         """Create constraint term as the sum of per-bin Poisson log-probabilities."""
-        pairs = self._build_bin_constraints(context, sample_data)
-        log_terms = [dist.log_expression(ctx) for dist, ctx in pairs]
-        return cast(TensorVar, pt.sum(pt.stack(log_terms), axis=0))  # type: ignore[no-untyped-call]
+        dist, augmented_context = self._build_bin_constraint(context, sample_data)
+        return cast(TensorVar, pt.sum(dist.log_expression(augmented_context)))  # type: ignore[no-untyped-call]
 
 
 class StatErrorModifier(HasConstraint, ParametersModifier):
@@ -425,60 +421,76 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
         """Apply staterror modifier (Barlow-Beeston statistical uncertainties)."""
         return cast("TensorVar", rates * self.expression(context))
 
-    def _build_bin_constraints(
+    def _build_bin_constraint(
         self, context: Context, sample_data: SampleData, data: StatErrorData
-    ) -> list[tuple[Distribution, Context]]:
-        """Construct the per-bin Gauss/Poisson constraint distributions.
+    ) -> tuple[Distribution, Context] | None:
+        """Construct a single vectorized Gauss/Poisson constraint distribution.
 
         Only used in BB-full mode. In BB-lite mode, constraints are built at
-        channel level. Shared by :meth:`make_constraint` (product of per-bin
-        probabilities) and :meth:`log_constraint` (sum of per-bin
-        log-probabilities) so the parametrization is defined exactly once.
-        ``data`` is taken as an explicit argument (rather than reading
-        ``self.data``) so callers narrow the ``StatErrorData | None`` type by
-        raising before calling, instead of asserting it here.
+        channel level. Stacks the per-bin nuisance parameters into one
+        length-B tensor and builds ONE GaussianDist/PoissonDist over
+        vector-valued inputs, instead of one scalar distribution per bin
+        (mirroring :meth:`ShapeSysModifier._build_bin_constraint`).
+
+        Returns ``None`` when there is nothing to constrain: either
+        ``self.parameters`` is empty, or (Poisson only) every bin has
+        ``nominal_yield <= 0`` and was excluded. Gauss bins with a
+        nonpositive yield are NOT excluded -- they fall back to
+        ``sigma_value = 1.0``, matching the pre-vectorization per-bin
+        behavior exactly.
+
+        Shared by :meth:`make_constraint` (product of per-bin probabilities)
+        and :meth:`log_constraint` (sum of per-bin log-probabilities) so the
+        parametrization is defined exactly once. ``data`` is taken as an
+        explicit argument (rather than reading ``self.data``) so callers
+        narrow the ``StatErrorData | None`` type by raising before calling,
+        instead of asserting it here.
         """
+        # Truncate to the shortest of parameters/uncertainties, mirroring the
+        # zip(..., strict=False) pairing used before vectorization.
+        n = min(len(self.parameters), len(data.uncertainties))
+        if n == 0:
+            return None
+
         name = f"constraint_{self.name}"
+        # Shape (B,): concrete per-bin nominal yields and uncertainties.
+        nominal_yields = np.asarray(sample_data.contents[:n], dtype=np.float64)
+        uncertainties = np.asarray(data.uncertainties[:n], dtype=np.float64)
         augmented_context = dict(context)
-        dists: list[Distribution] = []
 
-        for i, (parameter, uncertainty) in enumerate(
-            zip(self.parameters, data.uncertainties, strict=False)
-        ):
-            nominal_yield = sample_data.contents[i]
-            # sigma_value is the relative uncertainty = uncertainty / nominal_yield
-            sigma_value = uncertainty / nominal_yield if nominal_yield > 0 else 1.0
+        dist: Distribution
+        if self.constraint == "Poisson":
+            # Skip zero-yield bins: tau = (nu/sigma)^2 is undefined when nu <= 0.
+            keep = nominal_yields > 0
+            parameters = [
+                p for p, k in zip(self.parameters[:n], keep, strict=True) if k
+            ]
+            if not parameters:
+                return None
+            # tau = (nominal/uncertainty)^2 = 1/sigma_value^2. Shape: (B',).
+            sigma_value = uncertainties[keep] / nominal_yields[keep]
+            tau = 1.0 / sigma_value**2
+            gamma = pt.stack([context[parameter] for parameter in parameters])
+            scaled_name = f"{name}_scaled"
+            x_name = f"{name}_x"
+            augmented_context[x_name] = pt.constant(tau)
+            augmented_context[scaled_name] = gamma * pt.constant(tau)
+            dist = PoissonDist(name=name, x=x_name, mean=scaled_name)
+        else:  # "Gauss"
+            # sigma_value is the relative uncertainty = uncertainty / nominal_yield,
+            # falling back to 1.0 for nonpositive yields (bin kept, not skipped).
+            # Shape: (B,).
+            sigma_value = np.ones_like(nominal_yields)
+            positive = nominal_yields > 0
+            sigma_value[positive] = uncertainties[positive] / nominal_yields[positive]
+            gamma = pt.stack([context[parameter] for parameter in self.parameters[:n]])
+            mean_name = f"{name}_mean"
+            sigma_name = f"{name}_sigma"
+            augmented_context[mean_name] = gamma
+            augmented_context[sigma_name] = pt.constant(sigma_value)
+            dist = GaussianDist(name=name, x=1.0, mean=mean_name, sigma=sigma_name)
 
-            if self.constraint == "Poisson":
-                # Skip zero-yield bins: tau = (nu/sigma)^2 is undefined when nu <= 0
-                if nominal_yield <= 0:
-                    continue
-                # Poisson: Poisson(tau | gamma * tau) where tau = (nominal/uncertainty)^2
-                # Equivalently: tau = 1/sigma_value^2
-                tau = 1.0 / sigma_value**2
-                scaled_name = f"{parameter}_scaled"
-                augmented_context[scaled_name] = context[parameter] * tau
-                dist: Distribution = PoissonDist(
-                    name=f"{name}_{parameter}",
-                    x=float(tau),
-                    mean=scaled_name,
-                )
-            else:  # "Gauss"
-                # Gaussian: N(1.0 | gamma, sigma_value)
-                sigma_param_name = f"{parameter}_sigma"
-                augmented_context[sigma_param_name] = pt.constant(sigma_value)
-                dist = GaussianDist(
-                    name=f"{name}_{parameter}",
-                    x=1.0,
-                    mean=parameter,
-                    sigma=sigma_param_name,
-                )
-            dists.append(dist)
-
-        # Pair each distribution with a context augmented by its own constants.
-        return [
-            (dist, Context({**augmented_context, **dist.constants})) for dist in dists
-        ]
+        return dist, Context({**augmented_context, **dist.constants})
 
     def make_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
         """Create constraint term using PyTensor operations.
@@ -491,12 +503,12 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
             )
             raise ValueError(msg)
 
-        pairs = self._build_bin_constraints(context, sample_data, self.data)
-        if not pairs:
+        pair = self._build_bin_constraint(context, sample_data, self.data)
+        if pair is None:
             return pt.constant(1.0)
 
-        factors = [dist.expression(ctx) for dist, ctx in pairs]
-        return cast(TensorVar, pt.prod(pt.stack(factors), axis=0))  # type: ignore[no-untyped-call]
+        dist, augmented_context = pair
+        return cast(TensorVar, pt.prod(dist.expression(augmented_context)))  # type: ignore[no-untyped-call]
 
     def log_constraint(self, context: Context, sample_data: SampleData) -> TensorVar:
         """Create constraint term as the sum of per-bin Gauss/Poisson log-probabilities.
@@ -507,12 +519,12 @@ class StatErrorModifier(HasConstraint, ParametersModifier):
             msg = "StatErrorModifier.data is required for BB-full mode (log_constraint)"
             raise ValueError(msg)
 
-        pairs = self._build_bin_constraints(context, sample_data, self.data)
-        if not pairs:
+        pair = self._build_bin_constraint(context, sample_data, self.data)
+        if pair is None:
             return pt.constant(0.0)
 
-        log_terms = [dist.log_expression(ctx) for dist, ctx in pairs]
-        return cast(TensorVar, pt.sum(pt.stack(log_terms), axis=0))  # type: ignore[no-untyped-call]
+        dist, augmented_context = pair
+        return cast(TensorVar, pt.sum(dist.log_expression(augmented_context)))  # type: ignore[no-untyped-call]
 
 
 # Discriminated union of all modifier types.

--- a/tests/test_histfactory.py
+++ b/tests/test_histfactory.py
@@ -29,6 +29,7 @@ import pyhs3
 from pyhs3.axes import BinnedAxes
 from pyhs3.context import Context
 from pyhs3.distributions import HistFactoryDistChannel
+from pyhs3.distributions.basic import GaussianDist, PoissonDist
 from pyhs3.distributions.histfactory.modifiers import (
     HistoSysModifier,
     NormFactorModifier,
@@ -2751,3 +2752,59 @@ class TestBarlowBeestonLite:
             for mod in sample.modifiers:
                 if isinstance(mod, StatErrorModifier):
                     assert mod.parameters == expected
+
+
+class TestBarlowBeestonLiteVectorizedConstraint:
+    """The channel-level BB-lite constraint builds ONE constraint distribution
+    per channel call (vectorized over bins), not one scalar distribution per
+    bin.  Structural regression test for the #230 review perf item."""
+
+    N_BINS = 8
+
+    @pytest.mark.parametrize("constraint_type", ["Gauss", "Poisson"])
+    def test_builds_one_dist_per_call(self, monkeypatch, constraint_type):
+        dist_cls = GaussianDist if constraint_type == "Gauss" else PoissonDist
+        calls = {"count": 0}
+        original_init = dist_cls.__init__
+
+        def wrapped(self, *args, **kwargs):
+            calls["count"] += 1
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(dist_cls, "__init__", wrapped)
+
+        params = [f"gamma_bin{i}" for i in range(self.N_BINS)]
+        axes = [
+            {"name": "x", "min": 0.0, "max": float(self.N_BINS), "nbins": self.N_BINS}
+        ]
+        samples = [
+            {
+                "name": "signal",
+                "data": {
+                    "contents": [10.0 + i for i in range(self.N_BINS)],
+                    "errors": [1.0 + 0.1 * i for i in range(self.N_BINS)],
+                },
+                "modifiers": [
+                    {
+                        "name": "stat_error",
+                        "type": "staterror",
+                        "parameters": params,
+                        "constraint": constraint_type,
+                    }
+                ],
+            }
+        ]
+        channel = HistFactoryDistChannel(
+            name="test_channel",
+            axes=axes,
+            samples=samples,
+            barlow_beeston_method="lite",
+        )
+        context = Context({p: pt.constant(1.0, dtype="float64") for p in params})
+
+        channel._make_barlow_beeston_lite_constraint(context)
+        assert calls["count"] == 1
+
+        calls["count"] = 0
+        channel._make_barlow_beeston_lite_log_constraint(context)
+        assert calls["count"] == 1

--- a/tests/test_histfactory_modifiers.py
+++ b/tests/test_histfactory_modifiers.py
@@ -14,6 +14,7 @@ import pytest
 from scipy.stats import norm as scipy_norm
 
 from pyhs3.context import Context
+from pyhs3.distributions.basic import GaussianDist, PoissonDist
 from pyhs3.distributions.histfactory.data import SampleData
 from pyhs3.distributions.histfactory.modifiers import (
     HistoSysData,
@@ -549,6 +550,29 @@ class TestStatErrorModifier:
         expected = float(np.exp(log_factor))
         np.testing.assert_allclose(constraint_val, expected, rtol=1e-4)
 
+    def test_make_constraint_poisson_all_bins_skipped(self):
+        """make_constraint()/log_constraint() with Poisson return the
+        no-constraint constant (1.0 / 0.0) when every bin has
+        nominal_yield <= 0 and is therefore skipped, even though
+        ``self.parameters`` is non-empty."""
+        data = StatErrorData(uncertainties=[1.0, 1.0])
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=["gamma_stat_bin0", "gamma_stat_bin1"],
+            constraint="Poisson",
+            data=data,
+        )
+        context = Context(
+            {"gamma_stat_bin0": pt.constant(1.0), "gamma_stat_bin1": pt.constant(1.0)}
+        )
+        sample_data = SampleData(contents=[0.0, 0.0], errors=[0.0, 0.0])
+
+        constraint_val = float(modifier.make_constraint(context, sample_data).eval())
+        assert constraint_val == pytest.approx(1.0)
+
+        log_constraint_val = float(modifier.log_constraint(context, sample_data).eval())
+        assert log_constraint_val == pytest.approx(0.0)
+
 
 class TestModifierConstraintTypes:
     """Test different constraint types for modifiers."""
@@ -853,3 +877,79 @@ class TestLogConstraintUnderflow:
         log_prob = float(modifier.log_constraint(context, sample_data).eval())
         assert math.isfinite(log_prob)
         assert log_prob == pytest.approx(float(scipy_norm.logpdf(40.0)), rel=1e-10)
+
+
+def _spy_init_calls(monkeypatch, cls):
+    """Wrap ``cls.__init__`` to count constructions, returning a mutable counter.
+
+    Used to assert that per-bin constraint helpers build ONE vectorized
+    GaussianDist/PoissonDist per modifier call instead of one scalar
+    distribution object per bin (#230 review perf item).
+    """
+    calls = {"count": 0}
+    original_init = cls.__init__
+
+    def wrapped(self, *args, **kwargs):
+        calls["count"] += 1
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(cls, "__init__", wrapped)
+    return calls
+
+
+class TestVectorizedBinConstraints:
+    """Per-bin constraint helpers build ONE constraint distribution per modifier
+    call (vectorized over bins), not one scalar distribution per bin.
+
+    Structural regression test for the #230 review perf item: constructing a
+    GaussianDist/PoissonDist per bin inflates Python-side graph construction,
+    PyTensor compile time, and JAX traces for wide (many-bin) channels.
+    """
+
+    N_BINS = 8
+
+    def test_shapesys_builds_one_poisson_per_call(self, monkeypatch):
+        calls = _spy_init_calls(monkeypatch, PoissonDist)
+
+        params = [f"gamma_{i}" for i in range(self.N_BINS)]
+        vals = [0.1 + 0.01 * i for i in range(self.N_BINS)]
+        modifier = ShapeSysModifier(
+            name="uncorr_bkguncrt", parameters=params, data=ShapeSysData(vals=vals)
+        )
+        context = Context({p: pt.constant(1.0, dtype="float64") for p in params})
+        sample_data = SampleData(
+            contents=[100.0 + i for i in range(self.N_BINS)], errors=[5.0] * self.N_BINS
+        )
+
+        modifier.make_constraint(context, sample_data)
+        assert calls["count"] == 1
+
+        calls["count"] = 0
+        modifier.log_constraint(context, sample_data)
+        assert calls["count"] == 1
+
+    @pytest.mark.parametrize("constraint_type", ["Gauss", "Poisson"])
+    def test_staterror_bbfull_builds_one_dist_per_call(
+        self, monkeypatch, constraint_type
+    ):
+        dist_cls = GaussianDist if constraint_type == "Gauss" else PoissonDist
+        calls = _spy_init_calls(monkeypatch, dist_cls)
+
+        params = [f"gamma_{i}" for i in range(self.N_BINS)]
+        modifier = StatErrorModifier(
+            name="stat_unc",
+            parameters=params,
+            constraint=constraint_type,
+            data=StatErrorData(uncertainties=[2.0] * self.N_BINS),
+        )
+        context = Context({p: pt.constant(1.0, dtype="float64") for p in params})
+        sample_data = SampleData(
+            contents=[100.0 + i for i in range(self.N_BINS)], errors=[5.0] * self.N_BINS
+        )
+
+        modifier.make_constraint(context, sample_data)
+        assert calls["count"] == 1
+
+        calls["count"] = 0
+        modifier.log_constraint(context, sample_data)
+        assert calls["count"] == 1


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Last performance item from the #230 review: `ShapeSysModifier`/`StatErrorModifier` (BB-full) and the BB-lite channel-level constraint each built ONE `GaussianDist`/`PoissonDist` per bin, so a B-bin channel produced B scalar distribution objects whose consumers then `pt.prod`/`pt.sum`ed the per-bin results — inflating Python-side graph construction, PyTensor compile time, and JAX traces.

- Stack the per-bin nuisance-parameter tensors into a single length-B vector and build one constraint distribution per modifier call. `GaussianDist`/`PoissonDist` likelihood/log_likelihood are elementwise pytensor expressions, so vector-in gives vector-out; `make_constraint`/`log_constraint` reduce the (B,) result once with `pt.prod`/`pt.sum`.
- Per-bin numeric literals (rates, tau, sigma) become vector `pt.constant` tensors referenced by name in the augmented context, mirroring the existing string-reference pattern rather than pydantic-validated scalar fields.
- Zero-yield-bin exclusion is preserved exactly via boolean masking at construction time (concrete numpy arrays, not symbolic indexing): `StatErrorModifier` Poisson branch only skips nonpositive-yield bins (Gauss falls back to `sigma=1.0`), while the BB-lite path skips nonpositive-yield bins for both Poisson and Gauss — a genuine semantic difference between the two paths that is preserved as-is, not unified.
- Investigated the context contract before touching anything: the per-bin distribution names/context entries built by these helpers are local to each call (a fresh dict/Context) and never surface to Model or auxdata collection — `Model.distributions`/`Model.log_distributions` are keyed only by `ModifierNode` names from `get_internal_nodes()`, and the `.auxdata` property is unused by production code. Collapsing per-bin names to one name per modifier therefore changes no external contract.

### Graph-size before/after (8-bin channel, Apply-node count via applys_between)

| Constraint | Before | After |
|---|---|---|
| shapesys make_constraint/log_constraint | 114 | 21 |
| staterror(Gauss) make_constraint | 82 | 18 |
| staterror(Gauss) log_constraint | 74 | 16 |
| staterror(Poisson) make_constraint/log_constraint | 114 | 21 |
| BB-lite(Gauss) make_constraint | 82 | 18 |
| BB-lite(Gauss) log_constraint | 74 | 16 |

Roughly a 4-5x reduction in constraint-subgraph size for this channel width, growing with bin count.

Refs #230 (perf item), #254 (roadmap).

## Test plan

- [x] New structural regression tests (spy on `GaussianDist`/`PoissonDist.__init__`) confirm ONE distribution construction per modifier call for an 8-bin shapesys/staterror(BB-full)/BB-lite channel — verified RED against the pre-vectorization code (8 constructions), GREEN after.
- [x] Added one new edge-case test (`test_make_constraint_poisson_all_bins_skipped`) to cover the new "all Poisson bins skipped, non-empty parameters" branch introduced by vectorization.
- [x] Existing parity/dedup/BB-lite/log-space tests pass unchanged (no tolerance edits).
- [x] `pixi run --environment py312 test`: 1125 passed, 3 skipped, 1 xfailed.
- [x] `pixi run --environment py312 test-slow tests/test_realworld.py -s`: 5 passed, 1 xfailed.
- [x] Coverage: 100% lines+branches on both touched files (histfactory/modifiers.py, histfactory/__init__.py).
- [x] `pre-commit run --files <touched files>`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
