### PR TITLE
test: integrate pyhs3 with HS3TestSuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,61 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  hs3testsuite:
+    name: HS3TestSuite conformance (Python 3.12)
+    runs-on: ubuntu-latest
+    needs: [pre-commit]
+    env:
+      HS3TESTSUITE_ROOT: ${{ github.workspace }}/.hs3testsuite
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check out pinned HS3TestSuite
+        uses: actions/checkout@v7
+        with:
+          repository: hep-statistics-serialization-standard/HS3TestSuite
+          ref: 9d04e321ae6fddd283a35507f14ecf852eb7df61
+          path: .hs3testsuite
+          persist-credentials: false
+
+      - name: Configure temporary test directories
+        shell: bash
+        run: |
+          echo "HS3TESTSUITE_REPORT_DIR=$RUNNER_TEMP/hs3suite-reports" >> "$GITHUB_ENV"
+          echo "PYTENSOR_FLAGS=base_compiledir=$RUNNER_TEMP/hs3suite-pytensor" >> "$GITHUB_ENV"
+
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: v0.70.2
+          cache: true
+          cache-key: py312-${{ github.ref_name }}
+          cache-write:
+            ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          environments: py312
+
+      - name: Run HS3TestSuite conformance tests
+        run: |
+          mkdir -p "$HS3TESTSUITE_REPORT_DIR"
+          pixi run -e py312 test-hs3suite \
+            --junitxml="$HS3TESTSUITE_REPORT_DIR/junit.xml" \
+            -o junit_family=legacy
+
+      - name: Add HS3TestSuite summary
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          if [[ -f "$HS3TESTSUITE_REPORT_DIR/hs3suite-summary.md" ]]; then
+            cat "$HS3TESTSUITE_REPORT_DIR/hs3suite-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload HS3TestSuite reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: hs3testsuite-reports
+          path: ${{ runner.temp }}/hs3suite-reports
+          if-no-files-found: warn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: ["--pytest-test-first"]
-        exclude: ^tests/test_pdf/rf501_simultaneouspdf.py$
+        exclude: ^tests/(hs3testsuite_pyhs3_backend|test_pdf/rf501_simultaneouspdf)\.py$
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -73,6 +73,69 @@ Run specific tests:
 
    nox -s tests -- tests/test_distributions.py
 
+HS3TestSuite Conformance
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The external `HS3TestSuite <https://github.com/hep-statistics-serialization-standard/HS3TestSuite>`_
+checks pyhs3 against RooFit-generated reference values stored with the suite.
+ROOT is not run during these tests: each tested suite revision is a frozen
+comparison with the RooFit values and tolerances committed at that revision.
+
+The suite is intentionally pinned to an exact commit. To run the current pin
+locally, check out that commit and point the test harness at it:
+
+.. code-block:: bash
+
+   hs3suite_checkout="$(mktemp -d)"
+   git clone https://github.com/hep-statistics-serialization-standard/HS3TestSuite.git \
+       "$hs3suite_checkout"
+   git -C "$hs3suite_checkout" checkout --detach \
+       9d04e321ae6fddd283a35507f14ecf852eb7df61
+   export HS3TESTSUITE_ROOT="$hs3suite_checkout"
+   export HS3TESTSUITE_REPORT_DIR="$(mktemp -d)"
+   export PYTENSOR_FLAGS="base_compiledir=$(mktemp -d)"
+   pixi run -e py312 test-hs3suite
+
+The integration test is skipped when ``HS3TESTSUITE_ROOT`` is not set, so the
+normal local and platform test matrix does not fetch external test data.
+Machine-readable results and a Markdown summary are written to
+``HS3TESTSUITE_REPORT_DIR`` when it is set.
+
+The upstream snapshot is recorded in ``tests/hs3testsuite/pin.json`` and
+unsupported checks are recorded in ``tests/hs3testsuite/known_failures.json``
+as strict expected failures. A supported check that regresses fails normally,
+and an expected failure that starts passing is an unexpected pass and also
+fails. A known failure that moves to a different stage, such as from numerical
+comparison to workspace import, is also a regression. This forces the ledger
+to describe the currently pinned suite rather than silently accumulating stale
+entries.
+
+Updating the suite pin is a deliberate compatibility review, because the HS3
+specification, fixtures, schemas, and RooFit reference values evolve. In a
+dedicated pull request:
+
+1. Check out the candidate HS3TestSuite commit explicitly; never use a moving
+   branch or tag in CI.
+2. Audit changes to schemas, fixture and check identifiers, feature tags,
+   tolerances, and RooFit reference vectors.
+3. Run the candidate checkout without modifying the tracked pin or ledger:
+
+   .. code-block:: bash
+
+      pixi run -e py312 python tools/audit_hs3testsuite.py \
+          --suite-root /path/to/HS3TestSuite \
+          --output-dir /tmp/pyhs3-hs3-audit
+
+   This explicit audit mode records the candidate commit and manifest digest in
+   its reports without weakening the exact-pin check used by CI. Compare its
+   JSON and Markdown reports with the report from the current pin.
+4. Review every added or removed check and every pass-to-fail or fail-to-pass
+   transition. New expected failures require an explicit reason in the ledger;
+   newly supported checks must be removed from it.
+5. Update the upstream commit and manifest digest in the pin file, the CI
+   checkout ref, this page's local checkout command, and the strict
+   expected-failure ledger together. CI must validate that exact snapshot.
+
 Test Organization
 -----------------
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,6 +54,7 @@ jaxlib = "*"
 [feature.test.dependencies]
 pytest = ">=9"
 pytest-cov = ">=3"
+jsonschema = ">=4"
 pyhf = ">=0.7.6"
 scikit-hep-testdata = ">=0.6.2"
 pydot = "*"
@@ -84,6 +85,7 @@ test-docs = { cmd = "pytest README.rst docs", description = "Run doctests in doc
 test-slow = { cmd = "pytest --runslow", description = "Run tests including slow tests" }
 test-pydot = { cmd = "pytest --runpydot", description = "Run tests including pydot tests" }
 test-all = { cmd = "pytest --runslow --runpydot --cov=pyhs3", description = "Run all tests with coverage (slow + pydot)" }
+test-hs3suite = { cmd = "pytest tests/test_hs3testsuite.py -ra", description = "Run the pinned HS3TestSuite conformance tests" }
 
 [feature.docs.dependencies]
 sphinx = ">=7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 test = [
   "pytest >=9",
   "pytest-cov >=3",
+  "jsonschema >=4",
   "pyhf >= 0.7.6",
   "pydocstyle",
   "scikit-hep-testdata >= 0.5.7",

--- a/tests/hs3testsuite/known_failures.json
+++ b/tests/hs3testsuite/known_failures.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "suite_commit": "9d04e321ae6fddd283a35507f14ecf852eb7df61",
+  "failures": {
+    "rf103_interprfuncs::twice_delta_nll_scan": {
+      "category": "numerical_mismatch",
+      "reason": "The interpreted-function scan disagrees with the frozen RooFit reference values."
+    },
+    "rf110_normintegration::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 integral function."
+    },
+    "rf110_normintegration::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 integral function."
+    },
+    "rf111_derivatives::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 derivative function."
+    },
+    "rf111_derivatives::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 derivative function."
+    },
+    "rf207_comptools::structure_import": {
+      "category": "unsupported_distribution",
+      "reason": "pyhs3 does not implement chebychev_dist."
+    },
+    "rf207_comptools::twice_delta_nll_scan": {
+      "category": "unsupported_distribution",
+      "reason": "The likelihood cannot be built without chebychev_dist."
+    },
+    "rf208_convolution_fft3::structure_import": {
+      "category": "unsupported_distribution",
+      "reason": "pyhs3 does not implement fft_conv_pdf."
+    },
+    "rf208_convolution_fft3::twice_delta_nll_scan": {
+      "category": "unsupported_distribution",
+      "reason": "The likelihood cannot be built without fft_conv_pdf."
+    },
+    "rf209_anaconv::structure_import": {
+      "category": "unsupported_distribution",
+      "reason": "pyhs3 does not implement the analytical-convolution model and resolution types."
+    },
+    "rf210_angularconv::structure_import": {
+      "category": "unsupported_distribution",
+      "reason": "pyhs3 does not implement fft_conv_pdf."
+    },
+    "rf210_angularconv::twice_delta_nll_scan": {
+      "category": "unsupported_distribution",
+      "reason": "The likelihood cannot be built without fft_conv_pdf."
+    },
+    "rf301_composition::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 polynomial function."
+    },
+    "rf301_composition::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 polynomial function."
+    },
+    "rf302_utilfuncs::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 polynomial function."
+    },
+    "rf302_utilfuncs::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 polynomial function."
+    },
+    "rf303_conditional::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 polynomial function."
+    },
+    "rf303_conditional::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 polynomial function."
+    },
+    "rf305_condcorrprod::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 polynomial function."
+    },
+    "rf305_condcorrprod::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 polynomial function."
+    },
+    "rf308_normintegration2d::structure_import": {
+      "category": "unsupported_function",
+      "reason": "pyhs3 does not implement the HS3 integral function."
+    },
+    "rf308_normintegration2d::twice_delta_nll_scan": {
+      "category": "unsupported_function",
+      "reason": "The likelihood cannot be built without the HS3 integral function."
+    },
+    "rf309_ndimplot::twice_delta_nll_scan": {
+      "category": "evaluation_error",
+      "reason": "The multidimensional likelihood currently produces incompatible event shapes."
+    },
+    "rf703_effpdfprod::structure_import": {
+      "category": "unsupported_distribution",
+      "reason": "pyhs3 does not implement efficiency_product_pdf_dist."
+    },
+    "rf703_effpdfprod::twice_delta_nll_scan": {
+      "category": "unsupported_distribution",
+      "reason": "The likelihood cannot be built without efficiency_product_pdf_dist."
+    }
+  }
+}

--- a/tests/hs3testsuite/pin.json
+++ b/tests/hs3testsuite/pin.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "repository": "hep-statistics-serialization-standard/HS3TestSuite",
+  "commit": "9d04e321ae6fddd283a35507f14ecf852eb7df61",
+  "manifest_sha256": "7b6aae06492b232f78308bf01aae785f2107c51e171e5a4840f25c5004eb1fa6"
+}

--- a/tests/hs3testsuite_pyhs3_backend.py
+++ b/tests/hs3testsuite_pyhs3_backend.py
@@ -1,0 +1,327 @@
+"""pyhs3-owned backend adapter for the external HS3TestSuite runner."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal, NoReturn, cast
+
+import numpy as np
+import numpy.typing as npt
+import pytensor
+from pytensor.graph.traversal import explicit_graph_inputs
+
+from pyhs3 import Workspace
+from pyhs3.likelihoods import Likelihood
+from pyhs3.model import Model
+
+type Check = Mapping[str, Any]
+type GraphInput = Any
+type Evaluator = Callable[..., Any]
+type FailureStage = Literal["workspace_import", "structure_check", "evaluation"]
+
+FAILURE_STAGE_MARKER = "pyhs3_failure_stage="
+
+
+class BackendFailure(AssertionError):
+    """Failure carrying a stable stage through the upstream string-only runner."""
+
+    def __init__(self, stage: FailureStage, detail: str) -> None:
+        self.stage = stage
+        self.detail = detail
+        super().__init__(f"{FAILURE_STAGE_MARKER}{stage}: {detail}")
+
+
+class PyHS3Backend:
+    """Adapt pyhs3 to the backend protocol used by HS3TestSuite."""
+
+    name = "pyhs3"
+    mode = "FAST_COMPILE"
+
+    @staticmethod
+    def load_workspace(path: Path) -> Workspace:
+        """Load an HS3 document and preserve its full validation traceback."""
+        try:
+            return Workspace.load(path, suppress_traceback=False)
+        except BackendFailure:
+            raise
+        except Exception as exc:
+            _raise_backend_failure("workspace_import", exc)
+
+    @staticmethod
+    def structure(workspace: Workspace) -> dict[str, list[str]]:
+        """Return the object categories understood by structure-import checks."""
+        return {
+            "pdfs": _names(workspace.distributions),
+            "functions": _names(workspace.functions),
+            "data": _names(workspace.data),
+        }
+
+    def run_structure_check(self, workspace: Workspace, check: Check) -> None:
+        """Require the requested objects while allowing additional objects."""
+        try:
+            actual = self.structure(workspace)
+            target = _require_mapping(check.get("target", {}), "structure target")
+
+            for key in ("pdfs", "functions", "data"):
+                required = set(_string_sequence(target.get(key, ()), f"target {key}"))
+                missing = required.difference(actual[key])
+                if missing:
+                    msg = f"missing {key}: {sorted(missing)}"
+                    raise AssertionError(msg)
+        except BackendFailure:
+            raise
+        except Exception as exc:
+            _raise_backend_failure("structure_check", exc)
+
+    def run_twice_delta_nll_scan(
+        self, workspace: Workspace, check: Check
+    ) -> list[float]:
+        """Evaluate the suite's twice-delta-NLL scan for one PDF/data pair."""
+        try:
+            return self._run_twice_delta_nll_scan(workspace, check)
+        except BackendFailure:
+            raise
+        except Exception as exc:
+            _raise_backend_failure("evaluation", exc)
+
+    def _run_twice_delta_nll_scan(
+        self, workspace: Workspace, check: Check
+    ) -> list[float]:
+        target = _require_mapping(check.get("target"), "scan target")
+        pdf_name = _required_string(target, "pdf", "scan target")
+        data_name = _required_string(target, "data", "scan target")
+
+        distribution = _get_named(workspace.distributions, pdf_name, "distribution")
+        data = _get_named(workspace.data, data_name, "data")
+        likelihood = Likelihood(
+            name=f"hs3suite_{pdf_name}_{data_name}",
+            distributions=[distribution],
+            data=[data],
+        )
+        model = workspace.model(likelihood, progress=False, mode=self.mode)
+
+        twice_nll = -2.0 * model.log_prob
+        inputs = _named_graph_inputs(twice_nll)
+        evaluator: Evaluator = pytensor.function(
+            inputs=inputs,
+            outputs=twice_nll,
+            mode=self.mode,
+            on_unused_input="ignore",
+        )
+
+        reference_point = _require_mapping(
+            check.get("reference_point"), "reference point"
+        )
+        scan_parameter = _required_string(check, "scan_parameter", "scan check")
+        if scan_parameter not in reference_point:
+            msg = f"reference point does not define scan parameter {scan_parameter!r}"
+            raise AssertionError(msg)
+
+        base_values = self._base_values(model, check, inputs)
+        reference_values = dict(base_values)
+        reference_values[scan_parameter] = reference_point[scan_parameter]
+        reference = _evaluate_scalar(
+            evaluator,
+            inputs,
+            reference_values,
+            context="reference point",
+        )
+
+        scan_points = _number_sequence(check.get("scan_points"), "scan points")
+        results: list[float] = []
+        for index, point in enumerate(scan_points):
+            point_values = dict(base_values)
+            point_values[scan_parameter] = point
+            value = _evaluate_scalar(
+                evaluator,
+                inputs,
+                point_values,
+                context=f"scan point {index} ({scan_parameter}={point:.17g})",
+            )
+            delta = value - reference
+            if not np.isfinite(delta):
+                msg = (
+                    f"scan point {index} ({scan_parameter}={point:.17g}) produced "
+                    f"non-finite twice-delta-NLL {delta!r}"
+                )
+                raise AssertionError(msg)
+            results.append(delta)
+
+        return results
+
+    @staticmethod
+    def _base_values(
+        model: Model, check: Check, inputs: Sequence[GraphInput]
+    ) -> dict[str, Any]:
+        """Assemble defaults, reference overrides, data, and literal inputs."""
+        reference_point = _require_mapping(
+            check.get("reference_point"), "reference point"
+        )
+
+        # ``free_params`` contains the model's default values for every symbolic
+        # parameter input. The suite reference point overrides those defaults,
+        # and the selected dataset overrides observable placeholders such as x=0.
+        values: dict[str, Any] = dict(model.free_params)
+        values.update(reference_point)
+        values.update(model.data)
+
+        for variable in inputs:
+            name = _graph_input_name(variable)
+            if name not in values:
+                literal = _numeric_literal(name)
+                if literal is not None:
+                    values[name] = literal
+
+        missing = [
+            _graph_input_name(variable)
+            for variable in inputs
+            if _graph_input_name(variable) not in values
+        ]
+        if missing:
+            msg = f"missing pyhs3 graph inputs: {missing}"
+            raise AssertionError(msg)
+        return values
+
+
+def _raise_backend_failure(stage: FailureStage, exc: Exception) -> NoReturn:
+    detail = str(exc) or type(exc).__name__
+    raise BackendFailure(stage, detail) from exc
+
+
+def _names(collection: Any | None) -> list[str]:
+    if collection is None:
+        return []
+    return sorted(item.name for item in collection)
+
+
+def _get_named(collection: Any | None, name: str, label: str) -> Any:
+    if collection is None:
+        msg = f"{label} {name!r} not found"
+        raise AssertionError(msg)
+    item = collection.get(name)
+    if item is None:
+        msg = f"{label} {name!r} not found"
+        raise AssertionError(msg)
+    return item
+
+
+def _named_graph_inputs(expression: Any) -> list[GraphInput]:
+    inputs: list[GraphInput] = []
+    names: set[str] = set()
+    for variable in explicit_graph_inputs([expression]):
+        name = variable.name
+        if not isinstance(name, str):
+            msg = f"pyhs3 graph contains an unnamed free input of type {variable.type}"
+            raise AssertionError(msg)
+        if name in names:
+            msg = f"pyhs3 graph contains duplicate input name {name!r}"
+            raise AssertionError(msg)
+        names.add(name)
+        inputs.append(variable)
+    return inputs
+
+
+def _graph_input_name(variable: GraphInput) -> str:
+    name = variable.name
+    if not isinstance(name, str):
+        msg = "pyhs3 graph input is unnamed"
+        raise AssertionError(msg)
+    return name
+
+
+def _numeric_literal(name: str | None) -> float | None:
+    if name is None:
+        return None
+    try:
+        return float(name)
+    except ValueError:
+        return None
+
+
+def _ordered_values(
+    inputs: Sequence[GraphInput], values: Mapping[str, Any]
+) -> list[npt.NDArray[np.float64]]:
+    ordered: list[npt.NDArray[np.float64]] = []
+    for variable in inputs:
+        name = _graph_input_name(variable)
+        if name not in values:
+            msg = f"missing pyhs3 graph input {name!r}"
+            raise AssertionError(msg)
+        try:
+            value = np.asarray(values[name], dtype=np.float64)
+        except (TypeError, ValueError) as exc:
+            msg = f"pyhs3 graph input {name!r} cannot be converted to float64"
+            raise AssertionError(msg) from exc
+        ordered.append(value)
+    return ordered
+
+
+def _evaluate_scalar(
+    evaluator: Evaluator,
+    inputs: Sequence[GraphInput],
+    values: Mapping[str, Any],
+    *,
+    context: str,
+) -> float:
+    try:
+        output = evaluator(*_ordered_values(inputs, values))
+    except Exception as exc:
+        msg = f"pyhs3 failed to evaluate {context}: {exc}"
+        raise AssertionError(msg) from exc
+    return _as_scalar(output, context=context)
+
+
+def _as_scalar(value: Any, *, context: str = "NLL evaluation") -> float:
+    try:
+        array = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        msg = f"pyhs3 {context} did not return a numeric value"
+        raise AssertionError(msg) from exc
+    if array.size != 1:
+        msg = (
+            f"pyhs3 {context} returned shape {array.shape}; "
+            "expected exactly one scalar value"
+        )
+        raise AssertionError(msg)
+    result = float(array.item())
+    if not np.isfinite(result):
+        msg = f"pyhs3 {context} returned non-finite value {result!r}"
+        raise AssertionError(msg)
+    return result
+
+
+def _require_mapping(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        msg = f"{label} must be a mapping"
+        raise AssertionError(msg)
+    return cast(Mapping[str, Any], value)
+
+
+def _required_string(values: Check, key: str, label: str) -> str:
+    value = values.get(key)
+    if not isinstance(value, str) or not value:
+        msg = f"{label} must define a non-empty string {key!r}"
+        raise AssertionError(msg)
+    return value
+
+
+def _string_sequence(value: object, label: str) -> list[str]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        msg = f"{label} must be a sequence of strings"
+        raise AssertionError(msg)
+    if not all(isinstance(item, str) for item in value):
+        msg = f"{label} must contain only strings"
+        raise AssertionError(msg)
+    return list(cast(Sequence[str], value))
+
+
+def _number_sequence(value: object, label: str) -> list[float]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        msg = f"{label} must be a sequence of numbers"
+        raise AssertionError(msg)
+    try:
+        return [float(item) for item in value]
+    except (TypeError, ValueError) as exc:
+        msg = f"{label} must contain only numbers"
+        raise AssertionError(msg) from exc

--- a/tests/test_hs3testsuite.py
+++ b/tests/test_hs3testsuite.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+CONFIG_DIR = Path(__file__).with_name("hs3testsuite")
+TESTS_DIR = Path(__file__).parent
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+PIN = _load_json(CONFIG_DIR / "pin.json")
+KNOWN_FAILURE_CONFIG = _load_json(CONFIG_DIR / "known_failures.json")
+KNOWN_FAILURES: dict[str, dict[str, str]] = KNOWN_FAILURE_CONFIG["failures"]
+AUDIT_CANDIDATE = os.environ.get("PYHS3_HS3TESTSUITE_AUDIT_CANDIDATE") == "1"
+EXPECTED_STAGES_BY_CATEGORY = {
+    "evaluation_error": "evaluation",
+    "numerical_mismatch": "numerical_comparison",
+    "unsupported_distribution": "workspace_import",
+    "unsupported_function": "workspace_import",
+}
+
+suite_root_value = os.environ.get("HS3TESTSUITE_ROOT")
+if suite_root_value is None:
+    pytest.skip(
+        "set HS3TESTSUITE_ROOT to run the external HS3 conformance suite",
+        allow_module_level=True,
+    )
+
+SUITE_ROOT = Path(suite_root_value).resolve()
+if not (SUITE_ROOT / "manifest.json").is_file():
+    msg = f"HS3TESTSUITE_ROOT does not contain manifest.json: {SUITE_ROOT}"
+    raise RuntimeError(msg)
+
+
+def _suite_identity() -> dict[str, Any]:
+    completed = subprocess.run(
+        ["git", "-C", str(SUITE_ROOT), "rev-parse", "HEAD^{commit}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    status = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(SUITE_ROOT),
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    manifest_bytes = (SUITE_ROOT / "manifest.json").read_bytes()
+    return {
+        "repository": PIN["repository"],
+        "commit": completed.stdout.strip(),
+        "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        "checkout_clean": not bool(status.stdout.strip()),
+    }
+
+
+def _suite_matches_pin(actual: Mapping[str, Any]) -> bool:
+    return (
+        actual["commit"] == PIN["commit"]
+        and actual["manifest_sha256"] == PIN["manifest_sha256"]
+    )
+
+
+ACTUAL_SUITE = _suite_identity()
+if not AUDIT_CANDIDATE:
+    setup_errors = []
+    if not _suite_matches_pin(ACTUAL_SUITE):
+        setup_errors.append(
+            "checkout identity does not match tests/hs3testsuite/pin.json"
+        )
+    if not ACTUAL_SUITE["checkout_clean"]:
+        setup_errors.append("checkout has modified or untracked files")
+    if setup_errors:
+        msg = "Invalid pinned HS3TestSuite checkout: " + "; ".join(setup_errors)
+        raise RuntimeError(msg)
+
+sys.path.insert(0, str(SUITE_ROOT))
+sys.path.insert(0, str(TESTS_DIR))
+
+from hs3suite.backends import _BACKENDS  # noqa: E402
+from hs3suite.runner import CheckResult, run_suite  # noqa: E402
+
+_BACKENDS["pyhs3"] = ("hs3testsuite_pyhs3_backend", "PyHS3Backend")
+
+MANIFEST = _load_json(SUITE_ROOT / "manifest.json")
+CASES = [
+    (fixture["test_id"], check_id)
+    for fixture in MANIFEST["fixtures"]
+    for check_id in fixture["checks"]
+]
+CASE_KEYS = {f"{test_id}::{check_id}" for test_id, check_id in CASES}
+
+
+def _case_parameter(test_id: str, check_id: str) -> Any:
+    key = f"{test_id}::{check_id}"
+    failure = KNOWN_FAILURES.get(key)
+    if failure is None:
+        return pytest.param(test_id, check_id, id=key)
+    reason = f"{failure['category']}: {failure['reason']}"
+    return pytest.param(
+        test_id,
+        check_id,
+        marks=pytest.mark.xfail(reason=reason, strict=True),
+        id=key,
+    )
+
+
+CASE_PARAMETERS = [_case_parameter(*case) for case in CASES]
+
+
+def _result_key(result: CheckResult) -> str:
+    return f"{result.test_id}::{result.check_id}"
+
+
+def _expected_failure_stage(failure: Mapping[str, str]) -> str:
+    return EXPECTED_STAGES_BY_CATEGORY.get(failure["category"], "unconfigured")
+
+
+def _failure_stage(result: CheckResult) -> str | None:
+    if result.status != "failed":
+        return None
+
+    marker = "pyhs3_failure_stage="
+    if result.message.startswith(marker):
+        stage, separator, _ = result.message[len(marker) :].partition(":")
+        if separator and stage:
+            return stage
+    if result.check_id == "twice_delta_nll_scan" and result.message.startswith(
+        "point "
+    ):
+        return "numerical_comparison"
+    return "unclassified"
+
+
+def _classify(result: CheckResult) -> str:
+    failure = KNOWN_FAILURES.get(_result_key(result))
+    if result.status == "passed":
+        return "unexpected_pass" if failure is not None else "passed"
+    if result.status == "failed":
+        if failure is None:
+            return "unexpected_failure"
+        if _failure_stage(result) != _expected_failure_stage(failure):
+            return "known_failure_stage_changed"
+        return "known_failure"
+    return "unexpected_status"
+
+
+def _result_diagnostics(results: list[CheckResult]) -> dict[str, Any]:
+    keys = [_result_key(result) for result in results]
+    result_keys = set(keys)
+    return {
+        "pin_enforced": not AUDIT_CANDIDATE,
+        "suite_matches_pin": _suite_matches_pin(ACTUAL_SUITE),
+        "ledger_matches_pin": KNOWN_FAILURE_CONFIG["suite_commit"] == PIN["commit"],
+        "unknown_ledger_entries": sorted(set(KNOWN_FAILURES).difference(CASE_KEYS)),
+        "duplicate_results": sorted(
+            key for key, count in Counter(keys).items() if count > 1
+        ),
+        "missing_results": sorted(CASE_KEYS.difference(result_keys)),
+        "extra_results": sorted(result_keys.difference(CASE_KEYS)),
+        "unexpected_statuses": {
+            _result_key(result): result.status
+            for result in results
+            if result.status not in {"passed", "failed"}
+        },
+    }
+
+
+def _pyhs3_version() -> str:
+    try:
+        return importlib.metadata.version("pyhs3")
+    except importlib.metadata.PackageNotFoundError:
+        return "uninstalled"
+
+
+def _markdown_cell(value: str, limit: int = 300) -> str:
+    normalized = " ".join(value.split()).replace("|", "\\|")
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 1]}…"
+
+
+def _write_reports(results: list[CheckResult], error: str | None = None) -> None:
+    report_dir_value = os.environ.get("HS3TESTSUITE_REPORT_DIR")
+    if report_dir_value is None:
+        return
+
+    report_dir = Path(report_dir_value)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "test_id": result.test_id,
+            "check_id": result.check_id,
+            "key": _result_key(result),
+            "status": result.status,
+            "classification": _classify(result),
+            "failure_stage": _failure_stage(result),
+            "message": result.message,
+            "known_failure": KNOWN_FAILURES.get(_result_key(result)),
+        }
+        for result in results
+    ]
+    counts = Counter(row["classification"] for row in rows)
+    diagnostics = _result_diagnostics(results)
+    summary = (
+        ", ".join(f"{name}={count}" for name, count in sorted(counts.items()))
+        or "no check results"
+    )
+    payload = {
+        "schema_version": 1,
+        "suite": ACTUAL_SUITE,
+        "expected_suite": PIN,
+        "pyhs3_version": _pyhs3_version(),
+        "error": error,
+        "harness": diagnostics,
+        "summary": dict(sorted(counts.items())),
+        "results": rows,
+    }
+    with (report_dir / "hs3suite-results.json").open("w", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+
+    lines = [
+        "# HS3TestSuite compatibility report",
+        "",
+        f"- Suite commit: `{ACTUAL_SUITE['commit']}`",
+        f"- Expected pinned commit: `{PIN['commit']}`",
+        f"- Exact pin enforced: `{'no (candidate audit)' if AUDIT_CANDIDATE else 'yes'}`",
+        f"- pyhs3 version: `{payload['pyhs3_version']}`",
+        "- Reference: frozen RooFit values and tolerances from the selected suite revision",
+        f"- Summary: {summary}",
+        "- Result-set diagnostics: "
+        f"missing={len(diagnostics['missing_results'])}, "
+        f"extra={len(diagnostics['extra_results'])}, "
+        f"duplicates={len(diagnostics['duplicate_results'])}, "
+        f"invalid_statuses={len(diagnostics['unexpected_statuses'])}",
+    ]
+    if error:
+        lines.extend((f"- Runner error: `{_markdown_cell(error)}`", ""))
+    else:
+        lines.append("")
+    lines.extend(
+        (
+            "| Fixture | Check | Classification | Detail |",
+            "| --- | --- | --- | --- |",
+        )
+    )
+    for row in rows:
+        failure = row["known_failure"]
+        detail = row["message"]
+        if failure is not None:
+            detail = (
+                f"{failure['category']} "
+                f"(expected stage={_expected_failure_stage(failure)}, "
+                f"actual stage={row['failure_stage']}): {failure['reason']} Raw: {detail}"
+            )
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    row["test_id"],
+                    row["check_id"],
+                    row["classification"],
+                    _markdown_cell(detail),
+                )
+            )
+            + " |"
+        )
+    (report_dir / "hs3suite-summary.md").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+@pytest.fixture(scope="session")
+def hs3_results() -> list[CheckResult]:
+    try:
+        results = run_suite(SUITE_ROOT, "pyhs3")
+    except Exception as exc:
+        _write_reports([], error=f"{type(exc).__name__}: {exc}")
+        raise
+    _write_reports(results)
+    return results
+
+
+@pytest.fixture(scope="session")
+def hs3_result_map(hs3_results: list[CheckResult]) -> Mapping[str, CheckResult]:
+    keys = [_result_key(result) for result in hs3_results]
+    duplicates = sorted(key for key, count in Counter(keys).items() if count > 1)
+    assert not duplicates, f"duplicate HS3TestSuite results: {duplicates}"
+    return dict(zip(keys, hs3_results, strict=True))
+
+
+def test_suite_checkout_matches_pin() -> None:
+    assert ACTUAL_SUITE["commit"]
+    if not AUDIT_CANDIDATE:
+        assert _suite_matches_pin(ACTUAL_SUITE)
+        assert ACTUAL_SUITE["checkout_clean"]
+
+
+def test_known_failure_ledger_matches_pin_and_manifest() -> None:
+    assert KNOWN_FAILURE_CONFIG["suite_commit"] == PIN["commit"]
+    unknown = sorted(set(KNOWN_FAILURES).difference(CASE_KEYS))
+    assert not unknown, f"known-failure entries are absent from the manifest: {unknown}"
+    unknown_categories = sorted(
+        {
+            failure["category"]
+            for failure in KNOWN_FAILURES.values()
+            if failure["category"] not in EXPECTED_STAGES_BY_CATEGORY
+        }
+    )
+    assert not unknown_categories, (
+        f"known-failure categories have no expected stage: {unknown_categories}"
+    )
+
+
+def test_runner_returns_exact_manifest_checks(
+    hs3_result_map: Mapping[str, CheckResult],
+) -> None:
+    actual = set(hs3_result_map)
+    missing = sorted(CASE_KEYS.difference(actual))
+    extra = sorted(actual.difference(CASE_KEYS))
+    assert not missing, f"HS3TestSuite results are missing checks: {missing}"
+    assert not extra, f"HS3TestSuite returned unexpected checks: {extra}"
+
+
+def test_runner_returns_only_passed_or_failed(
+    hs3_result_map: Mapping[str, CheckResult],
+) -> None:
+    unexpected = {
+        key: result.status
+        for key, result in hs3_result_map.items()
+        if result.status not in {"passed", "failed"}
+    }
+    assert not unexpected, f"unexpected HS3TestSuite statuses: {unexpected}"
+
+
+def test_known_failures_match_expected_stages(
+    hs3_result_map: Mapping[str, CheckResult],
+) -> None:
+    mismatches = {}
+    for key, failure in KNOWN_FAILURES.items():
+        result = hs3_result_map.get(key)
+        if result is None or result.status != "failed":
+            continue
+        expected = _expected_failure_stage(failure)
+        actual = _failure_stage(result)
+        if actual != expected:
+            mismatches[key] = {"expected": expected, "actual": actual}
+    assert not mismatches, f"known failures changed stage: {mismatches}"
+
+
+@pytest.mark.parametrize(("test_id", "check_id"), CASE_PARAMETERS)
+def test_hs3_conformance_check(
+    test_id: str,
+    check_id: str,
+    hs3_result_map: Mapping[str, CheckResult],
+) -> None:
+    key = f"{test_id}::{check_id}"
+    assert key in hs3_result_map, f"HS3TestSuite did not return {key}"
+    result = hs3_result_map[key]
+    assert result.status == "passed", result.message

--- a/tests/test_hs3testsuite_backend.py
+++ b/tests/test_hs3testsuite_backend.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from pyhs3.model import Model
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import hs3testsuite_pyhs3_backend as backend
+
+
+@dataclass
+class _Named:
+    name: str
+
+
+class _Collection(list[_Named]):
+    def get(self, name: str) -> _Named | None:
+        return next((item for item in self if item.name == name), None)
+
+
+def _workspace_stub() -> Any:
+    return SimpleNamespace(
+        distributions=_Collection([_Named("model"), _Named("extra_pdf")]),
+        functions=_Collection([_Named("mean")]),
+        data=_Collection([_Named("observed")]),
+    )
+
+
+def test_structure_check_requires_subset_and_allows_extras() -> None:
+    adapter = backend.PyHS3Backend()
+    adapter.run_structure_check(
+        _workspace_stub(),
+        {
+            "target": {
+                "pdfs": ["model"],
+                "functions": ["mean"],
+                "data": ["observed"],
+            }
+        },
+    )
+
+
+def test_structure_check_reports_missing_object_category() -> None:
+    adapter = backend.PyHS3Backend()
+    with pytest.raises(
+        backend.BackendFailure, match=r"missing pdfs: \['absent'\]"
+    ) as exc_info:
+        adapter.run_structure_check(
+            _workspace_stub(),
+            {"target": {"pdfs": ["absent"], "functions": [], "data": []}},
+        )
+    assert exc_info.value.stage == "structure_check"
+    assert str(exc_info.value).startswith(
+        "pyhs3_failure_stage=structure_check: missing pdfs"
+    )
+
+
+def test_workspace_import_failure_has_stable_stage_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_load(*_args: object, **_kwargs: object) -> None:
+        msg = "invalid workspace"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(backend.Workspace, "load", fail_load)
+
+    with pytest.raises(backend.BackendFailure, match="invalid workspace") as exc_info:
+        backend.PyHS3Backend().load_workspace(Path("invalid.json"))
+
+    assert exc_info.value.stage == "workspace_import"
+    assert str(exc_info.value).startswith(
+        "pyhs3_failure_stage=workspace_import: invalid workspace"
+    )
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_evaluation_failure_has_stable_stage_marker() -> None:
+    with pytest.raises(
+        backend.BackendFailure, match="distribution 'absent' not found"
+    ) as exc_info:
+        backend.PyHS3Backend().run_twice_delta_nll_scan(
+            _workspace_stub(),
+            {"target": {"pdf": "absent", "data": "observed"}},
+        )
+
+    assert exc_info.value.stage == "evaluation"
+    assert str(exc_info.value).startswith(
+        "pyhs3_failure_stage=evaluation: distribution 'absent' not found"
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ([1.0, 2.0], "expected exactly one scalar"),
+        (np.nan, "non-finite value"),
+        ("not numeric", "did not return a numeric value"),
+    ],
+)
+def test_as_scalar_rejects_invalid_evaluator_output(
+    value: object, message: str
+) -> None:
+    with pytest.raises(AssertionError, match=message):
+        backend._as_scalar(value)
+
+
+def test_base_values_apply_reference_data_and_literal_precedence() -> None:
+    model = cast(
+        Model,
+        SimpleNamespace(
+            free_params={"mu": 1.0, "x": 999.0},
+            data={"x": np.asarray([0.5, 1.5])},
+        ),
+    )
+    inputs = [
+        SimpleNamespace(name="mu"),
+        SimpleNamespace(name="x"),
+        SimpleNamespace(name="3.5"),
+    ]
+
+    values = backend.PyHS3Backend._base_values(
+        model,
+        {"reference_point": {"mu": 2.0, "x": 0.0}},
+        inputs,
+    )
+
+    assert values["mu"] == 2.0
+    np.testing.assert_array_equal(values["x"], [0.5, 1.5])
+    assert values["3.5"] == 3.5

--- a/tools/audit_hs3testsuite.py
+++ b/tools/audit_hs3testsuite.py
@@ -1,0 +1,111 @@
+"""Run the pyhs3 compatibility checks against an explicit suite checkout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+REPORT_FILENAMES = (
+    "hs3suite-junit.xml",
+    "hs3suite-results.json",
+    "hs3suite-summary.md",
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit a candidate HS3TestSuite checkout without changing the tracked "
+            "suite pin or known-failure ledger."
+        )
+    )
+    parser.add_argument(
+        "--suite-root",
+        type=Path,
+        required=True,
+        help="Path to an explicit HS3TestSuite checkout",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Report directory (defaults to a new directory under the system temp dir)",
+    )
+    return parser
+
+
+def _write_wrapper_failure(output_dir: Path, returncode: int) -> None:
+    message = (
+        "pytest ended before the HS3TestSuite harness could write its reports "
+        f"(exit code {returncode})"
+    )
+    payload = {
+        "schema_version": 1,
+        "error": message,
+        "results": [],
+        "summary": {},
+    }
+    with (output_dir / "hs3suite-results.json").open("w", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    (output_dir / "hs3suite-summary.md").write_text(
+        f"# HS3TestSuite compatibility report\n\n- Audit error: `{message}`\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    suite_root = args.suite_root.resolve()
+    if not (suite_root / "manifest.json").is_file():
+        _parser().error(f"suite root does not contain manifest.json: {suite_root}")
+
+    output_dir = (
+        args.output_dir.resolve()
+        if args.output_dir is not None
+        else Path(tempfile.mkdtemp(prefix="pyhs3-hs3suite-audit-"))
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for filename in REPORT_FILENAMES:
+        (output_dir / filename).unlink(missing_ok=True)
+
+    env = os.environ.copy()
+    env["HS3TESTSUITE_ROOT"] = str(suite_root)
+    env["HS3TESTSUITE_REPORT_DIR"] = str(output_dir)
+    env["PYHS3_HS3TESTSUITE_AUDIT_CANDIDATE"] = "1"
+    env.setdefault("PYTENSOR_FLAGS", f"base_compiledir={output_dir / 'pytensor'}")
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "tests/test_hs3testsuite.py",
+        "-ra",
+        f"--junitxml={output_dir / 'hs3suite-junit.xml'}",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        check=False,
+    )
+    reports = (
+        output_dir / "hs3suite-results.json",
+        output_dir / "hs3suite-summary.md",
+    )
+    if not all(report.is_file() for report in reports):
+        _write_wrapper_failure(output_dir, completed.returncode)
+        log.info("HS3TestSuite audit reports: %s", output_dir)
+        return completed.returncode or 1
+    log.info("HS3TestSuite audit reports: %s", output_dir)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR integrates pyhs3 with the external [HS3TestSuite](https://github.com/hep-statistics-serialization-standard/HS3TestSuite), providing a direct comparison against the frozen RooFit reference results stored in the suite.

The integration uses a new backend adapter owned and maintained by pyhs3. 

## Motivation

ROOT already runs HS3TestSuite against RooFit. Adding the same suite to pyhs3 makes it possible to:
* Compare RooFit and pyhs3 using identical HS3 documents, scan points, tolerances, and reference values.
* Track which parts of the HS3 specification pyhs3 currently supports.
* Detect regressions in already-supported functionality.
* Identify when an unsupported test starts passing.
* Review compatibility changes deliberately as the HS3 specification and test suite evolve.


## Implementation

This PR adds:
* A pyhs3-owned HS3TestSuite backend adapter.
* Manifest-driven pytest cases for every fixture and check in the pinned suite.
* Exact verification of the upstream commit and manifest digest before loading the suite.
* A strict known-failure ledger for currently unsupported functionality.
* Stable failure-stage classification, distinguishing failures during workspace import, evaluation, and numerical comparison.
JSON, Markdown, and JUnit compatibility reports.
* A dedicated GitHub Actions job that checks out the exact suite revision and uploads the reports.
* A candidate-audit command and documentation for deliberately updating the suite pin.

The adapter loads each HS3 workspace with pyhs3, performs the requested structure checks, constructs the corresponding likelihood, and evaluates the twice-delta-NLL scans using public PyTensor APIs.

## Current compatibility

The pinned suite contains 56 checks across 19 fixtures. Current pyhs3 results are:
* 31 passing checks
* 25 strict expected failures

Expected failures currently cover unsupported HS3 functions and distributions, one multidimensional evaluation issue, and one numerical mismatch. The expected failures are strict: if one starts passing, CI fails until its ledger entry is deliberately removed. CI also fails if a known failure changes stage—for example, if a numerical mismatch regresses into a workspace-import failure.

## Pinning and update policy
HS3TestSuite is pinned to:
9d04e321ae6fddd283a35507f14ecf852eb7df61
The pin is intentionally not updated automatically. Updating it requires reviewing changes to:
* HS3 schemas and fixtures
* Check identifiers and feature tags
* RooFit reference vectors
* Scan points and tolerances
* Passing and failing pyhs3 checks
* Known-failure reasons and stages

A candidate revision can be audited without changing the tracked pin:
```bash
pixi run -e py312 python tools/audit_hs3testsuite.py \
    --suite-root /path/to/HS3TestSuite \
    --output-dir /tmp/pyhs3-hs3-audit
```
The resulting reports identify the candidate commit and manifest digest while leaving normal CI pin enforcement unchanged.

## Testing
Validated locally with:
```bash
pixi run -e py312 test-hs3suite
pytest tests/test_hs3testsuite_backend.py
```
## Results:
HS3TestSuite integration: 36 harness passes and 25 strict xfails
Raw HS3 compatibility: 31 passes and 25 known failures
Adapter unit tests: 8 passes
Ruff and configuration validation pass
Documentation doctests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HS3TestSuite conformance testing for validating compatibility with reference results.
  * Added automated CI execution with JUnit reports, summaries, and downloadable test artifacts.
  * Added a command-line audit tool for evaluating candidate test-suite revisions.
  * Added pinned-suite tracking and a documented known-failure ledger.

* **Documentation**
  * Documented local HS3TestSuite validation, CI reporting, pinning, and regression expectations.

* **Bug Fixes**
  * Improved test-hook exclusions for HS3 conformance tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->