### PR TITLE
refactor: delegate GaussianDist.log_likelihood to pytensor-distributions logpdf

### DIFF
--- a/src/pyhs3/distributions/basic.py
+++ b/src/pyhs3/distributions/basic.py
@@ -66,7 +66,8 @@ class GaussianDist(Distribution):
         r"""
         Builds a symbolic expression for the Gaussian log-PDF.
 
-        Analytic log form of :meth:`likelihood`:
+        Delegates to pytensor-distributions' analytic log form of
+        :meth:`likelihood`:
 
         .. math::
 
@@ -84,11 +85,13 @@ class GaussianDist(Distribution):
         Returns:
             pytensor.tensor.variable.TensorVariable: Symbolic representation of the Gaussian log-PDF.
         """
-        sigma = context[self._parameters["sigma"]]
-        z = (context[self._parameters["x"]] - context[self._parameters["mean"]]) / sigma
         return cast(
             TensorVar,
-            -0.5 * z**2 - pt.log(sigma) - 0.5 * math.log(2.0 * math.pi),
+            Normal.logpdf(
+                context[self._parameters["x"]],
+                context[self._parameters["mean"]],
+                context[self._parameters["sigma"]],
+            ),
         )
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This completes the pairing PR #251 started for `GaussianDist`: `likelihood()` was switched to delegate to `pytensor_distributions.normal.pdf(x, mean, sigma)`, but `log_likelihood()` was left with the hand-written analytic form added in #261. This PR updates `log_likelihood()` to delegate to `Normal.logpdf(x, mean, sigma)` the same way, mirroring `likelihood()`'s style (same cast pattern, same context lookups, same positional argument order).

`Normal.logpdf` in the installed `pytensor-distributions` package is itself the analytic log form:

```python
def logpdf(x, mu, sigma):
    return -0.5 * pt.pow((x - mu) / sigma, 2) - pt.log(pt.sqrt(2.0 * pt.pi)) - pt.log(sigma)
```

which is algebraically identical to the previous hand-written expression (`log(sqrt(2*pi)) == 0.5*log(2*pi)`), so this is a pure refactor: it evaluates the log-pdf directly rather than round-tripping through `pt.log(pt.exp(...))`, preserving the underflow-avoidance behavior that `TestGaussianLogLikelihood` in `tests/test_log_space_likelihood.py` exercises (parity with `log(likelihood())`, agreement with `scipy.stats.norm.logpdf`, and finiteness at `|z|=40` where `likelihood()` underflows to 0).

Refs #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
