### PR TITLE
refactor: unify Model on a single log-space compiled pipeline

### DIFF
--- a/src/pyhs3/model.py
+++ b/src/pyhs3/model.py
@@ -52,23 +52,30 @@ class Model:
     and distributions, ensuring proper evaluation order through topological
     sorting of the computation graph.
 
+    **Single log-space pipeline.** Every distribution node is built exactly
+    once, in log space, as ``self.log_distributions[name]``; the
+    probability-space counterpart ``self.distributions[name]`` is always
+    derived as ``pt.exp(self.log_distributions[name])`` rather than built
+    independently, so the two can never disagree on normalization or on their
+    free inputs -- :meth:`pars` is therefore valid for both :meth:`pdf` and
+    :meth:`logpdf` by construction.
+
     **HFDC constraint storage.** For ``HistFactoryDistChannel`` distributions,
-    ``self.distributions[name]`` stores the full per-channel expression
-    (main Poisson x constraint product) so that ``logpdf(name, **params)``
-    matches pyhf/cabinetry semantics for callers asking about a single
-    channel's probability.  ``self._hfdc_poisson[name]`` stores only the
-    main Poisson term; ``log_prob`` uses it to assemble the joint NLL without
-    double-counting constraint factors when multiple channels share a nuisance
-    parameter.  Constraint expressions are appended to
-    ``self._hfdc_constraints`` (probability space) and, in lockstep,
-    ``self._hfdc_log_constraints`` (log space) exactly once per unique dedup
-    key across all channels: single-parameter modifiers (``normsys``,
-    ``histosys``) are deduped by parameter name using
-    ``self._hfdc_constraint_params_seen``; multi-parameter modifiers
-    (``shapesys``, ``staterror``) are channel-local by workspace validation
-    and always emitted as-is.  ``log_prob`` sums ``self._hfdc_log_constraints``
-    directly rather than taking ``pt.log`` of ``self._hfdc_constraints``, so it
-    stays finite where the probability-space constraints underflow to 0.0.
+    ``self.log_distributions[name]`` stores the full per-channel log
+    expression (summed Poisson log-pmf plus summed log-constraints) so that
+    ``logpdf(name, **params)`` matches pyhf/cabinetry semantics for callers
+    asking about a single channel's probability; ``self.distributions[name]``
+    is ``pt.exp`` of that.  ``self._hfdc_log_poisson[name]`` stores only the
+    log-space Poisson term; ``log_prob`` uses it to assemble the joint NLL
+    without double-counting constraint factors when multiple channels share a
+    nuisance parameter.  Log-space constraint expressions are appended to
+    ``self._hfdc_log_constraints`` exactly once per unique dedup key across
+    all channels: single-parameter modifiers (``normsys``, ``histosys``) are
+    deduped by parameter name using ``self._hfdc_constraint_params_seen``;
+    multi-parameter modifiers (``shapesys``, ``staterror``) are channel-local
+    by workspace validation and always emitted as-is.  ``log_prob`` sums
+    ``self._hfdc_log_constraints`` directly, so it stays finite where a
+    probability-space constraint would underflow to 0.0.
 
     HS3 Reference:
         Models are computational representations of :hs3:label:`HS3 workspaces <hs3.file-format>`.
@@ -127,48 +134,44 @@ class Model:
         self.distributions: dict[str, TensorVar] = {}
         self.modifiers: dict[str, TensorVar] = {}
         self.mode = mode
+        # Compiled-function caches: one per output (probability-space vs
+        # log-space), since each compiles a different expression down to its
+        # own Callable.  But the two expressions differ only by the trailing
+        # pt.exp() wrapper (self.distributions[name] is always
+        # pt.exp(self.log_distributions[name])), so their free inputs are
+        # identical by construction -- _compiled_inputs/_compiled_input_names
+        # are therefore a single cache shared by both compile paths (see
+        # _compile_expression), populated by whichever of pdf()/logpdf()/
+        # pars() compiles first.
         self._compiled_functions: dict[str, Callable[..., npt.NDArray[np.float64]]] = {}
+        self._compiled_log_functions: dict[
+            str, Callable[..., npt.NDArray[np.float64]]
+        ] = {}
         self._compiled_inputs: dict[str, list[TensorVar]] = {}
         # Ordered input names cached alongside _compiled_inputs so that pars()
         # and _reorder_params() avoid rebuilding the list on every pdf/logpdf call.
         self._compiled_input_names: dict[str, list[str]] = {}
-        # Log-space distribution expressions (dist.log_expression(context)), built
-        # alongside self.distributions during graph construction.  logpdf and
-        # log_prob use these to evaluate in log space so that log(prod(exp(...)))
-        # stays collapsed and does not underflow to -inf.  Compiled log functions
-        # are cached separately from the probability-space ones.
+        # Log-space distribution expressions (dist.log_expression(context)), the
+        # only expression built per distribution node.  self.distributions is
+        # always pt.exp() of the corresponding entry here (see
+        # _build_distribution_node).  logpdf and log_prob use these to
+        # evaluate in log space so that log(prod(exp(...))) stays collapsed
+        # and does not underflow to -inf.
         self.log_distributions: dict[str, TensorVar] = {}
-        self._compiled_log_functions: dict[
-            str, Callable[..., npt.NDArray[np.float64]]
-        ] = {}
-        self._compiled_log_inputs: dict[str, list[TensorVar]] = {}
-        # Ordered log-input names cached alongside _compiled_log_inputs, mirroring
-        # _compiled_input_names for the prob-space path so log_pars() avoids
-        # rebuilding the list via a comprehension on every logpdf call.
-        self._compiled_log_input_names: dict[str, list[str]] = {}
         self._likelihood = likelihood
         # Views used internally for broadcasting: leaf[:, None] for observables,
         # leaf[None, :] for non-observable vector overrides.  Distributions see
         # these via Context; model.parameters[name] always holds the leaf.
         self._views: dict[str, TensorVar] = {}
-        # Pre-built HFDC constraint expressions, collected during graph construction.
-        # ParameterModifier constraints are deduped by parameter name across channels;
-        # ParametersModifier constraints (shapesys/staterror) are emitted per-channel.
-        self._hfdc_constraints: list[TensorVar] = []
-        # Log-space counterpart of self._hfdc_constraints, built alongside it
-        # (one modifier.log_constraint() call per modifier.make_constraint()
-        # call) so log_prob never has to take pt.log() of a probability-space
-        # constraint that can underflow to 0.0.
+        # Pre-built HFDC log-space constraint expressions, collected during
+        # graph construction. ParameterModifier constraints are deduped by
+        # parameter name across channels; ParametersModifier constraints
+        # (shapesys/staterror) are emitted per-channel.
         self._hfdc_log_constraints: list[TensorVar] = []
         self._hfdc_constraint_params_seen: set[str] = set()
-        # Poisson-only (no constraint product) expressions for HFDC channels.
-        # self.distributions[name] stores the full expression (Poisson x constraints)
-        # so that logpdf() continues to work; log_prob uses this dict to avoid
-        # double-counting constraint terms when multiple channels share a parameter.
-        self._hfdc_poisson: dict[str, TensorVar] = {}
-        # Log-space counterpart of self._hfdc_poisson: the summed per-bin Poisson
-        # log-pmf for each HFDC channel.  log_prob uses this instead of
-        # log(self._hfdc_poisson[name]) so the joint NLL stays finite where the
+        # Log-space Poisson-only (no constraint sum) expression for each HFDC
+        # channel: the summed per-bin Poisson log-pmf. log_prob uses this
+        # instead of log(exp(...)) so the joint NLL stays finite where the
         # probability-space product would underflow.
         self._hfdc_log_poisson: dict[str, TensorVar] = {}
         # Build dependency graph with proper entity identification
@@ -373,9 +376,10 @@ class Model:
             )
 
         # HFDC constraint terms: collected once per unique nuisance parameter
-        # across all channels during graph construction. Log-space terms are
-        # used directly (rather than pt.log(self._hfdc_constraints)) so this
-        # stays finite where the probability-space constraints underflow to 0.0.
+        # across all channels during graph construction. These are log-space
+        # terms built directly (not pt.log() of a probability-space product),
+        # so this stays finite where a probability-space constraint would
+        # underflow to 0.0.
         terms.extend(self._hfdc_log_constraints)
 
         if not terms:
@@ -489,34 +493,40 @@ class Model:
     def _build_distribution_node(
         self, node_name: str, distributions: Distributions, context: Context
     ) -> TensorVar:
-        """Build a distribution node by evaluating its symbolic expression.
+        """Build a distribution node from its log-space expression.
 
-        For HistFactoryDistChannel the full expression (Poisson x constraints)
-        is returned and stored in ``self.distributions`` so that :meth:`logpdf`
-        continues to work as before.  In addition, the Poisson-only term is
-        stored in ``self._hfdc_poisson`` and the deduplicated constraint terms
-        are appended to ``self._hfdc_constraints``/``self._hfdc_log_constraints``
-        so that :attr:`log_prob` can combine them without double-counting when
-        multiple channels share a nuisance parameter.
+        Only the log-space expression is built per node; the probability-
+        space counterpart stored in ``self.distributions`` is always
+        ``pt.exp()`` of it, so the two agree by construction (no separate
+        probability-space graph to keep in sync, and identical free inputs
+        for :meth:`pars`).
+
+        For HistFactoryDistChannel, the full expression is assembled directly
+        in log space and stored in ``self.log_distributions`` so that
+        :meth:`logpdf` continues to work as before.  In addition, the
+        Poisson-only log term is stored in ``self._hfdc_log_poisson`` and the
+        deduplicated log-constraint terms are appended to
+        ``self._hfdc_log_constraints`` so that :attr:`log_prob` can combine
+        them without double-counting when multiple channels share a nuisance
+        parameter.
         """
         dist = distributions[node_name]
         if not isinstance(dist, HistFactoryDistChannel):
-            # Build the log-space expression once for logpdf/log_prob (collapses
-            # log(prod(exp(...))) so it does not underflow to -inf).
-            self.log_distributions[node_name] = dist.log_expression(context)
-            return dist.expression(context)
+            log_expr = dist.log_expression(context)
+            self.log_distributions[node_name] = log_expr
+            full = cast(TensorVar, pt.exp(log_expr))
+            full.name = dist.name  # Evaluable.expression sets the name
+            return full
 
-        # Build the Poisson term and each constraint factor exactly once, then
-        # assemble the model-level deduped constraint list and both the
-        # probability-space and log-space per-channel expressions from those
-        # shared pieces.  This mirrors Distribution._expression/log_expression
-        # (likelihood -> normalization -> x/+ constraints) and
-        # HistFactoryDistChannel.extended_likelihood/log_extended_likelihood
-        # without rebuilding the Poisson subgraph or re-running
-        # make_constraint/log_constraint a second time.
-        poisson = dist.likelihood(context)
-        self._hfdc_poisson[node_name] = poisson
-        # Log-space Poisson-only term (sum of per-bin Poisson log-pmfs).
+        # Build the log-space Poisson term and each log-space constraint
+        # factor exactly once, then assemble the model-level deduped
+        # constraint list and the full per-channel log expression from those
+        # shared pieces.  This mirrors HistFactoryDistChannel.log_expression/
+        # log_extended_likelihood without rebuilding the Poisson subgraph or
+        # re-running log_constraint a second time.  The probability-space
+        # Poisson term and per-modifier make_constraint() are never called
+        # here: the probability-space channel expression is derived below as
+        # pt.exp() of the log expression instead.
         log_poisson = dist.log_likelihood(context)
         self._hfdc_log_poisson[node_name] = log_poisson
 
@@ -528,22 +538,19 @@ class Model:
             for d in self._likelihood.distributions
         )
 
-        # Single pass over constraint specs builds each constraint factor (both
-        # probability- and log-space) exactly once.
-        # - channel_seen dedups by parameter for the per-channel product
-        #   (matches extended_likelihood's local dedup),
+        # Single pass over constraint specs builds each log-constraint factor
+        # exactly once.
+        # - channel_seen dedups by parameter for the per-channel sum (matches
+        #   log_extended_likelihood's local dedup),
         # - self._hfdc_constraint_params_seen dedups across channels for log_prob.
         channel_seen: set[str] = set()
-        channel_constraints: list[TensorVar] = []
         channel_log_constraints: list[TensorVar] = []
         for dedup_key, modifier, sample_data in dist.constraint_specs():
-            constraint = modifier.make_constraint(context, sample_data)
             log_constraint = modifier.log_constraint(context, sample_data)
 
             if dedup_key is None or dedup_key not in channel_seen:
                 if dedup_key is not None:
                     channel_seen.add(dedup_key)
-                channel_constraints.append(constraint)
                 channel_log_constraints.append(log_constraint)
 
             if in_likelihood:
@@ -551,55 +558,42 @@ class Model:
                     if dedup_key in self._hfdc_constraint_params_seen:
                         continue
                     self._hfdc_constraint_params_seen.add(dedup_key)
-                self._hfdc_constraints.append(constraint)
                 self._hfdc_log_constraints.append(log_constraint)
 
         # BB-lite mode's channel-level constraint (shared gamma parameters
         # combining all samples' statistical uncertainties) is not a
         # per-modifier spec, so constraint_specs() cannot yield it -- mirror
-        # extended_likelihood's channel-level addition here.  It is
+        # log_extended_likelihood's channel-level addition here.  It is
         # channel-local (like shapesys/staterror dedup_key=None specs above),
         # so it is always appended, with no cross-channel dedup key.
         if dist.barlow_beeston_method == "lite":
-            lite_constraint = dist._make_barlow_beeston_lite_constraint(context)  # pylint: disable=protected-access
             lite_log_constraint = dist._make_barlow_beeston_lite_log_constraint(  # pylint: disable=protected-access
                 context
             )
-            if lite_constraint is not None:
-                channel_constraints.append(lite_constraint)
-                channel_log_constraints.append(cast(TensorVar, lite_log_constraint))
+            if lite_log_constraint is not None:
+                channel_log_constraints.append(lite_log_constraint)
                 if in_likelihood:
-                    self._hfdc_constraints.append(lite_constraint)
-                    self._hfdc_log_constraints.append(
-                        cast(TensorVar, lite_log_constraint)
-                    )
+                    self._hfdc_log_constraints.append(lite_log_constraint)
 
-        # Assemble the full per-channel expression: normalized Poisson term times
-        # the constraint product (extended likelihood).  HFDC is not normalizable
-        # (_normalizable defaults False here), so _apply_normalization is a no-op,
-        # but call it to stay faithful to Distribution._expression.
-        raw = dist._apply_normalization(poisson, context)  # pylint: disable=protected-access
-        if not channel_constraints:
-            extended: TensorVar = cast(TensorVar, pt.constant(1.0))
+        # Assemble the full per-channel log expression: summed Poisson log-pmf
+        # plus summed log-constraints (mirrors HistFactoryDistChannel.log_expression
+        # and log_extended_likelihood, reusing the pieces built above instead of
+        # calling dist.log_expression(context), which would rebuild log_poisson
+        # and re-run log_constraint for every spec).
+        if not channel_log_constraints:
             log_extended: TensorVar = cast(TensorVar, pt.constant(0.0))
         else:
-            extended = cast(
-                TensorVar,
-                pt.prod(pt.stack(channel_constraints)),  # type: ignore[no-untyped-call]
-            )
             log_extended = cast(
                 TensorVar,
                 pt.sum(pt.stack(channel_log_constraints)),  # type: ignore[no-untyped-call]
             )
-        full = cast(TensorVar, raw * extended)
-        full.name = dist.name  # Evaluable.expression sets the name
+        log_full = cast(TensorVar, log_poisson + log_extended)
+        self.log_distributions[node_name] = log_full
 
-        # Full per-channel log expression (Poisson + constraints) for logpdf(),
-        # assembled from the pieces built above (mirrors
-        # HistFactoryDistChannel.log_expression) instead of calling
-        # dist.log_expression(context), which would rebuild log_poisson and
-        # re-run make_constraint for every spec.
-        self.log_distributions[node_name] = cast(TensorVar, log_poisson + log_extended)
+        # Probability-space per-channel expression, derived rather than
+        # rebuilt from the (unused) probability-space Poisson/constraint terms.
+        full = cast(TensorVar, pt.exp(log_full))
+        full.name = dist.name  # Evaluable.expression sets the name
         return full
 
     def _build_dependency_graph(
@@ -696,48 +690,66 @@ class Model:
     def _compile_expression(
         self,
         name: str,
-        expressions: dict[str, TensorVar],
+        expression: TensorVar,
         compiled_functions: dict[str, Callable[..., npt.NDArray[np.float64]]],
-        compiled_inputs: dict[str, list[TensorVar]],
-        compiled_input_names: dict[str, list[str]],
         fn_name: str,
     ) -> Callable[..., npt.NDArray[np.float64]]:
         """
-        Get or create a compiled PyTensor function for an expression dict entry.
+        Get or create a compiled PyTensor function for a single expression.
 
         Shared by :meth:`_get_compiled_function` and
         :meth:`_get_compiled_log_function`, which differ only in which
-        expression dict (probability-space or log-space) they compile from
-        and which cache dicts they read and populate.
+        expression (probability-space ``self.distributions[name]`` or
+        log-space ``self.log_distributions[name]``) they compile and which
+        function cache they populate.
+
+        The probability-space expression is always ``pt.exp()`` of the
+        log-space one (see :meth:`_build_distribution_node`), so the two
+        graphs share identical free inputs by construction.
+        ``self._compiled_inputs``/``self._compiled_input_names`` are therefore
+        a single cache shared by both compile paths, populated by whichever
+        one compiles first; the second path validates (rather than
+        recomputes) the ordering against that shared cache.
 
         Args:
-            name (str): Key into ``expressions`` and the cache dicts.
-            expressions: Distribution expressions to compile from
-                (``self.distributions`` or ``self.log_distributions``).
-            compiled_functions: Cache of compiled functions to read and populate.
-            compiled_inputs: Cache of ordered input variables to populate.
-            compiled_input_names: Cache of ordered input names to populate.
+            name (str): Key into ``compiled_functions`` and the shared input caches.
+            expression: The distribution expression to compile.
+            compiled_functions: Cache of compiled functions to read and populate
+                (``self._compiled_functions`` or ``self._compiled_log_functions``).
             fn_name (str): Name to give the compiled PyTensor function.
 
         Returns:
             Callable: Compiled PyTensor function.
+
+        Raises:
+            RuntimeError: If this expression's free inputs do not match the
+                already-cached ordering from the other compile path -- this
+                would violate the pt.exp()-derivation invariant above.
         """
         if name not in compiled_functions:
-            expression = expressions[name]
-
             inputs = [
                 var
                 for var in explicit_graph_inputs([expression])
                 if var.name is not None
             ]
+            input_names = [var.name for var in inputs if var.name is not None]
 
-            # Cache the inputs list (and their names) for consistent ordering so
-            # pars()/log_pars() and _reorder_params()/_reorder_log_params() don't
-            # rebuild the name list per evaluation.
-            compiled_inputs[name] = cast(list[TensorVar], inputs)
-            compiled_input_names[name] = [
-                var.name for var in inputs if var.name is not None
-            ]
+            if name in self._compiled_input_names:
+                cached_names = self._compiled_input_names[name]
+                if input_names != cached_names:
+                    msg = (
+                        f"pdf/logpdf input mismatch for distribution '{name}': "
+                        f"{input_names} vs already-cached {cached_names}. "
+                        "The probability- and log-space expressions are expected "
+                        "to share identical free inputs by construction."
+                    )
+                    raise RuntimeError(msg)
+            else:
+                # Cache the inputs list (and their names) for consistent ordering
+                # so pars() and _reorder_params() don't rebuild the name list per
+                # evaluation, and so the other compile path can validate against it.
+                self._compiled_inputs[name] = cast(list[TensorVar], inputs)
+                self._compiled_input_names[name] = input_names
 
             compiled_functions[name] = cast(
                 Callable[..., npt.NDArray[np.float64]],
@@ -769,10 +781,8 @@ class Model:
         """
         return self._compile_expression(
             name,
-            self.distributions,
+            self.distributions[name],
             self._compiled_functions,
-            self._compiled_inputs,
-            self._compiled_input_names,
             name,
         )
 
@@ -796,10 +806,8 @@ class Model:
         """
         return self._compile_expression(
             name,
-            self.log_distributions,
+            self.log_distributions[name],
             self._compiled_log_functions,
-            self._compiled_log_inputs,
-            self._compiled_log_input_names,
             f"log_{name}",
         )
 
@@ -935,58 +943,34 @@ class Model:
             >>> model.logpdf("gauss", x=np.array(1.5), mu=np.array(0.0), sigma=np.array(1.0))  # doctest: +SKIP
         """
         func = self._get_compiled_log_function(name)
-        positional_values = self._reorder_log_params(name, parametervalues)
+        positional_values = self._reorder_params(name, parametervalues)
         return func(*positional_values)
-
-    def _get_pars(
-        self,
-        name: str,
-        compiled_input_names: dict[str, list[str]],
-        compile_fn: Callable[[str], Callable[..., npt.NDArray[np.float64]]],
-    ) -> list[str]:
-        """
-        Get the ordered input parameter names, compiling to populate the cache
-        if needed.
-
-        Shared by :meth:`pars` and :meth:`log_pars`, which differ only in
-        which cache dict and which compilation method populate it.
-
-        Args:
-            name: Distribution name
-            compiled_input_names: Cache of ordered input names to read/populate
-                (``self._compiled_input_names`` or ``self._compiled_log_input_names``).
-            compile_fn: Compilation method to call to populate the cache
-                (:meth:`_get_compiled_function` or :meth:`_get_compiled_log_function`).
-
-        Returns:
-            List of parameter names in the cached order
-        """
-        if name not in compiled_input_names:
-            # Trigger compilation to populate cache
-            compile_fn(name)
-        return compiled_input_names[name]
 
     def pars(self, name: str) -> list[str]:
         """
         Get the ordered list of input parameter names for a distribution.
 
         This method returns the parameter names in the exact order expected
-        by the compiled PDF function. This is useful when you need to know
-        the order of parameters for programmatic access.
+        by the compiled PDF function. Since the probability- and log-space
+        expressions for a distribution share identical free inputs by
+        construction (:meth:`pdf` evaluates ``pt.exp()`` of exactly what
+        :meth:`logpdf` evaluates), this same ordering is valid for both
+        :meth:`pdf` and :meth:`logpdf`.
 
         Args:
             name: Distribution name
 
         Returns:
-            List of parameter names in the order expected by pdf()
+            List of parameter names in the order expected by pdf() and logpdf()
 
         Example:
             >>> model.pars("model_singlechannel") # doctest: +SKIP
             ['uncorr_bkguncrt_1', 'uncorr_bkguncrt_0', 'model_singlechannel_observed', 'mu', 'Lumi']
         """
-        return self._get_pars(
-            name, self._compiled_input_names, self._get_compiled_function
-        )
+        if name not in self._compiled_input_names:
+            # Trigger compilation to populate the shared cache.
+            self._get_compiled_function(name)
+        return self._compiled_input_names[name]
 
     def parsort(self, name: str, names: list[str]) -> list[int]:
         """
@@ -1006,30 +990,6 @@ class Model:
         """
         return [names.index(par) for par in self.pars(name)]
 
-    def _reorder_by_pars(
-        self,
-        name: str,
-        params: Mapping[str, npt.NDArray[np.float64]],
-        pars_fn: Callable[[str], list[str]],
-    ) -> list[npt.NDArray[np.float64]]:
-        """
-        Reorder parameters to match an input order.
-
-        Shared by :meth:`_reorder_params` and :meth:`_reorder_log_params`,
-        which differ only in which method supplies the input order.
-
-        Args:
-            name: Distribution name
-            params: Dictionary of parameter values (numpy arrays)
-            pars_fn: Method supplying the ordered input names (:meth:`pars`
-                or :meth:`log_pars`).
-
-        Returns:
-            List of values in the order given by ``pars_fn``
-        """
-        input_order = pars_fn(name)
-        return [params[param_name] for param_name in input_order]
-
     def _reorder_params(
         self,
         name: str,
@@ -1038,6 +998,9 @@ class Model:
         """
         Reorder parameters to match the expected input order for a distribution.
 
+        Used by both :meth:`pdf` and :meth:`logpdf`: :meth:`pars` returns the
+        same ordering for either compiled function.
+
         Args:
             name: Distribution name
             params: Dictionary of parameter values (numpy arrays)
@@ -1045,42 +1008,8 @@ class Model:
         Returns:
             List of values in the correct order for the compiled function
         """
-        return self._reorder_by_pars(name, params, self.pars)
-
-    def log_pars(self, name: str) -> list[str]:
-        """
-        Get the ordered input parameter names for a distribution's log-PDF.
-
-        Like :meth:`pars`, but for the compiled log-PDF function (:meth:`logpdf`).
-        The log-space expression can have a different set or ordering of inputs
-        than the probability-space one, so it has its own cached ordering.
-
-        Args:
-            name: Distribution name
-
-        Returns:
-            List of parameter names in the order expected by logpdf()
-        """
-        return self._get_pars(
-            name, self._compiled_log_input_names, self._get_compiled_log_function
-        )
-
-    def _reorder_log_params(
-        self,
-        name: str,
-        params: Mapping[str, npt.NDArray[np.float64]],
-    ) -> list[npt.NDArray[np.float64]]:
-        """
-        Reorder parameters to match the input order of a distribution's log-PDF.
-
-        Args:
-            name: Distribution name
-            params: Dictionary of parameter values (numpy arrays)
-
-        Returns:
-            List of values in the correct order for the compiled log function
-        """
-        return self._reorder_by_pars(name, params, self.log_pars)
+        input_order = self.pars(name)
+        return [params[param_name] for param_name in input_order]
 
     def visualize_graph(
         self,

--- a/tests/test_hfdc_model_constraints.py
+++ b/tests/test_hfdc_model_constraints.py
@@ -850,12 +850,14 @@ def _single_channel_normsys_workspace() -> Workspace:
 class TestHFDCSubgraphBuildCounts:
     """Model construction must build each HFDC subgraph exactly once.
 
-    ``_build_distribution_node`` previously called ``dist.likelihood(context)``,
-    ``dist.log_likelihood(context)``, and ``dist.log_expression(context)`` for
-    the same context; the last call internally re-ran ``log_likelihood`` (which
-    recomputes expected_rates) and ``log_extended_likelihood`` (which reruns
-    ``make_constraint`` for every constraint spec), duplicating work already
-    done for the probability-space expression and the constraint loop below it.
+    ``_build_distribution_node`` builds only the log-space expression for a
+    channel (summed Poisson log-pmf plus summed log-constraints); the
+    probability-space expression is derived as ``pt.exp()`` of it rather than
+    built independently, so ``dist.likelihood(context)`` and
+    ``modifier.make_constraint(...)`` (the probability-space counterparts) are
+    never called during model construction -- only their log-space
+    counterparts, ``dist.log_likelihood(context)`` and
+    ``modifier.log_constraint(...)``, are.
     """
 
     def test_compute_expected_rates_called_once_per_channel(self, monkeypatch):
@@ -880,10 +882,11 @@ class TestHFDCSubgraphBuildCounts:
             f"expected exactly one _compute_expected_rates call per channel, got {calls}"
         )
 
-    def test_make_constraint_called_once_per_spec(self, monkeypatch):
-        """``make_constraint`` must build each constraint factor exactly once
-        during model construction, regardless of how many places (probability-space
-        expression, log-space expression, joint log_prob) reuse the result."""
+    def test_make_constraint_not_called(self, monkeypatch):
+        """``make_constraint`` (the probability-space constraint term) must
+        never be called during model construction: the probability-space
+        per-channel expression is derived as ``pt.exp()`` of the log-space
+        one (built from ``log_constraint`` below), not built independently."""
         calls: list[str] = []
         original = SingleParamConstraint.make_constraint
 
@@ -899,14 +902,11 @@ class TestHFDCSubgraphBuildCounts:
         likelihood = next(iter(ws.likelihoods))
         ws.model(likelihood, progress=False)
 
-        assert calls == ["lumi"], (
-            f"expected exactly one make_constraint call per constraint spec, got {calls}"
-        )
+        assert calls == [], f"expected make_constraint to never be called, got {calls}"
 
     def test_log_constraint_called_once_per_spec(self, monkeypatch):
         """``log_constraint`` (#243 Layer 2) must build each log-space constraint
-        factor exactly once during model construction, alongside the single
-        ``make_constraint`` call asserted above."""
+        factor exactly once during model construction."""
         calls: list[str] = []
         original = SingleParamConstraint.log_constraint
 
@@ -928,8 +928,8 @@ class TestHFDCSubgraphBuildCounts:
 
     def test_logpdf_matches_log_pdf_for_hfdc_with_constraint(self):
         """logpdf(channel) must equal log(pdf(channel)) for an HFDC channel with
-        a constraint modifier, confirming log_distributions is assembled from
-        the same pieces as the probability-space expression."""
+        a constraint modifier, confirming the probability-space expression
+        (pt.exp() of the log-space one) is numerically consistent."""
         ws = _single_channel_normsys_workspace()
         likelihood = next(iter(ws.likelihoods))
         model = ws.model(likelihood, progress=False)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -960,29 +960,47 @@ class TestModelParameterOrdering:
         assert isinstance(param_list, list)
         assert len(param_list) > 0
 
-    def test_log_pars_triggers_compilation(self, simple_workspace):
-        """Test that log_pars() triggers log compilation if not already compiled."""
+    def test_logpdf_populates_shared_pars_cache(self, simple_workspace):
+        """Compiling the log-space function alone (without ever calling pdf())
+        must populate the same shared input-name cache that pars() reads,
+        since the probability- and log-space expressions share identical free
+        inputs by construction (pdf() evaluates pt.exp() of exactly what
+        logpdf() evaluates)."""
         model = simple_workspace.model(0, mode="FAST_RUN")
 
-        # Before calling log_pars, neither cache should be populated
-        assert "gauss" not in model._compiled_log_inputs
-        assert "gauss" not in model._compiled_log_input_names
+        # Before calling logpdf, neither compiled-function cache is populated.
+        assert "gauss" not in model._compiled_functions
+        assert "gauss" not in model._compiled_log_functions
+        assert "gauss" not in model._compiled_input_names
 
-        # Call log_pars - should trigger compilation of the log function
-        param_list = model.log_pars("gauss")
+        model.logpdf_unsafe("gauss", x=0.0, mu=0.0, sigma=1.0)
 
-        # After calling log_pars, both caches should be populated
-        assert "gauss" in model._compiled_log_inputs
-        assert "gauss" in model._compiled_log_input_names
-
-        # log_pars returns the pre-built cached list (mirrors pars())
-        assert param_list is model._compiled_log_input_names["gauss"]
-
-        # Should return valid parameter list
-        assert isinstance(param_list, list)
+        # logpdf() compiled only the log-space function...
+        assert "gauss" in model._compiled_log_functions
+        assert "gauss" not in model._compiled_functions
+        # ...but the shared pars() cache is already populated from it.
+        assert "gauss" in model._compiled_input_names
+        param_list = model.pars("gauss")
         assert "x" in param_list
         assert "mu" in param_list
         assert "sigma" in param_list
+        # pars() must not have triggered a redundant probability-space compile.
+        assert "gauss" not in model._compiled_functions
+
+    def test_pars_ordering_identical_for_pdf_and_logpdf(self, simple_workspace):
+        """pars(name) must return the same ordering whether the probability-
+        space or the log-space compiled function is built first (issue #276
+        acceptance criterion: a single shared ordering is valid for both
+        pdf() and logpdf())."""
+        model_pdf_first = simple_workspace.model(0, mode="FAST_RUN")
+        model_pdf_first.pdf_unsafe("gauss", x=0.0, mu=0.0, sigma=1.0)
+        pars_from_pdf = model_pdf_first.pars("gauss")
+
+        model_logpdf_first = simple_workspace.model(0, mode="FAST_RUN")
+        model_logpdf_first.logpdf_unsafe("gauss", x=0.0, mu=0.0, sigma=1.0)
+        pars_from_logpdf = model_logpdf_first.pars("gauss")
+
+        assert pars_from_pdf == pars_from_logpdf
 
     def test_pars_order_matches_pdf_inputs(self, simple_workspace):
         """Test that pars() order matches what pdf() expects."""
@@ -1121,6 +1139,33 @@ class TestModelParameterOrdering:
         # Should raise an error when distribution doesn't exist
         with pytest.raises(KeyError):
             model.parsort("nonexistent_dist", ["x", "mu"])
+
+    def test_compile_expression_raises_on_input_mismatch(
+        self, simple_workspace, monkeypatch
+    ):
+        """_compile_expression() must raise RuntimeError if the second compile
+        path (pdf or logpdf, whichever runs second) ever finds different free
+        inputs than the first -- this would violate the invariant that the
+        probability- and log-space expressions share identical free inputs by
+        construction (one is pt.exp() of the other)."""
+        model = simple_workspace.model(0, mode="FAST_RUN")
+
+        # Compile the log-space function first to populate the shared cache.
+        model._get_compiled_log_function("gauss")
+        assert "gauss" in model._compiled_input_names
+
+        # Simulate a divergent input list for the probability-space compile.
+        original = hs3.model.explicit_graph_inputs
+
+        def fake_explicit_graph_inputs(exprs):
+            return [var for var in original(exprs) if var.name != "sigma"]
+
+        monkeypatch.setattr(
+            hs3.model, "explicit_graph_inputs", fake_explicit_graph_inputs
+        )
+
+        with pytest.raises(RuntimeError, match="input mismatch"):
+            model._get_compiled_function("gauss")
 
 
 class TestConstParameters:

--- a/tests/test_normalization_integration.py
+++ b/tests/test_normalization_integration.py
@@ -11,6 +11,7 @@ from pytensor.compile.maker import function
 from pytensor.graph.traversal import explicit_graph_inputs
 
 from pyhs3 import Model, Workspace
+from pyhs3.context import Context
 from pyhs3.data import BinnedData, Data
 from pyhs3.distributions import Distributions
 from pyhs3.distributions.basic import GaussianDist
@@ -390,37 +391,30 @@ class TestNormalizationRegression:
     """Regression tests ensuring normalization correctness."""
 
     def test_normalization_substitutes_integration_variable(self):
-        """The integration variable (leaf) must not leak into the normalized expression.
+        """The integration variable (leaf) must not leak into the normalization integral.
 
-        After normalization, the denominator subgraph must be fully substituted
-        to a constant — the observable leaf should not appear as a free input
-        to the denominator.
+        ``_normalization_integral_for()`` substitutes the observable leaf with
+        the upper/lower bounds via ``graph_replace``; the resulting integral
+        subgraph must not retain the leaf as a free input.  Tested directly
+        against the ``Distribution`` normalization hook rather than through
+        ``Model.distributions[name]``, since that expression is now
+        ``pt.exp(log_expression)`` and no longer exposes the raw/integral
+        division as its top-level Apply node.
         """
         generic_dist = GenericDist(name="test_dist", expression="exp(c*x)")
 
-        parameterset = ParameterSet(
-            name="default",
-            parameters=[ParameterPoint(name="c", value=-0.5)],
+        context = Context(
+            parameters={"c": pt.constant(-0.5, name="c"), "x": pt.vector("x")},
+            observables={"x": (pt.constant(0.0), pt.constant(10.0))},
         )
-        model = Model(
-            parameterset=parameterset,
-            distributions=Distributions([generic_dist]),
-            domain=ProductDomain(name="default"),
-            functions=Functions([]),
-            progress=False,
-            observables={"x": (0.0, 10.0)},
-        )
+        raw = generic_dist.likelihood(context)
+        matching = generic_dist._matching_observables(context)
+        integral = generic_dist._normalization_integral_for(raw, context, matching)
 
-        dist_expr = model.distributions["test_dist"]
-
-        # dist_expr is raw / integral (a True_div Apply node)
-        assert dist_expr.owner is not None
-        denominator = dist_expr.owner.inputs[1]
-
-        # The integration variable must be fully substituted out of the denominator.
+        # The integration variable must be fully substituted out of the integral.
         # Only non-observable parameters (like "c") may remain as free inputs.
-        denom_input_names = {
-            v.name for v in explicit_graph_inputs([denominator]) if v.name
+        integral_input_names = {
+            v.name for v in explicit_graph_inputs([integral]) if v.name
         }
-        assert "x" not in denom_input_names
-        assert denom_input_names <= {"c"}
+        assert "x" not in integral_input_names
+        assert integral_input_names <= {"c"}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #276
Refs #234, #254

## Summary

`Model` previously built two parallel graphs per distribution node (`self.distributions` / `self.log_distributions`), two compiled-function cache families, and two parameter-ordering paths (`pars()`/`log_pars()`). This unifies on a single log-space pipeline: every node is built once in log space, and the probability-space counterpart is always `pt.exp(log_distributions[name])`, so `pdf()` and `logpdf()` can never disagree on normalization or on their free inputs.

## What died

- `Model.log_pars()` and `Model._reorder_log_params()` — removed outright, no deprecation cycle (per the issue #276 decision thread: the API isn't frozen yet).
- `Model._reorder_by_pars()` / `Model._get_pars()` — these were single-use scaffolding shared only by the pars/log_pars pair; inlined once their log-space twins were removed.
- `Model._compiled_log_inputs` / `Model._compiled_log_input_names` — collapsed into the single shared `_compiled_inputs`/`_compiled_input_names` cache (the two compiled-function caches, `_compiled_functions`/`_compiled_log_functions`, still exist since they compile different output expressions).
- `Model._hfdc_poisson` (probability-space Poisson-only dict) and `Model._hfdc_constraints` (probability-space constraint list) — write-only bookkeeping, never read anywhere once the probability-space channel expression is derived from the log-space one instead of assembled independently. Verified via grep across `src/` and `tests/` before deleting.
- The probability-space calls that fed those two dicts: `dist.likelihood(context)` and `modifier.make_constraint(...)` are no longer invoked by `Model` for HistFactoryDistChannel nodes — only their log-space counterparts (`dist.log_likelihood(context)`, `modifier.log_constraint(...)`) are.

## Context-contract finding

The scoping concern in the issue (`MixtureDist.log_expression` becoming log-native via log-space context tensors) is **not** attempted here — it would require the context contract used by every distribution's `_expression()`/`likelihood()` to switch from probability-space to log-space values, which ripples into every distribution, not just Model. The exp-derived approach in this PR works without touching that contract: each node's context value is still `pt.exp(its own log expression)`, computed eagerly (symbolically, not compiled) at graph-build time so downstream distributions (`MixtureDist.likelihood`'s `context[summand]`, `ProductDist.likelihood`'s `context[factor]`) see exactly the same probability-space values they did before. No fundamental breakage found. The mixture-log-native follow-up remains open as a separate, deeper change.

## `pt.exp(pt.log(x))` collapse finding

Checked the compiled `pdf()` graph for a drop-down distribution (`PolynomialDist`, whose `log_likelihood` falls back to `pt.log(likelihood)`) under `FAST_RUN`. PyTensor's elemwise-fusion rewrite **does** fuse the `exp(...)`/`log(...)` pair into a single `Composite` scalar kernel alongside the surrounding arithmetic (so there's no extra full-array traversal/allocation for the intermediate), but it does **not** apply the algebraic identity `exp(log(x)) = x` to eliminate the transcendental calls themselves — the fused kernel's inner expression is literally `exp(log(polynomial) - log(integral))`. This is an honest partial collapse: no extra memory traffic, but each element still pays for one `log` and one `exp` call it wouldn't need with a direct `raw/integral` division. This is a bounded, per-element cost, not a doubling of the whole graph, and all existing value-level tests (including the 1e-12 pyhf-precision tests) pass unchanged, so the extra log/exp round-trip doesn't cost precision in practice.

## Benchmark

The issue suggested benchmarking on "the 14-channel workspace" (`test_hs3_unbinned_pyhs3_validation_issue41.json` via scikit-hep-testdata, used in `tests/test_realworld.py`). Model construction alone on that workspace takes ~2 minutes and the first `pdf()` compile pushed the dev machine to >6 GB RSS / heavy swap — unsafe to run repeatedly for a stable before/after comparison. Per an operational correction during development, I benchmarked instead on a **synthetic moderate HistFactory workspace** (4 channels x 2 samples x ~4 modifiers each, 10 bins/channel — normfactor + shared normsys + per-channel histosys + per-channel shapesys), which exercises the same code paths (HFDC constraint dedup, log-space Poisson assembly, `pt.exp()` derivation) at a size safe to run repeatedly. The full 14-channel workspace's *construction* time was independently confirmed unchanged pre/post-refactor via `tests/test_realworld.py::test_workspace_model_creation` (slow suite, passing on this branch). If a real number on the full workspace is wanted, I'd suggest running it offline rather than in this sandboxed environment.

Median of 5 runs each, `git worktree` at the parent commit (`4d8f9bb`, pre-refactor) vs this branch, same machine, sequential (not concurrent) runs:

| Metric | main (median) | this branch (median) | Delta |
|---|---|---|---|
| Model construction | 0.250s | 0.229s | -8% |
| First `pdf()` compile+eval | 0.048s | 0.046s | ~unchanged |
| First `logpdf()` compile+eval | 0.345s | 0.273s | **-21%** |
| `log_prob` build+compile | 0.506s | 0.500s | ~unchanged |
| Total | 1.951s | 1.587s | **-19%** |

`logpdf()` improves meaningfully (no more separate log-space HFDC assembly pass duplicating work against the prob-space one); `pdf()` is unchanged within noise — no regression on the `pdf()` path, consistent with the issue's acceptance bar ("a modest regression on the pdf path MIGHT be acceptable... report honestly, don't tune to hide" — no regression to report here).

## New regression tests

- `test_pars_ordering_identical_for_pdf_and_logpdf` — builds two models from the same workspace, compiles `pdf()` first in one and `logpdf()` first in the other, asserts `pars()` returns the identical ordering either way (issue acceptance criterion 2).
- `test_logpdf_populates_shared_pars_cache` — calling `logpdf()` alone (never `pdf()`) populates the shared `pars()` cache without triggering a redundant probability-space compile.
- `test_compile_expression_raises_on_input_mismatch` — the `_compile_expression` invariant guard (pdf/logpdf must share free inputs by construction) raises `RuntimeError` if that invariant is ever violated; covers the one defensive branch that isn't otherwise exercised (100% branch coverage on `model.py`, matching pyproject's coverage config).

## Existing tests updated for the new invariants

- `tests/test_hfdc_model_constraints.py::TestHFDCSubgraphBuildCounts` — `test_make_constraint_called_once_per_spec` renamed to `test_make_constraint_not_called`: since the probability-space HFDC path is derived via `pt.exp()` rather than assembled from `make_constraint()`, that method is now never called during model construction (previously: called once, to build the now-removed probability-space bookkeeping).
- `tests/test_model.py::TestModelParameterOrdering::test_log_pars_triggers_compilation` — removed (the method it tested no longer exists); replaced by the two new pars-ordering tests above.
- `tests/test_normalization_integration.py::TestNormalizationRegression::test_normalization_substitutes_integration_variable` — now calls `Distribution._normalization_integral_for()` directly instead of reaching into `Model.distributions[name].owner.inputs[1]`, since that expression's top-level Apply node is now `pt.exp(...)` (single input) rather than the raw/integral `True_div` node.

## Validation

- Quick suite: `pixi run --environment py312 test` -> 1212 passed (was 1210 pre-refactor; +2 net from the new regression tests replacing 1 removed test).
- Slow suite: `pixi run --environment py312 test-slow tests/test_realworld.py -s` -> 5 passed, 1 xfailed (unchanged).
- Coverage: `pytest --runpydot --cov=pyhs3 --cov-branch --cov-report=term-missing` -> **100%** lines+branches on `src/pyhs3/model.py` (the only miss without `--runpydot` is the pre-existing pydot-gated `visualize_graph`, matching the acceptance bar's stated exception).
- `pre-commit run --all-files` and `pylint pyhs3` (10.00/10): clean.

## Follow-up (deferred, not in scope here)

`MixtureDist.log_expression` (used for non-extended mixtures and standalone evaluation) still round-trips through probability-space component tensors via the context contract, as noted above — making it log-native requires threading log-space values through `Context` for every distribution, a materially larger change than this PR. Tracked by the mixture-log-native item already called out in issue #276's proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Probability and log-probability calculations now use a consistent shared build path, improving consistency between both evaluation modes.
  - Parameter ordering is unified across probability and log-probability calculations.
  - Constraint terms are assembled without duplicate contributions when shared across channels.
  - Compilation behavior is streamlined through shared caching.

- **Breaking Changes**
  - Removed the public `log_pars()` method. Use `pars()` for parameter ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->