### PR TITLE
docs: jaxify the log-space graph in the transpile example

### DIFF
--- a/src/pyhs3/transpile.py
+++ b/src/pyhs3/transpile.py
@@ -55,12 +55,19 @@ class JaxifiedGraph:
         original PyTensor variable names, so kwargs are forwarded directly.
         Python itself raises ``TypeError`` for missing or unexpected names.
 
-        The typical usage pattern with optimistix or everwillow is::
+        The typical usage pattern with optimistix or everwillow is to jaxify
+        the log-space graph directly (e.g. ``model.log_prob``) rather than
+        jaxifying a probability-space pdf and taking ``jnp.log`` of the
+        result — the latter underflows to ``-inf`` for realistic HistFactory
+        channels, where the probability-space product can be smaller than
+        the smallest representable float::
+
+            jg = jaxify(model.log_prob)
 
             @jax.jit
             def nll(free_params):          # free_params is a dict pytree
                 all_params = {**free_params, **fixed_params}
-                return -2 * jnp.log(jg(**all_params)[0])
+                return -2 * jg(**all_params)[0]
 
         Parameters
         ----------

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -38,6 +38,25 @@ def _gaussian_pytensor_expr() -> tuple[
     return x, mu, sigma, pdf_expr
 
 
+def _gaussian_log_pytensor_expr() -> tuple[
+    pt.TensorVariable, pt.TensorVariable, pt.TensorVariable, pt.TensorVariable
+]:
+    """Return (x, mu, sigma, log_pdf_expr) as pytensor scalars.
+
+    Built directly in log-space (no ``pt.log`` of a probability-space pdf),
+    mirroring how ``Model.log_prob`` is constructed to avoid underflow.
+    """
+    x = pt.scalar("x")
+    mu = pt.scalar("mu")
+    sigma = pt.scalar("sigma")
+    log_pdf_expr = (
+        -0.5 * ((x - mu) / sigma) ** 2
+        - pt.log(sigma)
+        - 0.5 * pt.log(pt.constant(2 * math.pi, dtype="float64"))
+    )
+    return x, mu, sigma, log_pdf_expr
+
+
 # ---------------------------------------------------------------------------
 # jaxify — basic smoke tests
 # ---------------------------------------------------------------------------
@@ -149,15 +168,21 @@ class TestJaxifiedGraphCall:
             jaxify(pdf_expr)
 
     def test_pytree_dict_usage(self):
-        """Typical everwillow/optimistix pattern: nll takes a dict pytree."""
-        _, _, _, pdf_expr = _gaussian_pytensor_expr()
-        jg = jaxify(pdf_expr)
+        """Typical everwillow/optimistix pattern: nll takes a dict pytree.
+
+        Jaxifies the log-space expression directly (as ``model.log_prob``
+        does) rather than jaxifying a probability-space pdf and taking
+        ``jnp.log`` of the result, which underflows for realistic
+        HistFactory channels.
+        """
+        _, _, _, log_pdf_expr = _gaussian_log_pytensor_expr()
+        jg = jaxify(log_pdf_expr)
         fixed_x = jnp.float64(0.0)
 
         @jax.jit
         def nll(free_params: dict) -> object:
             all_params = {**free_params, "x": fixed_x}
-            return -2 * jnp.log(jg(**all_params)[0])
+            return -2 * jg(**all_params)[0]
 
         free = {"mu": jnp.float64(0.0), "sigma": jnp.float64(1.0)}
         result = nll(free)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #278

The `JaxifiedGraph.__call__` docstring in `src/pyhs3/transpile.py` still advertised the pre-#234 pattern of jaxifying a probability-space pdf and taking `jnp.log` of the JAX-side result. That underflows to `-inf` for realistic HistFactory channels, where the probability-space product can be smaller than the smallest representable float.

**Before:**

```python
@jax.jit
def nll(free_params):          # free_params is a dict pytree
    all_params = {**free_params, **fixed_params}
    return -2 * jnp.log(jg(**all_params)[0])
```

**After:**

```python
jg = jaxify(model.log_prob)

@jax.jit
def nll(free_params):          # free_params is a dict pytree
    all_params = {**free_params, **fixed_params}
    return -2 * jg(**all_params)[0]
```

This matches how `Model.log_prob` is already built internally (see the `log_distributions` / `_hfdc_log_*` comments in `model.py`) — the log-space graph is constructed directly rather than derived from `pt.log()` of a probability-space expression.

Also updated `tests/test_transpile.py::TestJaxifiedGraphCall::test_pytree_dict_usage`, which demonstrated the same old `jaxify(pdf)` + `jnp.log` pattern, to jaxify a log-space expression instead.

## Verification

Ran the corrected example end-to-end against a small two-channel Gaussian workspace (reusing the fixture from `tests/test_model_likelihood.py`) under `pixi run --environment py312-jax`:

- `jg = jaxify(model.log_prob)`; `-2 * jg(**all_params)[0]` → `[43.12242576]` (finite, no `jnp.log` call anywhere)
- At nominal parameters, the old `jaxify(pdf)` + `jnp.log` route and the new `jaxify(log_pdf)` route agree exactly: both give a per-event `-2*logpdf` sum of `24.18938533204672`

Also ran:
- `pixi run --environment py312-jax python -m pytest tests/test_transpile.py -v` — 12 passed
- `pixi run --environment py312 test` — 1169 passed, 3 skipped (JAX not installed in that env), 1 xfailed
- `pixi run --environment dev bash -c "pre-commit run --files src/pyhs3/transpile.py tests/test_transpile.py"` — all hooks passed

## Test plan

- [x] `pixi run --environment py312-jax python -m pytest tests/test_transpile.py -v`
- [x] `pixi run --environment py312 test`
- [x] `pre-commit run --files src/pyhs3/transpile.py tests/test_transpile.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage guidance to recommend working directly with log-probability expressions.
  * Added clarification that probability-space calculations can underflow to negative infinity.

* **Tests**
  * Updated Gaussian expression tests to use log-space calculations.
  * Added coverage for computing negative log-likelihoods from jaxified log-probability expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->